### PR TITLE
ECOPROJECT-3262 | ci: Add automated Slack notifications for releases and weekly summaries

### DIFF
--- a/.github/workflows/tag-summary.yml
+++ b/.github/workflows/tag-summary.yml
@@ -1,0 +1,63 @@
+name: Release Tag Summary
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  summarize-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate summary and send to Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+          NEW_TAG: ${{ github.ref_name }}
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        run: |
+          set -e
+          
+          # Validate required environment variables
+          if [ -z "$SLACK_WEBHOOK_URL" ] && ([ -z "$SLACK_BOT_TOKEN" ] || [ -z "$SLACK_CHANNEL" ]); then
+            echo "Error: Either SLACK_WEBHOOK_URL or (SLACK_BOT_TOKEN + SLACK_CHANNEL) must be set"
+            echo "For threading support, use: SLACK_BOT_TOKEN and SLACK_CHANNEL"
+            echo "For simple messaging, use: SLACK_WEBHOOK_URL"
+            exit 1
+          fi
+          
+          PREV_TAG=$(git tag --sort=-committerdate | head -n 2 | tail -n 1)
+
+          if [ -z "$PREV_TAG" ]; then
+            COMMITS=$(git log --pretty=format:"%an|%s")
+            MESSAGE_TYPE="New Tag was created: $NEW_TAG 🎉"
+          else
+            MERGE_BASE=$(git merge-base $PREV_TAG $NEW_TAG)
+            COMMITS=$(git log --pretty=format:"%an|%s" $MERGE_BASE..$NEW_TAG)
+            MESSAGE_TYPE="New Tag was created: $NEW_TAG (changes since $PREV_TAG) 🎉"
+          fi
+
+          if [ -z "$COMMITS" ]; then
+            CHANGE_DETAILS="No new commits were found."
+          else
+            # Generate detailed changes message
+            DETAILS_PAYLOAD=$(echo "$COMMITS" | ./ci/create-slack-message.sh)
+            
+            # Parse JSON to get the text content
+            if [ -n "$DETAILS_PAYLOAD" ] && CHANGE_DETAILS=$(echo "$DETAILS_PAYLOAD" | jq -r '.text' 2>/dev/null); then
+              echo "Successfully generated commit details with JIRA integration"
+            else
+              echo "WARNING: Could not parse JSON output, using fallback"
+              CHANGE_DETAILS="Unable to parse commit details"
+            fi
+          fi
+
+          # Use the new send-slack-message script
+          ./ci/send-slack-message.sh "$MESSAGE_TYPE" "$CHANGE_DETAILS"

--- a/.github/workflows/weekly-summary.yml
+++ b/.github/workflows/weekly-summary.yml
@@ -1,0 +1,59 @@
+name: Weekly Commit Summary
+
+on:
+  schedule:
+    # Run every Saturday at 10:00 AM UTC
+    # Format: minute(0-59) hour(0-23) day_of_month(1-31) month(1-12) day_of_week(0-6, 0=Sunday, 6=Saturday)
+    - cron: '0 10 * * 6'
+
+jobs:
+  summarize-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate summary and send to Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        run: |
+          set -e
+          
+          # Validate required environment variables
+          if [ -z "$SLACK_WEBHOOK_URL" ] && ([ -z "$SLACK_BOT_TOKEN" ] || [ -z "$SLACK_CHANNEL" ]); then
+            echo "Error: Either SLACK_WEBHOOK_URL or (SLACK_BOT_TOKEN + SLACK_CHANNEL) must be set"
+            echo "For threading support, use: SLACK_BOT_TOKEN and SLACK_CHANNEL"
+            echo "For simple messaging, use: SLACK_WEBHOOK_URL"
+            exit 1
+          fi
+          
+          # Simplified: get commits from last 7 days
+          COMMITS=$(git log --since="7 days ago" --pretty=format:"%an|%s")
+          
+          MESSAGE_TYPE="Weekly Summary (Last 7 Days) 📅"
+
+          echo "Processing weekly commits..."
+
+          if [ -z "$COMMITS" ]; then
+            CHANGE_DETAILS="No new commits were pushed to the main branch in the last 7 days."
+          else
+            # Generate detailed changes message
+            DETAILS_PAYLOAD=$(echo "$COMMITS" | ./ci/create-slack-message.sh)
+            
+            # Parse JSON to get the text content
+            if [ -n "$DETAILS_PAYLOAD" ] && CHANGE_DETAILS=$(echo "$DETAILS_PAYLOAD" | jq -r '.text' 2>/dev/null); then
+              echo "Successfully generated weekly summary with JIRA integration"
+            else
+              echo "WARNING: Could not parse JSON output, using fallback"
+              CHANGE_DETAILS="Unable to parse commit details"
+            fi
+          fi
+
+          # Use the new send-slack-message script
+          ./ci/send-slack-message.sh "$MESSAGE_TYPE" "$CHANGE_DETAILS"

