### PR TITLE
ECOPROJECT-3327 | fix: disable delete button while pending action

### DIFF
--- a/src/pages/assessment/Assessment.tsx
+++ b/src/pages/assessment/Assessment.tsx
@@ -529,6 +529,7 @@ const Assessment: React.FC<Props> = ({ assessments, isLoading }) => {
         onClose={handleCloseDeleteModal}
         onCancel={handleCloseDeleteModal}
         onConfirm={handleConfirmDelete}
+        isDisabled={discoverySourcesContext.isDeletingAssessment}
         title="Delete Assessment"
         titleIconVariant="warning"
         primaryButtonVariant="danger"


### PR DESCRIPTION
Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The delete confirmation in Assessments is now disabled while deletion is in progress, preventing duplicate requests and accidental repeat clicks.
  * Improves reliability by avoiding race conditions and inconsistent UI states during deletion.
  * Provides clearer feedback that an operation is underway, enhancing overall user experience when deleting assessments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->