### PR TITLE
NO-JIRA | fix: enable Create target cluster option in assessment's menu

### DIFF
--- a/src/pages/assessment/AssessmentsTable.tsx
+++ b/src/pages/assessment/AssessmentsTable.tsx
@@ -19,6 +19,7 @@ import {
 } from '@patternfly/react-icons';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
+import { openAssistedInstaller } from './utils/functions';
 import { parseLatestSnapshot } from './utils/snapshotParser';
 
 type Props = {
@@ -450,10 +451,7 @@ export const AssessmentsTable: React.FC<Props> = ({
                       >
                         Edit assessment
                       </DropdownItem>
-                      <DropdownItem
-                        onClick={() => alert('Edit functionality coming soon!')}
-                        isDisabled={true}
-                      >
+                      <DropdownItem onClick={openAssistedInstaller}>
                         Create a target cluster
                       </DropdownItem>
                       <DropdownItem onClick={() => handleDelete(row.id)}>

--- a/src/pages/assessment/utils/functions.ts
+++ b/src/pages/assessment/utils/functions.ts
@@ -1,0 +1,15 @@
+export const openAssistedInstaller = (): void => {
+  const currentHost = window.location.hostname;
+
+  if (currentHost === 'console.stage.redhat.com') {
+    window.open(
+      'https://console.dev.redhat.com/openshift/assisted-installer/clusters/~new?source=assisted_migration',
+      '_blank',
+    );
+  } else {
+    window.open(
+      '/openshift/assisted-installer/clusters/~new?source=assisted_migration',
+      '_blank',
+    );
+  }
+};

--- a/src/pages/report/Report.tsx
+++ b/src/pages/report/Report.tsx
@@ -25,25 +25,10 @@ import { AppPage } from '../../components/AppPage';
 import { useDiscoverySources } from '../../migration-wizard/contexts/discovery-sources/Context';
 import { Provider as DiscoverySourcesProvider } from '../../migration-wizard/contexts/discovery-sources/Provider';
 import EnhancedDownloadButton from '../../migration-wizard/steps/discovery/EnhancedDownloadButton';
+import { openAssistedInstaller } from '../assessment/utils/functions';
 import { parseLatestSnapshot } from '../assessment/utils/snapshotParser';
 
 import { Dashboard } from './assessment-report/Dashboard';
-
-const openAssistedInstaller = (): void => {
-  const currentHost = window.location.hostname;
-
-  if (currentHost === 'console.stage.redhat.com') {
-    window.open(
-      'https://console.dev.redhat.com/openshift/assisted-installer/clusters/~new?source=assisted_migration',
-      '_blank',
-    );
-  } else {
-    window.open(
-      '/openshift/assisted-installer/clusters/~new?source=assisted_migration',
-      '_blank',
-    );
-  }
-};
 
 export type SnapshotLike = {
   infra?: Infra;


### PR DESCRIPTION
NO-JIRA | fix: enable Create target cluster option in assessment's menu

<img width="1847" height="397" alt="image" src="https://github.com/user-attachments/assets/7e0da037-7b8d-4271-9144-e4ff8b12f86d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Create a target cluster” action in Assessments and Reports that opens the Assisted Installer in a new tab. Links adapt to the environment for a seamless experience.

* **Refactor**
  * Unified installer-launch behavior across pages for consistent user experience and easier maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->