### PR TITLE
NO-JIRA | fix: Add auth header for POST assessments

### DIFF
--- a/src/migration-wizard/contexts/discovery-sources/Provider.tsx
+++ b/src/migration-wizard/contexts/discovery-sources/Provider.tsx
@@ -48,12 +48,14 @@ export const Provider: React.FC<PropsWithChildren> = (props) => {
     Symbols.AssessmentApi,
   );
 
-  // Create assessmentService instance with the same baseUrl as the injected APIs
+  // Create assessmentService instance with the same baseUrl and fetchApi as the injected APIs
   const assessmentService = React.useMemo(() => {
     const baseUrl =
       process.env.PLANNER_API_BASE_URL || '/api/migration-assessment';
-    return new AssessmentService(baseUrl);
-  }, []);
+    // Get the authenticated fetch function from the configuration of an existing API instance
+    const fetchApi = (assessmentApi as any).configuration?.fetchApi || fetch;
+    return new AssessmentService(baseUrl, fetchApi);
+  }, [assessmentApi]);
 
   const [listAgentsState, listAgents] = useAsyncFn(async () => {
     if (!sourcesLoaded) return;

--- a/src/pages/assessment/assessmentService.ts
+++ b/src/pages/assessment/assessmentService.ts
@@ -10,38 +10,11 @@ export interface CreateAssessmentRequest {
 
 export class AssessmentService {
   private baseUrl: string;
+  private fetchApi: typeof fetch;
 
-  constructor(baseUrl: string) {
+  constructor(baseUrl: string, fetchApi: typeof fetch = fetch) {
     this.baseUrl = baseUrl;
-  }
-
-  /**
-   * Create assessment from JSON inventory
-   */
-  async createFromInventory(
-    name: string,
-    inventory: Inventory,
-  ): Promise<Assessment> {
-    const response = await fetch(`${this.baseUrl}/api/v1/assessments`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        name,
-        sourceType: 'inventory',
-        inventory,
-      }),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(
-        `Failed to create assessment from inventory: ${errorText}`,
-      );
-    }
-
-    return response.json();
+    this.fetchApi = fetchApi;
   }
 
   /**
@@ -57,7 +30,7 @@ export class AssessmentService {
     });
     formData.append('file', blob, rvToolFile.name);
 
-    const response = await fetch(`${this.baseUrl}/api/v1/assessments`, {
+    const response = await this.fetchApi(`${this.baseUrl}/assessments`, {
       method: 'POST',
       // Let browser set Content-Type automatically with correct boundary
       body: formData,
@@ -71,65 +44,16 @@ export class AssessmentService {
     return response.json();
   }
 
-  /**
-   * Create assessment from agent/source
-   */
-  async createFromAgent(name: string, sourceId: string): Promise<Assessment> {
-    const response = await fetch(`${this.baseUrl}/assessments`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        name,
-        sourceType: 'agent',
-        sourceId,
-      }),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`Failed to create assessment from agent: ${errorText}`);
-    }
-
-    return response.json();
-  }
-
-  /**
-   * Generic create assessment method that routes to the appropriate specific method
-   */
   async createAssessment(
     request: CreateAssessmentRequest,
   ): Promise<Assessment> {
     const assessmentName =
       request.name || `Assessment-${new Date().toISOString()}`;
 
-    switch (request.sourceType) {
-      case 'inventory':
-        if (!request.inventory) {
-          throw new Error(
-            'Inventory data is required for inventory assessment',
-          );
-        }
-        return this.createFromInventory(assessmentName, request.inventory);
-
-      case 'rvtools':
-        if (!request.rvToolFile) {
-          throw new Error('RVTools file is required for RVTools assessment');
-        }
-        return this.createFromRVTools(assessmentName, request.rvToolFile);
-
-      case 'agent':
-        if (!request.sourceId) {
-          throw new Error('Source ID is required for agent assessment');
-        }
-        return this.createFromAgent(assessmentName, request.sourceId);
-
-      default:
-        throw new Error(
-          `Unsupported assessment source type: ${request.sourceType}`,
-        );
+    if (!request.rvToolFile) {
+      throw new Error('RVTools file is required for RVTools assessment');
     }
+    return this.createFromRVTools(assessmentName, request.rvToolFile);
   }
 }
 


### PR DESCRIPTION
This PR use the fetchApi function from ioc package to inject the jwt into the right header.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Assessment requests now use the app’s authenticated network client, improving reliability for signed-in users.

- Refactor
  - Assessment creation simplified to use RVTools file uploads exclusively; inventory and agent creation paths removed.
  - Network initialization aligned with the app’s existing API client for consistent request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->