### PR TITLE
ECOPROJECT-2345: Add proxy fields to Download Source dialog

### DIFF
--- a/src/migration-wizard/contexts/discovery-sources/@types/DiscoverySources.d.ts
+++ b/src/migration-wizard/contexts/discovery-sources/@types/DiscoverySources.d.ts
@@ -13,7 +13,7 @@ declare namespace DiscoverySources {
     sourceSelected: Source;
     listSources: () => Promise<Source[]>;
     deleteSource: (id: string) => Promise<Source>;
-    downloadSource: (envName: string, sourceSshKey: string) => Promise<void>;
+    downloadSource: (envName: string, sourceSshKey: string, httpProxy:string, httpsProxy:string, noProxy: string) => Promise<void>;
     startPolling: (delay: number) => void;
     stopPolling: () => void;
     selectSource: (source: Source) => void;

--- a/src/migration-wizard/contexts/discovery-sources/Provider.tsx
+++ b/src/migration-wizard/contexts/discovery-sources/Provider.tsx
@@ -44,9 +44,13 @@ export const Provider: React.FC<PropsWithChildren> = (props) => {
   });
 
   const [createSourceState, createSource] = useAsyncFn(
-    async (name: string, sshPublicKey: string) => {
+    async (name: string, sshPublicKey: string, httpProxy:string, httpsProxy:string, noProxy: string) => {
       try {
-        return await sourceApi.createSource({ sourceCreate: { name, sshPublicKey } });
+        return await sourceApi.createSource({ sourceCreate: { name, sshPublicKey, proxy: {
+          httpUrl: httpProxy,
+          httpsUrl: httpsProxy,
+          noProxy: noProxy          
+        } } });
       } catch (error: unknown) {
         console.error("Error creating source:", error);
   
@@ -72,11 +76,11 @@ export const Provider: React.FC<PropsWithChildren> = (props) => {
   );
 
   const [downloadSourceState, downloadSource] = useAsyncFn(
-    async (sourceName: string, sourceSshKey: string): Promise<void> => {
+    async (sourceName: string, sourceSshKey: string, httpProxy:string, httpsProxy:string, noProxy: string): Promise<void> => {
       const anchor = document.createElement('a');
       anchor.download = sourceName + '.ova';
 
-      const newSource = await createSource(sourceName, sourceSshKey);
+      const newSource = await createSource(sourceName, sourceSshKey, httpProxy, httpsProxy, noProxy);
 
       if (!newSource?.id) {
         throw new Error(

--- a/src/migration-wizard/steps/connect/ConnectStep.tsx
+++ b/src/migration-wizard/steps/connect/ConnectStep.tsx
@@ -131,9 +131,15 @@ export const ConnectStep: React.FC = () => {
               const environmentName = form['discoveryEnvironmentName']
                 .value as string;
               const sshKey = form['discoverySourceSshKey'].value as string;
+              const httpProxy = form['httpProxy']? form['httpProxy'].value as string:'';
+              const httpsProxy =  form['httpsProxy'] ? form['httpsProxy'].value as string:'';
+              const noProxy = form['noProxy'] ? form['noProxy'].value as string:'';
               await discoverySourcesContext.downloadSource(
                 environmentName,
                 sshKey,
+                httpProxy,
+                httpsProxy,
+                noProxy,
               );
               toggleDiscoverySourceSetupModal();
               await discoverySourcesContext.listSources();

--- a/src/migration-wizard/steps/connect/sources-table/empty-state/DiscoverySourceSetupModal.tsx
+++ b/src/migration-wizard/steps/connect/sources-table/empty-state/DiscoverySourceSetupModal.tsx
@@ -15,6 +15,7 @@ import {
   ModalFooter,
   ModalHeader,
 } from "@patternfly/react-core/next";
+import ProxyFields from "./ProxyFields";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace DiscoverySourceSetupModal {
@@ -139,6 +140,7 @@ export const DiscoverySourceSetupModal: React.FC<
               </HelperText>
             </FormHelperText>
           </FormGroup>
+          <ProxyFields/>
         </Form>
       </ModalBody>
       <ModalFooter>

--- a/src/migration-wizard/steps/connect/sources-table/empty-state/EmptyState.tsx
+++ b/src/migration-wizard/steps/connect/sources-table/empty-state/EmptyState.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useState } from 'react';
 import {
   Button,
   EmptyState as PFEmptyState,
@@ -7,11 +7,11 @@ import {
   EmptyStateFooter,
   EmptyStateHeader,
   EmptyStateIcon,
-} from "@patternfly/react-core";
-import { ExclamationCircleIcon, SearchIcon } from "@patternfly/react-icons";
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon, SearchIcon } from '@patternfly/react-icons';
 import { global_danger_color_200 as globalDangerColor200 } from '@patternfly/react-tokens/dist/js/global_danger_color_200';
-import { DiscoverySourceSetupModal } from "./DiscoverySourceSetupModal";
-import { useDiscoverySources } from "../../../../contexts/discovery-sources/Context";
+import { DiscoverySourceSetupModal } from './DiscoverySourceSetupModal';
+import { useDiscoverySources } from '../../../../contexts/discovery-sources/Context';
 
 export const EmptyState: React.FC = () => {
   const discoverySourcesContext = useDiscoverySources();
@@ -39,15 +39,12 @@ export const EmptyState: React.FC = () => {
         icon={<EmptyStateIcon icon={SearchIcon} />}
       />
       <EmptyStateBody>
-        Begin by creating a discovery environment. Then download and import the OVA
-        file into your VMware environment.
+        Begin by creating a discovery environment. Then download and import the
+        OVA file into your VMware environment.
       </EmptyStateBody>
       <EmptyStateFooter>
         <EmptyStateActions>
-          <Button
-            variant="secondary"
-            onClick={toggleDiscoverySourceSetupModal}
-          >
+          <Button variant="secondary" onClick={toggleDiscoverySourceSetupModal}>
             Create
           </Button>
         </EmptyStateActions>
@@ -93,9 +90,19 @@ export const EmptyState: React.FC = () => {
           isDisabled={discoverySourcesContext.isDownloadingSource}
           onSubmit={async (event) => {
             const form = event.currentTarget;
-            const environmentName = form["discoveryEnvironmentName"].value as string;
-            const sshKey = form["discoverySourceSshKey"].value as string;
-            await discoverySourcesContext.downloadSource(environmentName,sshKey);
+            const environmentName = form['discoveryEnvironmentName']
+              .value as string;
+            const sshKey = form['discoverySourceSshKey'].value as string;
+            const httpProxy = form['httpProxy']? form['httpProxy'].value as string:'';
+            const httpsProxy =  form['httpsProxy'] ? form['httpsProxy'].value as string:'';
+            const noProxy = form['noProxy'] ? form['noProxy'].value as string:'';
+            await discoverySourcesContext.downloadSource(
+              environmentName,
+              sshKey,
+              httpProxy,
+              httpsProxy,
+              noProxy,
+            );
             toggleDiscoverySourceSetupModal();
             await discoverySourcesContext.listSources();
           }}
@@ -105,4 +112,4 @@ export const EmptyState: React.FC = () => {
   );
 };
 
-EmptyState.displayName = "SourcesTableEmptyState";
+EmptyState.displayName = 'SourcesTableEmptyState';

--- a/src/migration-wizard/steps/connect/sources-table/empty-state/ProxyFields.tsx
+++ b/src/migration-wizard/steps/connect/sources-table/empty-state/ProxyFields.tsx
@@ -1,0 +1,178 @@
+import React, { useState } from 'react';
+import {
+  FormGroup,
+  Grid,
+  GridItem,
+  Popover,
+  TextInput,
+  Checkbox,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+} from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
+
+const ProxyInputFields = ({
+  httpProxy,
+  httpsProxy,
+  noProxy,
+  onChange,
+}: {
+  httpProxy: string;
+  httpsProxy: string;
+  noProxy: string;
+  onChange: (field: string, value: string) => void;
+}) => {
+  return (
+    <Grid hasGutter>
+      <GridItem span={12}>
+        <FormGroup
+          label="HTTP proxy URL"
+          labelIcon={
+            <Popover bodyContent="The HTTP proxy URL that agents should use to access the discovery service.">
+              <button
+                type="button"
+                aria-label="More info"
+                onClick={(e) => e.preventDefault()}
+                className="pf-v5-c-form__group-label-help"
+              >
+                <HelpIcon />
+              </button>
+            </Popover>
+          }
+        >
+          <TextInput
+            name="httpProxy"
+            type="text"
+            value={httpProxy}
+            placeholder="http://<user>:<password>@<ipaddr>:<port>"
+            onChange={(_event,value) => onChange('httpProxy', value)}
+          />
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem>URL must start with http.</HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        </FormGroup>
+      </GridItem>
+
+      <GridItem span={12}>
+        <FormGroup
+          label="HTTPS proxy URL"
+          labelIcon={
+            <Popover bodyContent="Specify the HTTPS proxy that agents should use to access the discovery service. If you don't provide a value, your HTTP proxy URL will be used by default for both HTTP and HTTPS connections.">
+              <button
+                type="button"
+                aria-label="More info"
+                onClick={(e) => e.preventDefault()}
+                className="pf-v5-c-form__group-label-help"
+              >
+                <HelpIcon />
+              </button>
+            </Popover>
+          }
+        >
+          <TextInput
+            name="httpsProxy"
+            type="text"
+            value={httpsProxy}
+            placeholder="https://<user>:<password>@<ipaddr>:<port>"
+            onChange={(_event,value) => onChange('httpsProxy', value)}
+          />
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem>
+                URL must start with https.
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        </FormGroup>
+      </GridItem>
+
+      <GridItem span={12}>
+        <FormGroup
+          label="No proxy domains"
+          labelIcon={
+            <Popover bodyContent="Exclude destination domain names, IP addresses, or other network CIDRs from proxying by adding them to this comma-separated list.">
+              <button
+                type="button"
+                aria-label="More info"
+                onClick={(e) => e.preventDefault()}
+                className="pf-v5-c-form__group-label-help"
+              >
+                <HelpIcon />
+              </button>
+            </Popover>
+          }
+        >
+          <TextInput
+            name="noProxy"
+            type="text"
+            value={noProxy}
+            placeholder="one.domain.com,second.domain.com"
+            onChange={(_event,value) => onChange('noProxy', value)}
+            onBlur={() =>
+              onChange(
+                'noProxy',
+                noProxy.split(',').map((s) => s.trim()).join(','),
+              )
+            }
+          />
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem>
+                Use a comma to separate each listed domain. Preface a domain with "." to include its subdomains. Use "*" to bypass the proxy for all destinations.
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        </FormGroup>
+      </GridItem>
+    </Grid>
+  );
+};
+
+const ProxyFields: React.FC = () => {
+  const [enableProxy, setEnableProxy] = useState(false);
+  const [proxyValues, setProxyValues] = useState({
+    httpProxy: '',
+    httpsProxy: '',
+    noProxy: '',
+  });
+
+  const handleFieldChange = (field: string, value: string) => {
+    setProxyValues((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const toggleEnableProxy = (checked: boolean) => {
+    setEnableProxy(checked);
+    if (!checked) {
+      setProxyValues({
+        httpProxy: '',
+        httpsProxy: '',
+        noProxy: '',
+      });
+    }
+  };
+  return (
+    <>
+      <FormGroup label="Show proxy settings">
+        <Checkbox
+          id="enable-proxy"
+          label="Enable proxy"
+          isChecked={enableProxy}
+          onChange={(_event,value) => toggleEnableProxy(value)}
+        />
+      </FormGroup>
+      {enableProxy && (
+        <ProxyInputFields
+          httpProxy={proxyValues.httpProxy}
+          httpsProxy={proxyValues.httpsProxy}
+          noProxy={proxyValues.noProxy}
+          onChange={handleFieldChange}
+        />
+      )}
+    </>
+  );
+};
+
+export default ProxyFields;


### PR DESCRIPTION
Related with https://issues.redhat.com/browse/ECOPROJECT-2345

By default the proxy section is hidden:
![image](https://github.com/user-attachments/assets/3af48c35-857a-4494-bff0-659519b4ee56)


And when you enable the option the proxy fields appears:
![image](https://github.com/user-attachments/assets/f724a867-7c8b-4e43-b579-545ea793d0b6)
