### PR TITLE
ECOPROJECT-3098 | add the option on source click to download again the OVA

### DIFF
--- a/src/migration-wizard/contexts/discovery-sources/@types/DiscoverySources.d.ts
+++ b/src/migration-wizard/contexts/discovery-sources/@types/DiscoverySources.d.ts
@@ -53,5 +53,8 @@ declare namespace DiscoverySources {
     ) => Promise<void>;
     isUpdatingSource: boolean;
     errorUpdatingSource?: Error;
+    sourceDownloadUrls: Record<string, string>;
+    getDownloadUrlForSource: (sourceId: string) => string | undefined;
+    storeDownloadUrlForSource: (sourceId: string, downloadUrl: string) => void;
   };
 }

--- a/src/migration-wizard/contexts/discovery-sources/Provider.tsx
+++ b/src/migration-wizard/contexts/discovery-sources/Provider.tsx
@@ -1,4 +1,4 @@
-import React, { type PropsWithChildren, useCallback, useState } from 'react';
+import React, { type PropsWithChildren, useCallback, useState, useEffect } from 'react';
 import { useAsyncFn, useInterval } from 'react-use';
 
 import {
@@ -27,6 +27,7 @@ export const Provider: React.FC<PropsWithChildren> = (props) => {
   const [sourcesLoaded, setSourcesLoaded] = useState(false);
 
   const [downloadSourceUrl, setDownloadSourceUrl] = useState('');
+  const [sourceDownloadUrls, setSourceDownloadUrls] = useState<Record<string, string>>({});
 
   const [sourceCreatedId, setSourceCreatedId] = useState<string | null>(null);
 
@@ -158,10 +159,22 @@ export const Provider: React.FC<PropsWithChildren> = (props) => {
       });
       downloadSourceState.loading = true;
 
+      storeDownloadUrlForSource(newSource.id, imageUrl.url);
       setDownloadSourceUrl(imageUrl.url);
       setSourceCreatedId(newSource.id);
     },
   );
+
+  const getDownloadUrlForSource = useCallback((sourceId: string): string | undefined => {
+    return sourceDownloadUrls[sourceId];
+  }, [sourceDownloadUrls]);
+
+  const storeDownloadUrlForSource = useCallback((sourceId: string, downloadUrl: string) => {
+    setSourceDownloadUrls(prev => ({
+      ...prev,
+      [sourceId]: downloadUrl
+    }));
+  }, []);
 
   const [isPolling, setIsPolling] = useState(false);
   const [pollingDelay, setPollingDelay] = useState<number | null>(null);
@@ -354,6 +367,9 @@ export const Provider: React.FC<PropsWithChildren> = (props) => {
     uploadRvtoolsFile,
     isUploadingRvtoolsFile: uploadRvtoolsFileState.loading,
     errorUploadingRvtoolsFile: uploadRvtoolsFileState.error,
+    sourceDownloadUrls,
+    getDownloadUrlForSource,
+    storeDownloadUrlForSource,
   };
 
   return <Context.Provider value={ctx}>{children}</Context.Provider>;

--- a/src/migration-wizard/steps/connect/sources-table/SourcesTable.tsx
+++ b/src/migration-wizard/steps/connect/sources-table/SourcesTable.tsx
@@ -10,6 +10,7 @@ import { Link } from 'react-router-dom';
 import { Source } from '@migration-planner-ui/api-client/models';
 import { AgentStatusView } from './AgentStatusView';
 import { UploadInventoryAction } from './actions/UploadInventoryAction';
+import { DownloadOvaAction } from './actions/DownloadOvaAction';
 import { useDiscoverySources } from '../../../contexts/discovery-sources/Context';
 
 export const SourcesTable: React.FC<{
@@ -240,6 +241,12 @@ export const SourcesTable: React.FC<{
                             onUploadSuccess={onUploadSuccess}
                           />
                         )}
+                      {source.name !== 'Example' && (
+                        <DownloadOvaAction
+                          sourceId={source.id}
+                          sourceName={source.name}
+                        />
+                      )}
                     </Td>
                   </Tr>
                 );

--- a/src/migration-wizard/steps/connect/sources-table/actions/DownloadOvaAction.tsx
+++ b/src/migration-wizard/steps/connect/sources-table/actions/DownloadOvaAction.tsx
@@ -1,0 +1,69 @@
+import React, { useCallback, useState } from "react";
+import {
+  Tooltip,
+  Button,
+  Icon,
+} from "@patternfly/react-core";
+import { DownloadIcon } from "@patternfly/react-icons";
+import { useDiscoverySources } from "../../../../contexts/discovery-sources/Context";
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace DownloadOvaAction {
+  export type Props = {
+    sourceId: string;
+    sourceName?: string;
+    isDisabled?: boolean;
+  };
+}
+
+export const DownloadOvaAction: React.FC<DownloadOvaAction.Props> = (
+  props
+) => {
+  const { 
+    sourceId, 
+    sourceName, 
+    isDisabled = false, 
+  } = props;
+  
+  const discoverySourcesContext = useDiscoverySources();
+  const [isDownloading, setIsDownloading] = useState(false);
+  const url = discoverySourcesContext.getDownloadUrlForSource(sourceId);
+
+  const handleDownload = useCallback(async () => {
+    try {
+      setIsDownloading(true);
+
+      const anchor = document.createElement('a');
+      anchor.download = `${sourceName || sourceId}.ova`;
+      anchor.href = url;
+      anchor.click();
+      anchor.remove();
+
+    } catch (error) {
+      console.error('Download failed:', error);
+    } finally {
+      setIsDownloading(false);
+    }
+  }, [
+    sourceId, 
+    sourceName,
+    url,
+  ]);
+
+  return (
+    <Tooltip content="Download OVA File">
+      <Button
+        data-source-id={sourceId}
+        variant="plain"
+        isDisabled={isDisabled || isDownloading || !url}
+        onClick={handleDownload}
+      >
+        <Icon size="md" isInline>
+          <DownloadIcon />
+        </Icon>
+      </Button>
+    </Tooltip>
+  );
+};
+
+DownloadOvaAction.displayName = "DownloadOvaAction"; 


### PR DESCRIPTION
Hi,

https://github.com/user-attachments/assets/34541dc6-c529-49fd-b5e7-25b3b1c75111

Please view the short attached demo.

In the current implementation, it saves the download URL for each source, but it doesn’t keep it after a refresh.

[ECOPROJECT-3098](https://issues.redhat.com/browse/ECOPROJECT-3098)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Download OVA File" action button to the sources table, allowing users to download OVA files for each source (except "Example").
  * Users can now easily access and download OVA files directly from the interface.

* **Bug Fixes**
  * None.

* **Documentation**
  * None.

* **Refactor**
  * None.

* **Style**
  * None.

* **Tests**
  * None.

* **Chores**
  * None.

* **Revert**
  * None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->