### PR TITLE
ECOPROJECT-3152: Solving problems with table size on print assessment report

### DIFF
--- a/src/migration-wizard/steps/discovery/assessment-report/OSDistribution.tsx
+++ b/src/migration-wizard/steps/discovery/assessment-report/OSDistribution.tsx
@@ -13,13 +13,16 @@ export const OSDistribution: React.FC<OSDistributionProps> = ({
   osData,
   isExportMode = false,
 }) => {
+ 
   return (
     <Card className={isExportMode ? 'dashboard-card-print' : 'dashboard-card'}>
       <CardTitle>
         <i className="fas fa-database" /> Operating Systems
       </CardTitle>
       <CardBody>
-        <OSBarChart osData={osData} isExportMode={isExportMode} />
+        
+          <OSBarChart osData={osData} isExportMode={isExportMode} />
+      
       </CardBody>
     </Card>
   );
@@ -43,6 +46,6 @@ export const OSBarChart: React.FC<OSBarChartProps> = ({
     count: count,
     legendCategory: `Supported`, // You may want to add logic to determine if an OS is supported
   }));
-
-  return <MigrationChart data={chartData} />;
+  const tableHeight = isExportMode ? '100%' : '200px';
+  return <MigrationChart data={chartData} maxHeight={tableHeight} />;
 };

--- a/src/migration-wizard/steps/discovery/assessment-report/StorageOverview.tsx
+++ b/src/migration-wizard/steps/discovery/assessment-report/StorageOverview.tsx
@@ -23,7 +23,7 @@ export const StorageOverview: React.FC<DiskHistogramProps> = ({
   step,
   isExportMode = false,
 }) => {
-  const tableHeight = isExportMode ? '100%' : '200px';
+  const tableHeight = isExportMode ? '100%' : '180px';
   const chartData = useMemo(() => {
     return data
       .map((count, index) => {
@@ -53,9 +53,7 @@ export const StorageOverview: React.FC<DiskHistogramProps> = ({
       </CardTitle>
       <CardBody>
         <Text component={TextVariants.small}>Disk Size Distribution</Text>
-       
-          <MigrationChart data={chartData} maxHeight='180px'/>
-        
+        <MigrationChart data={chartData}  maxHeight={tableHeight} />    
       </CardBody>
     </Card>
   );


### PR DESCRIPTION
Related to  https://issues.redhat.com/browse/ECOPROJECT-3152

Before the changes not all the data is reflected in the file - that's include  part of the Operating Systems, part of the Disks sizes or part of the Network Topology sections.
Below is an example of a data missed (and cut) in the operating systems section:
![image](https://github.com/user-attachments/assets/ba691814-fb8d-4ca6-bdb7-45d43476728d)


After the changes:
![image](https://github.com/user-attachments/assets/5f21e879-f080-490e-a879-b357d7ad7794)






