### PR TITLE
NO-ISSUE | feat: Add job to build container

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -1,0 +1,28 @@
+name: Build and push images
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build_push:
+    runs-on: ubuntu-latest
+    env:
+    steps:
+      - name: Checkout forklift
+        uses: actions/checkout@v4
+
+      - name: Login to quay.io with bot account
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Build and push images to quay.io
+        run: |
+          cd ${GITHUB_WORKSPACE}
+          make podman-build IMAGE=quay.io/kubev2v/migration-planner-ui
+          make podman-push IMAGE=quay.io/kubev2v/migration-planner-ui


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a CI workflow to automatically build and publish container images to the registry on pushes to the main branch and on manual triggers, ensuring up-to-date images are readily available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->