--- a/ci/create-slack-message.sh
+++ b/ci/create-slack-message.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+
+# This script generates a formatted Slack message from a list of commit messages.
+# It takes the commit log and author as input and outputs a JSON payload.
+#
+# Requirements:
+# - Bash 4.0+ (for associative arrays)
+# - jq (for JSON formatting)
+#
+# Setup for cross-platform compatibility:
+# On Linux: Usually has bash 4+ by default
+# On macOS: Run `brew install bash` then add to PATH:
+#   echo 'export PATH="/opt/homebrew/bin:$PATH"' >> ~/.zshrc
+#   source ~/.zshrc
+#
+# Usage:
+#   git log --pretty=format:"%an|%s" | ./ci/create-slack-message.sh
+
+set -euo pipefail
+
+echo "🔄 Starting Slack message generation with JIRA integration..." >&2
+
+# Check if we have bash 4.0+ for associative arrays
+if [ "${BASH_VERSION%%.*}" -lt 4 ]; then
+  echo "Error: This script requires Bash 4.0 or later for associative arrays." >&2
+  echo "Current version: $BASH_VERSION" >&2
+  echo "Please ensure you have bash 4+ in your PATH." >&2
+  echo "On macOS: brew install bash && export PATH=\"/opt/homebrew/bin:\$PATH\"" >&2
+  exit 1
+fi
+
+if [ -t 0 ]; then
+  echo "Error: This script expects commit messages via stdin." >&2
+  exit 1
+fi
+
+# Check if jq is available
+if ! command -v jq &> /dev/null; then
+  echo "Error: jq is required but not installed." >&2
+  exit 1
+fi
+
+declare -A COMMITS_BY_TYPE
+COMMITS_BY_TYPE[feat]=""
+COMMITS_BY_TYPE[fix]=""
+COMMITS_BY_TYPE[build]=""
+COMMITS_BY_TYPE[ci]=""
+COMMITS_BY_TYPE[docs]=""
+COMMITS_BY_TYPE[perf]=""
+COMMITS_BY_TYPE[refactor]=""
+COMMITS_BY_TYPE[style]=""
+COMMITS_BY_TYPE[test]=""
+COMMITS_BY_TYPE[misc]=""
+COMMITS_BY_TYPE[bot]=""
+
+# Track JIRA tickets to avoid duplicates
+declare -A JIRA_TICKETS_SEEN
+declare -A JIRA_TICKET_TYPES
+declare -A JIRA_TICKET_MESSAGES
+
+# Define commit type priority (higher number = higher priority)
+declare -A TYPE_PRIORITY
+TYPE_PRIORITY[feat]=9
+TYPE_PRIORITY[fix]=8
+TYPE_PRIORITY[perf]=7
+TYPE_PRIORITY[refactor]=6
+TYPE_PRIORITY[build]=5
+TYPE_PRIORITY[ci]=4
+TYPE_PRIORITY[docs]=3
+TYPE_PRIORITY[test]=2
+TYPE_PRIORITY[style]=1
+TYPE_PRIORITY[misc]=0
+
+# Define a list of bot accounts to ignore commit parsing for
+BOT_USERS=("github-actions[bot]" "dependabot[bot]" "red-hat-konflux[bot]")
+
+is_bot_user() {
+  local user="$1"
+  for bot in "${BOT_USERS[@]}"; do
+    if [[ "$user" == "$bot" ]]; then
+      return 0 # is a bot
+    fi
+  done
+  return 1 # not a bot
+}
+
+COMMIT_COUNT=0
+while IFS=$'\n' read -r line; do
+  COMMIT_COUNT=$((COMMIT_COUNT + 1))
+  if [ $COMMIT_COUNT -eq 1 ]; then
+    echo "📥 Processing commits:" >&2
+  fi
+  if [ $COMMIT_COUNT -le 5 ]; then
+    echo "$line" >&2
+  elif [ $COMMIT_COUNT -eq 6 ]; then
+    echo "... (showing first 5 commits)" >&2
+  fi
+  AUTHOR=$(echo "$line" | cut -d'|' -f1 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+  COMMIT_SUBJECT=$(echo "$line" | cut -d'|' -f2- | sed 's/^[[:space:]]*//')
+
+  if is_bot_user "$AUTHOR"; then
+    FORMATTED_COMMIT="• $COMMIT_SUBJECT"
+    COMMITS_BY_TYPE[bot]+="$FORMATTED_COMMIT"$'\n'
+  else
+    JIRA_TICKET=$(echo "$COMMIT_SUBJECT" | grep -o -E '^[A-Z]+-[0-9]+' || echo "NO-JIRA")
+    
+    # Extract commit type - look for pattern "type:" in commit message
+    if echo "$COMMIT_SUBJECT" | grep -q -iE '(feat|fix|docs|style|refactor|perf|test|build|ci):'; then
+      COMMIT_TYPE=$(echo "$COMMIT_SUBJECT" | grep -oiE '(feat|fix|docs|style|refactor|perf|test|build|ci):' | sed 's/://' | tr '[:upper:]' '[:lower:]')
+      # Extract everything after "type: " case-insensitively
+      COMMIT_MESSAGE=$(echo "$COMMIT_SUBJECT" | sed -E 's/.*(feat|fix|docs|style|refactor|perf|test|build|ci): *(.*)/\2/i')
+    else
+      COMMIT_TYPE="misc"
+      COMMIT_MESSAGE="$COMMIT_SUBJECT"
+    fi
+
+    # Handle JIRA tickets - group commits by ticket with priority-based type selection
+    if [ "$JIRA_TICKET" != "NO-JIRA" ]; then
+      # Check if we've already seen this JIRA ticket
+      if [[ ! -v JIRA_TICKETS_SEEN[$JIRA_TICKET] ]]; then
+        # First time seeing this ticket
+        JIRA_TICKETS_SEEN[$JIRA_TICKET]=1
+        JIRA_TICKET_TYPES[$JIRA_TICKET]=$COMMIT_TYPE
+        JIRA_TICKET_MESSAGES[$JIRA_TICKET]="$COMMIT_MESSAGE"
+      else
+        # We've seen this ticket before - check if current type has higher priority
+        CURRENT_PRIORITY=${TYPE_PRIORITY[$COMMIT_TYPE]:-0}
+        EXISTING_TYPE=${JIRA_TICKET_TYPES[$JIRA_TICKET]}
+        EXISTING_PRIORITY=${TYPE_PRIORITY[$EXISTING_TYPE]:-0}
+        
+        if [ "$CURRENT_PRIORITY" -gt "$EXISTING_PRIORITY" ]; then
+          # Update to higher priority type
+          JIRA_TICKET_TYPES[$JIRA_TICKET]=$COMMIT_TYPE
+          JIRA_TICKET_MESSAGES[$JIRA_TICKET]="$COMMIT_MESSAGE"
+        fi
+      fi
+    else
+      # No JIRA ticket - add commit normally
+      FORMATTED_COMMIT="• $COMMIT_MESSAGE"
+      if [[ -v COMMITS_BY_TYPE[$COMMIT_TYPE] ]]; then
+        COMMITS_BY_TYPE[$COMMIT_TYPE]+="$FORMATTED_COMMIT"$'\n'
+      else
+        COMMITS_BY_TYPE[misc]+="$FORMATTED_COMMIT"$'\n'
+      fi
+    fi
+  fi
+done
+
+echo "📊 Processed $COMMIT_COUNT commits total" >&2
+echo "" >&2
+
+# Second pass: Process all collected JIRA tickets
+for JIRA_TICKET in "${!JIRA_TICKETS_SEEN[@]}"; do
+  COMMIT_TYPE=${JIRA_TICKET_TYPES[$JIRA_TICKET]}
+  COMMIT_MESSAGE=${JIRA_TICKET_MESSAGES[$JIRA_TICKET]}
+  
+  # Try to fetch JIRA ticket title if API is available
+  JIRA_TITLE=""
+  if [ -n "${JIRA_BASE_URL:-}" ] && [ -n "${JIRA_API_TOKEN:-}" ]; then
+    # Make the API call
+    JIRA_RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}" \
+      -H "Authorization: Bearer $JIRA_API_TOKEN" \
+      "$JIRA_BASE_URL/rest/api/2/issue/$JIRA_TICKET" 2>&1)
+    
+    HTTP_CODE=$(echo "$JIRA_RESPONSE" | grep "HTTP_CODE:" | cut -d: -f2)
+    JIRA_JSON=$(echo "$JIRA_RESPONSE" | sed '/HTTP_CODE:/d')
+    
+    if [ "$HTTP_CODE" = "200" ]; then
+      JIRA_TITLE=$(echo "$JIRA_JSON" | jq -r '.fields.summary // empty' 2>/dev/null || echo "")
+    else
+      echo "⚠ JIRA API failed for $JIRA_TICKET (HTTP $HTTP_CODE)" >&2
+    fi
+  fi
+  
+  # Use JIRA title if available, otherwise use commit message
+  if [ -n "$JIRA_TITLE" ]; then
+    DISPLAY_MESSAGE="$JIRA_TITLE"
+  else
+    DISPLAY_MESSAGE="$COMMIT_MESSAGE"
+  fi
+  
+  if [ -n "${JIRA_BASE_URL:-}" ]; then
+    JIRA_LINK="${JIRA_BASE_URL}/browse/$JIRA_TICKET"
+    FORMATTED_COMMIT="• $DISPLAY_MESSAGE [<$JIRA_LINK|$JIRA_TICKET>]"
+  else
+    FORMATTED_COMMIT="• $DISPLAY_MESSAGE [$JIRA_TICKET]"
+  fi
+  
+  if [[ -v COMMITS_BY_TYPE[$COMMIT_TYPE] ]]; then
+    COMMITS_BY_TYPE[$COMMIT_TYPE]+="$FORMATTED_COMMIT"$'\n'
+  else
+    COMMITS_BY_TYPE[misc]+="$FORMATTED_COMMIT"$'\n'
+  fi
+done
+
+MESSAGE_TEXT=""
+
+[ ! -z "${COMMITS_BY_TYPE[feat]}" ] && MESSAGE_TEXT+=$'\n'":sparkles: *New Features*"$'\n'"${COMMITS_BY_TYPE[feat]}"$'\n'
+[ ! -z "${COMMITS_BY_TYPE[fix]}" ] && MESSAGE_TEXT+=$'\n'":bug: *Bug Fixes*"$'\n'"${COMMITS_BY_TYPE[fix]}"$'\n'
+[ ! -z "${COMMITS_BY_TYPE[perf]}" ] && MESSAGE_TEXT+=$'\n'":rocket: *Performance Improvements*"$'\n'"${COMMITS_BY_TYPE[perf]}"$'\n'
+[ ! -z "${COMMITS_BY_TYPE[refactor]}" ] && MESSAGE_TEXT+=$'\n'":recycle: *Refactoring*"$'\n'"${COMMITS_BY_TYPE[refactor]}"$'\n'
+[ ! -z "${COMMITS_BY_TYPE[docs]}" ] && MESSAGE_TEXT+=$'\n'":memo: *Documentation*"$'\n'"${COMMITS_BY_TYPE[docs]}"$'\n'
+[ ! -z "${COMMITS_BY_TYPE[test]}" ] && MESSAGE_TEXT+=$'\n'":white_check_mark: *Tests*"$'\n'"${COMMITS_BY_TYPE[test]}"$'\n'
+[ ! -z "${COMMITS_BY_TYPE[build]}" ] && MESSAGE_TEXT+=$'\n'":package: *Build System & Dependencies*"$'\n'"${COMMITS_BY_TYPE[build]}"$'\n'
+[ ! -z "${COMMITS_BY_TYPE[ci]}" ] && MESSAGE_TEXT+=$'\n'":gear: *CI Changes*"$'\n'"${COMMITS_BY_TYPE[ci]}"$'\n'
+[ ! -z "${COMMITS_BY_TYPE[style]}" ] && MESSAGE_TEXT+=$'\n'":nail_care: *Code Style Changes*"$'\n'"${COMMITS_BY_TYPE[style]}"$'\n'
+[ ! -z "${COMMITS_BY_TYPE[misc]}" ] && MESSAGE_TEXT+=$'\n'":file_folder: *Other Changes*"$'\n'"${COMMITS_BY_TYPE[misc]}"$'\n'
+[ ! -z "${COMMITS_BY_TYPE[bot]}" ] && MESSAGE_TEXT+=$'\n'":robot_face: *Bot Commits*"$'\n'"${COMMITS_BY_TYPE[bot]}"$'\n'
+
+echo "✅ Slack message generation completed successfully" >&2
+jq -n --arg msg "$MESSAGE_TEXT" '{"text": $msg}'

