### PR TITLE
ECOPOJECT-3247 | feat: add tooltip to uploaded manually

### DIFF
--- a/src/pages/environment/sources-table/AgentStatusView.tsx
+++ b/src/pages/environment/sources-table/AgentStatusView.tsx
@@ -29,6 +29,7 @@ export namespace AgentStatusView {
     statusInfo?: Agent['statusInfo'];
     credentialUrl?: Agent['credentialUrl'];
     uploadedManually?: boolean;
+    updatedAt?: string | Date;
   };
 }
 
@@ -53,7 +54,8 @@ const StatusInfoWaitingForCredentials: React.FC<{
 };
 
 export const AgentStatusView: React.FC<AgentStatusView.Props> = (props) => {
-  const { status, statusInfo, credentialUrl, uploadedManually } = props;
+  const { status, statusInfo, credentialUrl, uploadedManually, updatedAt } =
+    props;
   const statusView = useMemo(() => {
     // eslint-disable-next-line prefer-const
     let fake: Agent['status'] | null = null;
@@ -120,20 +122,25 @@ export const AgentStatusView: React.FC<AgentStatusView.Props> = (props) => {
       <SplitItem>{statusView && statusView.icon}</SplitItem>
       <SplitItem>
         {statusInfo ||
-        (statusView && statusView.text === 'Waiting for credentials') ? (
+        (statusView && statusView.text === 'Waiting for credentials') ||
+        (uploadedManually && !statusInfo) ? (
           <Popover
             aria-label={statusView && statusView.text}
             headerContent={statusView && statusView.text}
             headerComponent="h1"
             bodyContent={
-              statusView && statusView.text !== 'Waiting for credentials' ? (
-                <TextContent>
-                  <Text>{statusInfo}</Text>
-                </TextContent>
-              ) : (
+              statusView && statusView.text === 'Waiting for credentials' ? (
                 <StatusInfoWaitingForCredentials
                   credentialUrl={credentialUrl}
                 />
+              ) : uploadedManually && !statusInfo ? (
+                <TextContent>
+                  <Text>{`Last updated via inventory file on ${updatedAt ? new Date(updatedAt).toLocaleString() : '-'}`}</Text>
+                </TextContent>
+              ) : (
+                <TextContent>
+                  <Text>{statusInfo}</Text>
+                </TextContent>
               )
             }
           >

--- a/src/pages/environment/sources-table/SourcesTable.tsx
+++ b/src/pages/environment/sources-table/SourcesTable.tsx
@@ -304,13 +304,19 @@ export const SourcesTable: React.FC<SourceTableProps> = ({
                         <AgentStatusView
                           status={agent ? agent.status : 'not-connected'}
                           statusInfo={
-                            agent ? agent.statusInfo : 'Not connected'
+                            source?.onPremises &&
+                            source?.inventory !== undefined
+                              ? undefined
+                              : agent
+                                ? agent.statusInfo
+                                : 'Not connected'
                           }
                           credentialUrl={agent ? agent.credentialUrl : ''}
                           uploadedManually={
                             source?.onPremises &&
                             source?.inventory !== undefined
                           }
+                          updatedAt={source?.updatedAt}
                         />
                       </Td>
                       <Td dataLabel={Columns.Hosts}>


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/ECOPROJECT-3247

In the environment table, the Discovery VM status of "Ready" has a tooltip, while "Uploaded manually" does not when the source was updated by json file.

<img width="1473" height="402" alt="Captura desde 2025-10-02 13-51-08" src="https://github.com/user-attachments/assets/0d3749c4-cf67-4d10-8185-8407cc9ea0ca" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Status popover now shows “Last updated via inventory file on …” with a localized timestamp when sources are uploaded manually and no agent status info is available.
  - Popover visibility expanded to appear for inventory-uploaded sources lacking status details, improving clarity without requiring agent data.
  - Continues to display “Waiting for credentials” with a quick link when applicable.
  - Sources list now provides last-updated timestamps to the status view for more accurate, contextual status messaging, especially for on-premises sources with inventory present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->