### PR TITLE
ECOPROJECT-3154: Read new field osInfo for OS histogram

### DIFF
--- a/src/components/MigrationChart.tsx
+++ b/src/components/MigrationChart.tsx
@@ -4,7 +4,7 @@ import {
   FlexItem,
   Text,
   TextVariants,
-  Tooltip
+  Tooltip,
 } from '@patternfly/react-core';
 import { Table, Tbody, Td, Tr } from '@patternfly/react-table';
 
@@ -21,40 +21,73 @@ interface MigrationChartProps {
   maxHeight?: string;
 }
 
-type DLength = 10 | 15 | 20 | 25 | 30 | 35 | 40 | 45 | 50 | 60 | 70 | 80 | 90 | 100;
+type DLength =
+  | 10
+  | 15
+  | 20
+  | 25
+  | 30
+  | 35
+  | 40
+  | 45
+  | 50
+  | 60
+  | 70
+  | 80
+  | 90
+  | 100;
 
 const legendColors = ['#28a745', '#f0ad4e', '#d9534f', '#C9190B'];
 
-const MigrationChart: React.FC<MigrationChartProps> = ({ data, legend, dataLength=40,maxHeight='200px' }: MigrationChartProps) => {
+const MigrationChart: React.FC<MigrationChartProps> = ({
+  data,
+  legend,
+  dataLength = 40,
+  maxHeight = '200px',
+}: MigrationChartProps) => {
   const dynamicLegend = useMemo(() => {
-    return data.reduce((acc, current) => {
-      const key = `${current.legendCategory}`;
-      if (!acc.seen.has(key)) {
-        acc.seen.add(key);
-        acc.result.push({[key]: legendColors[acc.seen.size - 1]});
-      }
-      return acc;
-    }, { seen: new Set(), result: [] }).result;
+    return data.reduce(
+      (acc, current) => {
+        const key = `${current.legendCategory}`;
+        if (!acc.seen.has(key)) {
+          acc.seen.add(key);
+          acc.result.push({ [key]: legendColors[acc.seen.size - 1] });
+        }
+        return acc;
+      },
+      { seen: new Set(), result: [] },
+    ).result;
   }, [data, legendColors]);
-  
+
   const chartLegend = legend ? legend : Object.assign({}, ...dynamicLegend);
-  const getColor = (name: string) : string => chartLegend[name];
+  const getColor = (name: string): string => chartLegend[name];
 
   return (
-    <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
+    <Flex
+      direction={{ default: 'column' }}
+      spaceItems={{ default: 'spaceItemsLg' }}
+    >
       {/* Legend */}
       <FlexItem>
-        <Flex spaceItems={{ default: 'spaceItemsLg' }} justifyContent={{ default: 'justifyContentFlexEnd' }}>
-          { Object.entries(chartLegend).map(([key, color]) => (
+        <Flex
+          spaceItems={{ default: 'spaceItemsLg' }}
+          justifyContent={{ default: 'justifyContentFlexEnd' }}
+        >
+          {Object.entries(chartLegend).map(([key, color]) => (
             <FlexItem key={key}>
-              <Flex alignItems={{ default: 'alignItemsCenter' }} spaceItems={{ default: 'spaceItemsSm' }}>
+              <Flex
+                alignItems={{ default: 'alignItemsCenter' }}
+                spaceItems={{ default: 'spaceItemsSm' }}
+              >
                 <FlexItem>
-                  <div style={{ 
-                    width: '12px', 
-                    height: '12px', 
-                    backgroundColor: color as string, 
-                    borderRadius: '2px' 
-                  }} />
+                  <div
+                    style={{
+                      width: '12px',
+                      height: '12px',
+                      backgroundColor: color as string,
+                      borderRadius: '2px',
+                    }}
+                  />
                 </FlexItem>
                 <FlexItem>
                   <Text component={TextVariants.small}>{key}</Text>
@@ -66,59 +99,77 @@ const MigrationChart: React.FC<MigrationChartProps> = ({ data, legend, dataLengt
       </FlexItem>
       {/* Chart Area */}
       <FlexItem>
-        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
-          <div style={{maxHeight: maxHeight,overflowY: 'auto'}}>  
+        <Flex
+          direction={{ default: 'column' }}
+          spaceItems={{ default: 'spaceItemsMd' }}
+        >
+          <div style={{ maxHeight: maxHeight, overflowY: 'auto' }}>
             <Table variant="compact" borders={false}>
               <Tbody>
                 {data.map((item, index) => (
-                <Tr key={index}>
-                  <Td  width={dataLength} style={{paddingLeft: '0px'}}>
-                    <Tooltip content={<div>{item.name}</div>}  exitDelay={0}>
-                      <Text component={TextVariants.p} 
-                          style={{fontSize: 'clamp(0.4rem, 0.7vw, 1.1rem)', 
-                                  overflow: 'hidden',
-                                  textOverflow: 'ellipsis',
-                                  wordBreak: 'break-word',
-                                  display: '-webkit-box',
-                                  WebkitLineClamp: 1, // Number of lines to show
-                                  textTransform: 'capitalize',
-                                  WebkitBoxOrient: 'vertical' }}>{item.name}</Text> 
-                    </Tooltip>
-                  </Td>
-                  <Td>
+                  <Tr key={index}>
+                    <Td width={dataLength} style={{ paddingLeft: '0px' }}>
+                      <Tooltip content={<div>{item.name}</div>} exitDelay={0}>
+                        <Text
+                          component={TextVariants.p}
+                          style={{
+                            fontSize: 'clamp(0.4rem, 0.7vw, 1.1rem)',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            wordBreak: 'break-word',
+                            display: '-webkit-box',
+                            WebkitLineClamp: 1, // Number of lines to show
+                            textTransform: 'capitalize',
+                            WebkitBoxOrient: 'vertical',
+                          }}
+                        >
+                          {item.name}
+                        </Text>
+                      </Tooltip>
+                    </Td>
+                    <Td>
                       {/* Visual Bar */}
                       <div>
-                        <div style={{ 
-                          position: 'relative',
-                          height: '8px',
-                          backgroundColor: '#F5F5F5',
-                          overflow: 'hidden'
-                        }}>
-                          <div style={{
-                            height: '100%',
-                            width: `${item.count}%`,
-                            backgroundColor: `${getColor(item.legendCategory)}`,
-                            transition: 'width 0.3s ease'
-                          }} />
+                        <div
+                          style={{
+                            position: 'relative',
+                            height: '8px',
+                            backgroundColor: '#F5F5F5',
+                            overflow: 'hidden',
+                          }}
+                        >
+                          <div
+                            style={{
+                              height: '100%',
+                              width: `${item.count}%`,
+                              backgroundColor: `${getColor(
+                                item.legendCategory,
+                              )}`,
+                              transition: 'width 0.3s ease',
+                            }}
+                          />
                         </div>
                       </div>
-                  </Td>
-                  <Td width={10}  style={{paddingRight : '0px', textAlign: 'center'}}>
-                    <Text style={{fontSize: 'clamp(0.4rem, 0.7vw, 1.1rem)'}}>{item.count}</Text>
-                  </Td>
-                </Tr>
-                 ))}
+                    </Td>
+                    <Td
+                      width={10}
+                      style={{ paddingRight: '0px', textAlign: 'center' }}
+                    >
+                      <Text
+                        style={{ fontSize: 'clamp(0.4rem, 0.7vw, 1.1rem)' }}
+                      >
+                        {item.count}
+                      </Text>
+                    </Td>
+                  </Tr>
+                ))}
               </Tbody>
             </Table>
           </div>
         </Flex>
       </FlexItem>
-      
-      
     </Flex>
   );
 };
 
 export default MigrationChart;
-
-

--- a/src/migration-wizard/steps/discovery/assessment-report/Dashboard.tsx
+++ b/src/migration-wizard/steps/discovery/assessment-report/Dashboard.tsx
@@ -38,13 +38,22 @@ export const Dashboard: React.FC<Props> = ({
   vms,
   isExportMode,
 }) => {
-  // Transform osInfo to the expected format, fallback to os if osInfo is undefined
+  // Transform osInfo to include both count and supported fields, fallback to os with supported=true if osInfo is undefined
   const osData = vms.osInfo
     ? Object.entries(vms.osInfo).reduce((acc, [osName, osInfo]) => {
-        acc[osName] = osInfo.count;
+        acc[osName] = {
+          count: osInfo.count,
+          supported: osInfo.supported,
+        };
         return acc;
-      }, {} as { [osName: string]: number })
-    : vms.os;
+      }, {} as { [osName: string]: { count: number; supported: boolean } })
+    : Object.entries(vms.os).reduce((acc, [osName, count]) => {
+        acc[osName] = {
+          count: count,
+          supported: true, // Default to supported when using fallback data
+        };
+        return acc;
+      }, {} as { [osName: string]: { count: number; supported: boolean } });
 
   return (
     <PageSection variant={PageSectionVariants.light}>

--- a/src/migration-wizard/steps/discovery/assessment-report/Dashboard.tsx
+++ b/src/migration-wizard/steps/discovery/assessment-report/Dashboard.tsx
@@ -1,23 +1,25 @@
 import React from 'react';
-import {
-  PageSection,
-  PageSectionVariants,
-  Grid,
-  GridItem,
-  Gallery,
-  GalleryItem,
-} from '@patternfly/react-core';
-import { InfrastructureOverview } from './InfastructureOverview';
+
 import {
   Infra,
   VMResourceBreakdown,
   VMs,
 } from '@migration-planner-ui/api-client/models';
-import { VMMigrationStatus } from './VMMigrationStatus';
-import { NetworkTopology } from './NetworkTopology';
-import { StorageOverview } from './StorageOverview';
-import { OSDistribution } from './OSDistribution';
+import {
+  Gallery,
+  GalleryItem,
+  Grid,
+  GridItem,
+  PageSection,
+  PageSectionVariants,
+} from '@patternfly/react-core';
+
 import { Datastores } from './Datastores';
+import { InfrastructureOverview } from './InfastructureOverview';
+import { NetworkTopology } from './NetworkTopology';
+import { OSDistribution } from './OSDistribution';
+import { StorageOverview } from './StorageOverview';
+import { VMMigrationStatus } from './VMMigrationStatus';
 
 import './Dashboard.css';
 
@@ -36,6 +38,14 @@ export const Dashboard: React.FC<Props> = ({
   vms,
   isExportMode,
 }) => {
+  // Transform osInfo to the expected format, fallback to os if osInfo is undefined
+  const osData = vms.osInfo
+    ? Object.entries(vms.osInfo).reduce((acc, [osName, osInfo]) => {
+        acc[osName] = osInfo.count;
+        return acc;
+      }, {} as { [osName: string]: number })
+    : vms.os;
+
   return (
     <PageSection variant={PageSectionVariants.light}>
       <Grid hasGutter>
@@ -58,7 +68,7 @@ export const Dashboard: React.FC<Props> = ({
               />
             </GalleryItem>
             <GalleryItem>
-              <OSDistribution osData={vms.os}  isExportMode={isExportMode}/>
+              <OSDistribution osData={osData} isExportMode={isExportMode} />
             </GalleryItem>
           </Gallery>
         </GridItem>
@@ -73,18 +83,20 @@ export const Dashboard: React.FC<Props> = ({
               />
             </GalleryItem>
             <GalleryItem>
-            <NetworkTopology networks={infra.networks}  isExportMode={isExportMode}/>
-                
+              <NetworkTopology
+                networks={infra.networks}
+                isExportMode={isExportMode}
+              />
             </GalleryItem>
           </Gallery>
         </GridItem>
         <GridItem span={12}>
           <Gallery hasGutter minWidths={{ default: '80%' }}>
             <GalleryItem>
-            <Datastores
-                  datastores={infra.datastores}
-                  isExportMode={isExportMode}
-                />
+              <Datastores
+                datastores={infra.datastores}
+                isExportMode={isExportMode}
+              />
             </GalleryItem>
           </Gallery>
         </GridItem>

--- a/src/migration-wizard/steps/discovery/assessment-report/OSDistribution.tsx
+++ b/src/migration-wizard/steps/discovery/assessment-report/OSDistribution.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
+
 import { Card, CardBody, CardTitle } from '@patternfly/react-core';
+
 import MigrationChart from '../../../../components/MigrationChart';
 
 interface OSDistributionProps {
   osData: {
-    [osName: string]: number;
+    [osName: string]: {
+      count: number;
+      supported: boolean;
+    };
   };
   isExportMode?: boolean;
 }
@@ -13,23 +18,20 @@ export const OSDistribution: React.FC<OSDistributionProps> = ({
   osData,
   isExportMode = false,
 }) => {
- 
   return (
     <Card className={isExportMode ? 'dashboard-card-print' : 'dashboard-card'}>
       <CardTitle>
         <i className="fas fa-database" /> Operating Systems
       </CardTitle>
       <CardBody>
-        
-          <OSBarChart osData={osData} isExportMode={isExportMode} />
-      
+        <OSBarChart osData={osData} isExportMode={isExportMode} />
       </CardBody>
     </Card>
   );
 };
 
 interface OSBarChartProps {
-  osData: { [osName: string]: number };
+  osData: { [osName: string]: { count: number; supported: boolean } };
   isExportMode?: boolean;
 }
 
@@ -39,13 +41,26 @@ export const OSBarChart: React.FC<OSBarChartProps> = ({
 }) => {
   const dataEntries = Object.entries(osData).filter(([os]) => os.trim() !== '');
 
-  const sorted = dataEntries.sort(([, a], [, b]) => b - a);
+  const sorted = dataEntries.sort(([, a], [, b]) => b.count - a.count);
 
-  const chartData = sorted.map(([os, count]) => ({
+  const chartData = sorted.map(([os, osInfo]) => ({
     name: os,
-    count: count,
-    legendCategory: `Supported`, // You may want to add logic to determine if an OS is supported
+    count: osInfo.count,
+    legendCategory: osInfo.supported ? 'Supported' : 'Not Supported',
   }));
+
+  // Define custom colors: green for supported, red for not supported
+  const customLegend = {
+    Supported: '#28a745', // Green
+    'Not Supported': '#d9534f', // Red
+  };
+
   const tableHeight = isExportMode ? '100%' : '200px';
-  return <MigrationChart data={chartData} maxHeight={tableHeight} />;
+  return (
+    <MigrationChart
+      data={chartData}
+      legend={customLegend}
+      maxHeight={tableHeight}
+    />
+  );
 };


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/ECOPROJECT-3154

Newer agents send osInfo field which contains also supported attribute. We would like to use this attribute and if it's not defined fallback to previous solution using os attribute.

Use the new supported field to display items in red if unsupported or green if supported.
<img width="632" height="356" alt="image" src="https://github.com/user-attachments/assets/1002a8e0-9acc-4c1d-8c06-eae9fdffc10b" />

