### PR TITLE
ECOPROJECT-3296 | feat: Implement assessment creation flow from OVA

### DIFF
--- a/src/Routing.tsx
+++ b/src/Routing.tsx
@@ -16,6 +16,10 @@ interface RouteType {
   elementProps?: Record<string, unknown>;
 }
 
+const CreateFromOva = React.lazy(
+  () => import('./pages/assessment/CreateFromOva'),
+);
+
 const Routing: React.FC = () => {
   const routes: RouteType[] = [
     {
@@ -25,6 +29,10 @@ const Routing: React.FC = () => {
     {
       path: '/migrate/assessments/:id',
       element: Report,
+    },
+    {
+      path: '/migrate/assessments/create',
+      element: CreateFromOva,
     },
     {
       path: '/migrate/wizard',

--- a/src/pages/assessment/Assessment.tsx
+++ b/src/pages/assessment/Assessment.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { Assessment as AssessmentModel } from '@migration-planner-ui/api-client/models';
 import {
@@ -30,6 +31,7 @@ type Props = {
 };
 
 const Assessment: React.FC<Props> = ({ assessments, isLoading }) => {
+  const navigate = useNavigate();
   const discoverySourcesContext = useDiscoverySources();
   const [search, setSearch] = useState('');
   const [sortBy, setSortBy] = useState<
@@ -361,9 +363,7 @@ const Assessment: React.FC<Props> = ({ assessments, isLoading }) => {
                     <DropdownItem
                       key="agent"
                       component="button"
-                      onClick={() => {
-                        alert('To be implemented');
-                      }}
+                      onClick={() => navigate('migrate/assessments/create')}
                     >
                       With discovery OVA
                     </DropdownItem>
@@ -422,8 +422,8 @@ const Assessment: React.FC<Props> = ({ assessments, isLoading }) => {
         titleIconVariant="warning"
         primaryButtonVariant="danger"
       >
-        `Are you sure you want to delete{' '}
-        {(selectedAssessment as AssessmentModel)?.name}?`
+        Are you sure you want to delete{' '}
+        {(selectedAssessment as AssessmentModel)?.name}?
       </ConfirmationModal>
     </>
   );

--- a/src/pages/assessment/CreateFromOva.tsx
+++ b/src/pages/assessment/CreateFromOva.tsx
@@ -1,0 +1,259 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import {
+  Alert,
+  AlertActionLink,
+  Button,
+  Checkbox,
+  Form,
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  HelperText,
+  HelperTextItem,
+  InputGroup,
+  InputGroupItem,
+  Text,
+  TextContent,
+  TextInput,
+} from '@patternfly/react-core';
+
+import { AppPage } from '../../components/AppPage';
+import { useDiscoverySources } from '../../migration-wizard/contexts/discovery-sources/Context';
+import { DiscoverySourceSetupModal } from '../environment/sources-table/empty-state/DiscoverySourceSetupModal';
+
+const CreateFromOva: React.FC = () => {
+  const navigate = useNavigate();
+  const discoverySourcesContext = useDiscoverySources();
+
+  const [name, setName] = React.useState<string>('');
+  const [useExisting, setUseExisting] = React.useState<boolean>(false);
+  const [selectedEnvironmentId, setSelectedEnvironmentId] =
+    React.useState<string>('');
+  const [isSetupModalOpen, setIsSetupModalOpen] =
+    React.useState<boolean>(false);
+
+  const createdSourceId = discoverySourcesContext.sourceCreatedId || '';
+  const createdSource = createdSourceId
+    ? discoverySourcesContext.getSourceById?.(createdSourceId)
+    : undefined;
+
+  React.useEffect(() => {
+    discoverySourcesContext.startPolling(5000);
+    if (!discoverySourcesContext.isLoadingSources) {
+      discoverySourcesContext.listSources();
+    }
+    return () => discoverySourcesContext.stopPolling();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [discoverySourcesContext.sources]);
+
+  const availableEnvironments = React.useMemo(
+    () =>
+      (discoverySourcesContext.sources || [])
+        .filter(
+          (source) =>
+            source.agent?.status === 'up-to-date' && source.name !== 'Example',
+        )
+        .slice()
+        .sort((a, b) => (a.name || '').localeCompare(b.name || '')),
+    [discoverySourcesContext.sources],
+  );
+
+  const handleSubmit = async (): Promise<void> => {
+    const sourceIdToUse = useExisting ? selectedEnvironmentId : createdSourceId;
+
+    if (!sourceIdToUse) return;
+
+    await discoverySourcesContext.createAssessment(
+      name,
+      'agent',
+      undefined,
+      sourceIdToUse,
+    );
+
+    await discoverySourcesContext.listAssessments();
+    navigate('/openshift/migration-assessment/');
+  };
+
+  const isSubmitDisabled =
+    !name || (useExisting ? !selectedEnvironmentId : !createdSourceId);
+
+  return (
+    <AppPage
+      breadcrumbs={[
+        {
+          key: 1,
+          to: '/openshift/migration-assessment/',
+          children: 'Migration assessment',
+        },
+        {
+          key: 2,
+          to: '/openshift/migration-assessment/',
+          children: 'assessments',
+        },
+        { key: 3, to: '#', isActive: true, children: 'create new assessment' },
+      ]}
+      title="Create new migration assessment"
+    >
+      <div style={{ maxWidth: '900px' }}>
+        <Form isWidthLimited>
+          <FormGroup
+            label="Assessment Name"
+            isRequired
+            fieldId="assessment-name"
+          >
+            <InputGroup>
+              <InputGroupItem isFill>
+                <TextInput
+                  id="assessment-name"
+                  aria-label="Assessment name"
+                  placeholder="Assessment 1"
+                  value={name}
+                  onChange={(_, v) => setName(v)}
+                />
+              </InputGroupItem>
+            </InputGroup>
+            <HelperText>
+              <HelperTextItem>Name your migration assessment</HelperTextItem>
+            </HelperText>
+          </FormGroup>
+
+          <TextContent style={{ marginTop: '16px' }}>
+            <Text component="p" style={{ fontWeight: 600 }}>
+              follow these steps to connect your environment and create the
+              assessment report
+            </Text>
+            <ol style={{ paddingLeft: '1.2rem', lineHeight: 1.6 }}>
+              <li>
+                To create a migration assessment for an existing environment,
+                select the already created environment from the list and click
+                the “Create assessment report” button
+              </li>
+              <li>
+                To connect to a new environment, click the “Add environment”
+                button then download and import the Discovery OVA Image to your
+                VMware environment
+              </li>
+              <li>
+                When the VM is running, a link will appear below. Use this link
+                to input credentials and connect to your environment
+              </li>
+              <li>
+                After the connection is established, you’ll be able to proceed
+                and view the discovery report
+              </li>
+            </ol>
+          </TextContent>
+
+          <div style={{ marginTop: '16px' }}>
+            <Checkbox
+              id="use-existing-env"
+              label="For an existing environment"
+              isChecked={useExisting}
+              onChange={(_, checked) => setUseExisting(checked)}
+            />
+          </div>
+
+          {useExisting && (
+            <FormGroup
+              label="Existing environments"
+              isRequired
+              fieldId="existing-environments"
+            >
+              <FormSelect
+                id="existing-environments"
+                value={selectedEnvironmentId}
+                onChange={(_e, value) => setSelectedEnvironmentId(value)}
+              >
+                <FormSelectOption
+                  value=""
+                  label="Select an existing environment"
+                />
+                {availableEnvironments.map((env) => (
+                  <FormSelectOption
+                    key={env.id}
+                    value={env.id}
+                    label={env.name}
+                  />
+                ))}
+              </FormSelect>
+            </FormGroup>
+          )}
+
+          <div style={{ marginTop: '8px' }}>
+            <Button
+              variant="secondary"
+              onClick={() => setIsSetupModalOpen(true)}
+              isDisabled={useExisting}
+            >
+              Add environment
+            </Button>
+          </div>
+
+          {createdSource?.agent?.status === 'waiting-for-credentials' && (
+            <div style={{ marginTop: '16px' }}>
+              <Alert
+                isInline
+                variant="custom"
+                title="Discovery VM"
+                actionLinks={
+                  createdSource?.agent?.credentialUrl ? (
+                    <AlertActionLink
+                      component="a"
+                      href={createdSource.agent.credentialUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {createdSource.agent.credentialUrl}
+                    </AlertActionLink>
+                  ) : undefined
+                }
+              >
+                <TextContent>
+                  <Text>
+                    Click the link below to connect the Discovery Source to your
+                    VMware environment.
+                  </Text>
+                </TextContent>
+              </Alert>
+            </div>
+          )}
+
+          <div style={{ marginTop: '24px', display: 'flex', gap: '12px' }}>
+            <Button
+              variant="primary"
+              isDisabled={
+                isSubmitDisabled ||
+                discoverySourcesContext.isCreatingAssessment ||
+                !selectedEnvironmentId
+              }
+              onClick={handleSubmit}
+            >
+              Create assessment report
+            </Button>
+            <Button variant="link" onClick={() => navigate(-1)}>
+              Cancel
+            </Button>
+          </div>
+        </Form>
+
+        {isSetupModalOpen && (
+          <DiscoverySourceSetupModal
+            isOpen={isSetupModalOpen}
+            onClose={() => setIsSetupModalOpen(false)}
+            isDisabled={discoverySourcesContext.isDownloadingSource}
+            onStartDownload={() => discoverySourcesContext.setDownloadUrl?.('')}
+            onAfterDownload={async () => {
+              await discoverySourcesContext.listSources();
+            }}
+          />
+        )}
+      </div>
+    </AppPage>
+  );
+};
+
+CreateFromOva.displayName = 'CreateFromOva';
+
+export default CreateFromOva;

--- a/src/pages/assessment/EmptyTableBanner.tsx
+++ b/src/pages/assessment/EmptyTableBanner.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import {
   Button,
@@ -29,6 +30,7 @@ type Props = {
 };
 
 const EmptyTableBanner: React.FC<Props> = ({ onOpenModal }) => {
+  const navigate = useNavigate();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   const onDropdownToggle = (): void => {
@@ -120,9 +122,7 @@ const EmptyTableBanner: React.FC<Props> = ({ onOpenModal }) => {
             <DropdownItem
               key="agent"
               component="button"
-              onClick={() => {
-                alert('To be implemented');
-              }}
+              onClick={() => navigate('migrate/assessments/create')}
             >
               With discovery OVA
             </DropdownItem>

--- a/src/pages/environment/Environment.tsx
+++ b/src/pages/environment/Environment.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
-import { Source } from '@migration-planner-ui/api-client/models';
 import {
   Alert,
   AlertActionLink,
@@ -43,7 +42,12 @@ export const Environment: React.FC = () => {
     discoverySourcesContext.sources &&
     discoverySourcesContext.sources.length > 0;
   const [firstSource, ..._otherSources] = discoverySourcesContext.sources ?? [];
-  const [sourceSelected, setSourceSelected] = useState<Source>();
+  const sourceSelected =
+    (discoverySourcesContext.sourceSelected &&
+      discoverySourcesContext.sources?.find(
+        (source) => source.id === discoverySourcesContext.sourceSelected?.id,
+      )) ||
+    firstSource;
   const [isOvaDownloading, setIsOvaDownloading] = useState(false);
   const [uploadMessage, setUploadMessage] = useState<string | null>(null);
   const [isUploadError, setIsUploadError] = useState(false);
@@ -72,25 +76,6 @@ export const Environment: React.FC = () => {
     { key: 'error', label: 'Error' },
     { key: 'up-to-date', label: 'Ready' },
   ];
-
-  useEffect(() => {
-    if (discoverySourcesContext.sourceSelected) {
-      const foundSource = discoverySourcesContext.sources.find(
-        (source) => source.id === discoverySourcesContext.sourceSelected?.id,
-      );
-
-      if (foundSource) {
-        setSourceSelected(foundSource);
-      } else {
-        if (firstSource) {
-          setSourceSelected(firstSource);
-        } else {
-          setSourceSelected(undefined);
-        }
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [discoverySourcesContext.sources, firstSource]);
 
   useEffect(() => {
     if (uploadMessage) {


### PR DESCRIPTION
- First iteration to create assessment from OVA file: create assessment from existing environment


https://github.com/user-attachments/assets/72775ec4-93c2-46be-aeba-a941a809275c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added “Create migration assessment from discovery OVA” page with form to name assessments, select or add environments, and guidance through setup.
  - Inline alert with link when credentials are required for the Discovery VM.
  - New navigation entry points to the create flow from Assessments and the empty-state banner; route is lazily loaded.

- Refactor
  - Simplified environment selection logic to improve reliability and reduce sync issues.

- Style
  - Minor copy update in the deletion confirmation dialog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->