### PR TITLE
ECOPROJECT-3100: Wizard perfomance is low

### DIFF
--- a/src/migration-wizard/steps/discovery/DiscoveryStep.tsx
+++ b/src/migration-wizard/steps/discovery/DiscoveryStep.tsx
@@ -293,6 +293,7 @@ export const DiscoveryStep: React.FC = () => {
                   <Progress
                     value={(ds.freeCapacityGB / ds.totalCapacityGB) * 100}
                     size="sm"
+                    aria-label="Disk usage"
                   />
                 </div>
               ),

--- a/src/migration-wizard/steps/discovery/assessment-report/Datastores.tsx
+++ b/src/migration-wizard/steps/discovery/assessment-report/Datastores.tsx
@@ -35,6 +35,7 @@ interface DatastoresProps {
                   <Progress
                     value={(ds.freeCapacityGB / ds.totalCapacityGB) * 100}
                     size="sm"
+                    aria-label="Disk usage"
                   />
                 </div>
               ),


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/ECOPROJECT-3100

Add aria-label to Progress component to avoid this error "One of aria-label or aria-labelledby properties should be passed when using the progress component without a title"