--- a/ci/send-slack-message.sh
+++ b/ci/send-slack-message.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+
+# This script sends Slack messages with a title and detailed changes.
+# It supports both Slack webhooks and Web API for maximum flexibility.
+#
+# THREADING SUPPORT:
+# - Slack Web API (SLACK_BOT_TOKEN + SLACK_CHANNEL): Full threading support
+# - Slack webhooks (SLACK_WEBHOOK_URL): Separate messages (no threading)
+#
+# The repository name is automatically extracted from git remote URL or directory name.
+#
+# Usage:
+#   ./ci/send-slack-message.sh "message_type_part" "change_details"
+#
+# Example:
+#   ./ci/send-slack-message.sh "New Tag Release: v1.2.3" "• Feature: Added new API\n• Fix: Resolved bug #123"
+#   ./ci/send-slack-message.sh "Weekly Summary (Last 7 Days) 📅" "• Feature: Added new API\n• Fix: Resolved bug #123"
+#
+# Environment variables (one of these is required):
+#   SLACK_WEBHOOK_URL - Slack webhook URL for sending messages (no threading support)
+#   SLACK_BOT_TOKEN + SLACK_CHANNEL - Slack bot token and channel for Web API (supports threading)
+
+set -euo pipefail
+
+echo "📤 Starting Slack notification..." >&2
+
+# Check required arguments
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 \"message_type_part\" \"change_details\"" >&2
+  echo "Example: $0 \"New Tag Release: v1.2.3\" \"change details here\"" >&2
+  exit 1
+fi
+
+# Check required environment variables
+if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_CHANNEL:-}" ]; then
+  USE_WEB_API=true
+  echo "Using Slack Web API (supports threading)"
+elif [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+  USE_WEB_API=false
+  echo "Using Slack webhook (no threading support)"
+else
+  echo "Error: Either SLACK_WEBHOOK_URL or (SLACK_BOT_TOKEN + SLACK_CHANNEL) must be set" >&2
+  echo "For threading support, use: SLACK_BOT_TOKEN and SLACK_CHANNEL" >&2
+  echo "For simple messaging, use: SLACK_WEBHOOK_URL" >&2
+  exit 1
+fi
+
+# Check if we're in a git repository
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+  echo "Error: Not in a git repository" >&2
+  exit 1
+fi
+
+# Check if jq is available
+if ! command -v jq &> /dev/null; then
+  echo "Error: jq is required but not installed." >&2
+  exit 1
+fi
+
+MESSAGE_TYPE="$1"
+CHANGE_DETAILS="$2"
+
+# Get repository name from git remote URL and current date
+REMOTE_URL=$(git config --get remote.origin.url 2>/dev/null || echo "")
+if [ -n "$REMOTE_URL" ]; then
+  # Extract repo name from various URL formats:
+  # https://github.com/owner/repo.git -> repo
+  # git@github.com:owner/repo.git -> repo  
+  # https://github.com/owner/repo -> repo
+  REPO_NAME=$(echo "$REMOTE_URL" | sed -E 's|.*[:/]([^/]+)/([^/]+)/?(.git)?$|\2|' | sed 's/\.git$//')
+else
+  # Fallback: use directory name if no remote
+  REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
+fi
+
+CURRENT_DATE=$(date +"%Y-%m-%d")
+
+if [ "$USE_WEB_API" = true ]; then
+  # Web API: Send title with thread icon, then details in thread
+  TITLE_MESSAGE="*${REPO_NAME}* - ${CURRENT_DATE} - ${MESSAGE_TYPE} 🧵"
+  
+  echo "Sending title message with threading support..."
+  
+  TITLE_PAYLOAD=$(jq -n --arg channel "$SLACK_CHANNEL" --arg msg "$TITLE_MESSAGE" '{"channel": $channel, "text": $msg}')
+  RESPONSE=$(curl -s -X POST \
+    -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+    -H 'Content-type: application/json' \
+    --data "$TITLE_PAYLOAD" \
+    "https://slack.com/api/chat.postMessage")
+  
+  echo "Slack API response: $RESPONSE"
+  
+  # Check if the API call was successful
+  if echo "$RESPONSE" | jq -r '.ok' | grep -q "true"; then
+    TIMESTAMP=$(echo "$RESPONSE" | jq -r '.ts')
+    echo "Title message sent successfully. Timestamp: $TIMESTAMP"
+  else
+    ERROR_MSG=$(echo "$RESPONSE" | jq -r '.error // "Unknown error"')
+    echo "Error sending message: $ERROR_MSG" >&2
+    exit 1
+  fi
+else
+  # Webhook: Send title + body in one message
+  TITLE_MESSAGE="*${REPO_NAME}* - ${CURRENT_DATE} - ${MESSAGE_TYPE}"
+  
+  # Check if we have change details to include
+  if [ -n "$CHANGE_DETAILS" ]; then
+    COMBINED_MESSAGE="${TITLE_MESSAGE}"$'\n'$'\n'"${CHANGE_DETAILS}"
+  else
+    COMBINED_MESSAGE="$TITLE_MESSAGE"
+  fi
+  
+  echo "Sending combined message via webhook..."
+  
+  COMBINED_PAYLOAD=$(jq -n --arg msg "$COMBINED_MESSAGE" '{"text": $msg}')
+  RESPONSE=$(curl -s -X POST -H 'Content-type: application/json' --data "$COMBINED_PAYLOAD" "$SLACK_WEBHOOK_URL")
+  
+  echo "Webhook response: $RESPONSE"
+  echo "Combined message sent via webhook."
+  
+  # Exit here since webhook sends everything in one message
+  echo "Slack notification completed."
+  exit 0
+fi
+
+# Check if we have change details to send
+if [ -z "$CHANGE_DETAILS" ]; then
+  echo "No change details provided, skipping thread message."
+  exit 0
+fi
+
+if [ "$USE_WEB_API" = true ] && [ -n "$TIMESTAMP" ]; then
+  echo "Sending details as threaded reply..."
+  THREAD_PAYLOAD=$(jq -n --arg channel "$SLACK_CHANNEL" --arg msg "$CHANGE_DETAILS" --arg ts "$TIMESTAMP" '{"channel": $channel, "text": $msg, "thread_ts": $ts}')
+  THREAD_RESPONSE=$(curl -s -X POST \
+    -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+    -H 'Content-type: application/json' \
+    --data "$THREAD_PAYLOAD" \
+    "https://slack.com/api/chat.postMessage")
+  
+  if echo "$THREAD_RESPONSE" | jq -r '.ok' | grep -q "true"; then
+    echo "Threaded message sent successfully."
+  else
+    ERROR_MSG=$(echo "$THREAD_RESPONSE" | jq -r '.error // "Unknown error"')
+    echo "Error sending threaded message: $ERROR_MSG" >&2
+    exit 1
+  fi
+else
+  echo "Sending details as separate message..."
+  if [ "$USE_WEB_API" = true ]; then
+    # Use Web API for separate message
+    DETAILS_PAYLOAD=$(jq -n --arg channel "$SLACK_CHANNEL" --arg msg "$CHANGE_DETAILS" '{"channel": $channel, "text": $msg}')
+    DETAILS_RESPONSE=$(curl -s -X POST \
+      -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+      -H 'Content-type: application/json' \
+      --data "$DETAILS_PAYLOAD" \
+      "https://slack.com/api/chat.postMessage")
+    
+    if echo "$DETAILS_RESPONSE" | jq -r '.ok' | grep -q "true"; then
+      echo "Details message sent successfully."
+    else
+      ERROR_MSG=$(echo "$DETAILS_RESPONSE" | jq -r '.error // "Unknown error"')
+      echo "Error sending details message: $ERROR_MSG" >&2
+      exit 1
+    fi
+  else
+    # Use webhook for separate message
+    DETAILS_PAYLOAD=$(jq -n --arg msg "$CHANGE_DETAILS" '{"text": $msg}')
+    curl -s -X POST -H 'Content-type: application/json' --data "$DETAILS_PAYLOAD" "$SLACK_WEBHOOK_URL"
+    echo "Details message sent via webhook."
+  fi
+fi
+
+echo "✅ Slack notification completed successfully" >&2


### PR DESCRIPTION
Add GitHub workflows and supporting script to automatically send formatted Slack notifications for project activity:

- Tag summary workflow: Triggers on new release tags, sends commit summary comparing changes since previous release with categorized formatting
- Weekly summary workflow: Runs every Saturday at 10 AM (UTC), sends summary of commits from the past week
- Slack message formatter script: Parses commit messages into categorized sections (features, fixes, docs, etc.) with emoji icons and optional JIRA ticket linking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automated Slack notifications for new release tags with summarized changes.
  - Weekly commit summaries posted to Slack.
  - Messages grouped by change type, with optional JIRA ticket enrichment and links.
  - Supports Slack webhook or bot token delivery, including threaded replies when available.

- Chores
  - Added CI automation and supporting scripts for message creation and delivery, with validation and clear guidance for misconfiguration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->