### PR TITLE
ECOPROJECT-3151: the cluster creation button in the Stage environment should be reconfigured to direct users to the Dev environment.

### DIFF
--- a/src/migration-wizard/MigrationWizard.tsx
+++ b/src/migration-wizard/MigrationWizard.tsx
@@ -14,10 +14,22 @@ import { PrepareMigrationStep } from './steps/prepare-migration/PrepareMigration
 import { Source } from '@migration-planner-ui/api-client/models';
 
 const openAssistedInstaller = (): void => {
-  window.open(
-    '/openshift/assisted-installer/clusters/~new?source=assisted_migration',
-    '_blank',
-  );
+  const currentHost = window.location.hostname;
+  
+  
+  if (currentHost === 'console.stage.redhat.com') {
+    console.log('Opening dev URL for stage environment');
+    window.open(
+      'https://console.dev.redhat.com/openshift/assisted-installer/clusters/~new?source=assisted_migration',
+      '_blank',
+    );
+  } else {
+    console.log('Opening default URL');
+    window.open(
+      '/openshift/assisted-installer/clusters/~new?source=assisted_migration',
+      '_blank',
+    );
+  }
 };
 
 type CustomWizardFooterPropType = {


### PR DESCRIPTION
Related with https://issues.redhat.com/browse/ECOPROJECT-3151

The cluster creation button in the Stage environment should be reconfigured to direct users to the Dev environment. This approach supports continued testing within the Stage environment, where data is maintained separately from production.

To test it:
- Go to console.stage.redhat.com/openshift/migration-assessment/migrate/wizard
- Select a source with status "Ready"
- Go to the last page of the wizard
- Click in the "Let's create a new cluster button"
- It will open this URL: https://console.dev.redhat.com/openshift/assisted-installer/clusters/~new?source=assisted_migration