### PR TITLE
ECOPROJECT-3181: Problem sending empty values in proxy fields

### DIFF
--- a/src/migration-wizard/contexts/discovery-sources/Provider.tsx
+++ b/src/migration-wizard/contexts/discovery-sources/Provider.tsx
@@ -48,11 +48,32 @@ export const Provider: React.FC<PropsWithChildren> = (props) => {
   const [createSourceState, createSource] = useAsyncFn(
     async (name: string, sshPublicKey: string, httpProxy:string, httpsProxy:string, noProxy: string) => {
       try {
-        return await sourceApi.createSource({ sourceCreate: { name, sshPublicKey, proxy: {
-          httpUrl: httpProxy,
-          httpsUrl: httpsProxy,
-          noProxy: noProxy          
-        } } });
+        // Build the sourceCreate object conditionally
+        const sourceCreate: any = { name };
+        
+        // Only include sshPublicKey if it has a value
+        if (sshPublicKey && sshPublicKey.trim()) {
+          sourceCreate.sshPublicKey = sshPublicKey;
+        }
+        
+        // Only include proxy if at least one proxy field has a value
+        const proxyFields: any = {};
+        if (httpProxy && httpProxy.trim()) {
+          proxyFields.httpUrl = httpProxy;
+        }
+        if (httpsProxy && httpsProxy.trim()) {
+          proxyFields.httpsUrl = httpsProxy;
+        }
+        if (noProxy && noProxy.trim()) {
+          proxyFields.noProxy = noProxy;
+        }
+        
+        // Only add proxy object if it has at least one field
+        if (Object.keys(proxyFields).length > 0) {
+          sourceCreate.proxy = proxyFields;
+        }
+        
+        return await sourceApi.createSource({ sourceCreate });
       } catch (error: unknown) {
         console.error("Error creating source:", error);
   


### PR DESCRIPTION
Related with https://issues.redhat.com/browse/ECOPROJECT-3181

Steps to reproduce:

- Navigate to the "Add Environment" wizard/modal.
- Fill in the "Name your environment" field (e.g., "try").
- Provide a valid SSH Key.
- Do not check "Enable proxy" checkbox
- Click the "Generate OVA" button

Actual Results:

- An alert is displayed.
- The error message states:
"Failed to create source. Response: "Key: 'SourceCreate.Proxy.HttpUrl' Error:Field validation for 'HttpUrl' failed on the 'url' tag Key: 'SourceCreate.Proxy.HttpsUrl' Error:Field validation for 'HttpsUrl' failed on the 'url' tag" 
The OVA generation process does not proceed."

![image](https://github.com/user-attachments/assets/fbab3cca-55d6-41f3-b0f4-e318c749c7d7)
