### PR TITLE
ECOPROJECT-3143: Change the icon for 'Uploaded manually' sources to the same icon as 'Ready' sources

### DIFF
--- a/src/migration-wizard/steps/connect/sources-table/AgentStatusView.tsx
+++ b/src/migration-wizard/steps/connect/sources-table/AgentStatusView.tsx
@@ -65,9 +65,15 @@ export const AgentStatusView: React.FC<AgentStatusView.Props> = (props) => {
       case "not-connected":
         return {
           icon: (
-            <Icon isInline>
-              <DisconnectedIcon />
-            </Icon>
+            uploadedManually ? (
+              <Icon size="md" isInline>
+                <CheckCircleIcon color={globalSuccessColor100.value} />
+              </Icon>
+            ) : (
+              <Icon isInline>
+                <DisconnectedIcon />
+              </Icon>
+            )
           ),
           text: uploadedManually ? "Uploaded manually": "Not connected",
         };


### PR DESCRIPTION
Related with https://issues.redhat.com/browse/ECOPROJECT-3143

To test it:
- Go to the sources list
- Check if "Uploaded manually" sources have the "Ready" icon

![image](https://github.com/user-attachments/assets/63c4badc-b082-47cb-89aa-0713afa948b3)
