### PR TITLE
ECOPROJECT-3242: Change VM Migration Status diagram

### DIFF
--- a/src/migration-wizard/steps/discovery/assessment-report/Dashboard.tsx
+++ b/src/migration-wizard/steps/discovery/assessment-report/Dashboard.tsx
@@ -72,8 +72,8 @@ export const Dashboard: React.FC<Props> = ({
             <GalleryItem>
               <VMMigrationStatus
                 data={{
-                  migratable: vms.totalMigratableWithWarnings,
-                  nonMigratable: vms.total - vms.totalMigratableWithWarnings,
+                  migratable: vms.totalMigratable,
+                  nonMigratable: vms.total - vms.totalMigratable,
                 }}
                 isExportMode={isExportMode}
               />


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/ECOPROJECT-3242

<img width="594" height="355" alt="Captura desde 2025-08-07 10-00-21" src="https://github.com/user-attachments/assets/7940b942-7ae6-4bcd-ae68-9a618922c3f8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the migration status dashboard to display the correct counts for migratable and non-migratable virtual machines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->