### PR TITLE
NO-JIRA | fix: add correct discover VM status in assessment details page

### DIFF
--- a/src/pages/environment/sources-table/AgentStatusView.tsx
+++ b/src/pages/environment/sources-table/AgentStatusView.tsx
@@ -30,6 +30,7 @@ export namespace AgentStatusView {
     credentialUrl?: Agent['credentialUrl'];
     uploadedManually?: boolean;
     updatedAt?: string | Date;
+    disableInteractions?: boolean;
   };
 }
 
@@ -54,8 +55,14 @@ const StatusInfoWaitingForCredentials: React.FC<{
 };
 
 export const AgentStatusView: React.FC<AgentStatusView.Props> = (props) => {
-  const { status, statusInfo, credentialUrl, uploadedManually, updatedAt } =
-    props;
+  const {
+    status,
+    statusInfo,
+    credentialUrl,
+    uploadedManually,
+    updatedAt,
+    disableInteractions,
+  } = props;
   const statusView = useMemo(() => {
     // eslint-disable-next-line prefer-const
     let fake: Agent['status'] | null = null;
@@ -116,6 +123,15 @@ export const AgentStatusView: React.FC<AgentStatusView.Props> = (props) => {
         };
     }
   }, [status, uploadedManually]);
+
+  if (disableInteractions) {
+    return (
+      <Split hasGutter style={{ gap: '0.66rem' }}>
+        <SplitItem>{statusView && statusView.icon}</SplitItem>
+        <SplitItem>{statusView && statusView.text}</SplitItem>
+      </Split>
+    );
+  }
 
   return (
     <Split hasGutter style={{ gap: '0.66rem' }}>


### PR DESCRIPTION
Add correct discover VM status in assessment details page

<img width="1482" height="600" alt="Captura desde 2025-10-07 13-19-51" src="https://github.com/user-attachments/assets/8fb21bbb-53cd-4d7b-a3d4-3d0497737287" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Assessment Details now shows a richer, read-only agent status with source info and last updated time; interactions are disabled in this context.
- Bug Fixes
  - Auto-loads sources after assessments to reduce missing status data.
  - Adds safeguards to handle absent source/agent data without errors.
- Style
  - Replaced status and “Open report” icons with a unified Monitoring icon for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->