### PR TITLE
ECOPROJECT-3372 | fix: not allow empty proxy fields in add/edit environment form

### DIFF
--- a/src/migration-wizard/contexts/discovery-sources/@types/DiscoverySources.d.ts
+++ b/src/migration-wizard/contexts/discovery-sources/@types/DiscoverySources.d.ts
@@ -55,6 +55,12 @@ declare namespace DiscoverySources {
     setDownloadUrl?: (url: string) => void;
     sourceCreatedId?: string;
     deleteSourceCreated: () => void;
+    clearErrors: (options?: {
+      downloading?: boolean;
+      updating?: boolean;
+      creating?: boolean;
+      loadingAssessments?: boolean;
+    }) => void;
     updateSource: (
       sourceId: string,
       sourceSshKey: string,

--- a/src/pages/environment/sources-table/empty-state/DiscoverySourceSetupModal.tsx
+++ b/src/pages/environment/sources-table/empty-state/DiscoverySourceSetupModal.tsx
@@ -65,6 +65,7 @@ export const DiscoverySourceSetupModal: React.FC<
   const [enableProxy, setEnableProxy] = useState(false);
   const [httpProxyError, setHttpProxyError] = useState<string | null>(null);
   const [httpsProxyError, setHttpsProxyError] = useState<string | null>(null);
+  const [proxyGroupError, setProxyGroupError] = useState<string | null>(null);
   const [isEditingConfiguration, setIsEditingConfiguration] = useState(false);
   const [networkConfigType, setNetworkConfigType] = useState<'dhcp' | 'static'>(
     'dhcp',
@@ -196,6 +197,7 @@ export const DiscoverySourceSetupModal: React.FC<
     setEnableProxy(false);
     setHttpProxyError(null);
     setHttpsProxyError(null);
+    setProxyGroupError(null);
     setIsEditingConfiguration(false);
     setNetworkConfigType('dhcp');
     setDns('');
@@ -217,8 +219,11 @@ export const DiscoverySourceSetupModal: React.FC<
     });
     discoverySourcesContext.setDownloadUrl('');
     discoverySourcesContext.deleteSourceCreated();
-    discoverySourcesContext.errorDownloadingSource = null;
-    discoverySourcesContext.errorUpdatingSource = null;
+    discoverySourcesContext.clearErrors?.({
+      downloading: true,
+      updating: true,
+      creating: true,
+    });
   };
 
   const backToOvaConfiguration = (): void => {
@@ -233,8 +238,11 @@ export const DiscoverySourceSetupModal: React.FC<
     setSubnetMaskError(null);
     setDefaultGatewayError(null);
     setDnsError(null);
-    discoverySourcesContext.errorDownloadingSource = null;
-    discoverySourcesContext.errorUpdatingSource = null;
+    discoverySourcesContext.clearErrors?.({
+      downloading: true,
+      updating: true,
+      creating: true,
+    });
   };
 
   const handleSubmit = useCallback<React.FormEventHandler<HTMLFormElement>>(
@@ -244,24 +252,33 @@ export const DiscoverySourceSetupModal: React.FC<
       if (!discoverySourcesContext.downloadSourceUrl) {
         // Proxy validation when enabled
         if (enableProxy) {
-          const httpErr = !httpProxy.trim()
-            ? 'HTTP proxy URL is required when proxy is enabled'
-            : /^http:\/\//i.test(httpProxy.trim())
+          const hasAnyProxyValue = Boolean(
+            httpProxy.trim() || httpsProxy.trim() || noProxy.trim(),
+          );
+          const httpErr = httpProxy.trim()
+            ? /^http:\/\//i.test(httpProxy.trim())
               ? null
-              : 'URL must start with http://';
-          const httpsErr = !httpsProxy.trim()
-            ? null
-            : /^https:\/\//i.test(httpsProxy.trim())
+              : 'URL must start with http://'
+            : null;
+          const httpsErr = httpsProxy.trim()
+            ? /^https:\/\//i.test(httpsProxy.trim())
               ? null
-              : 'URL must start with https://';
+              : 'URL must start with https://'
+            : null;
           setHttpProxyError(httpErr);
           setHttpsProxyError(httpsErr);
-          if (httpErr || httpsErr) {
+          setProxyGroupError(
+            hasAnyProxyValue
+              ? null
+              : 'At least one proxy field is required when proxy is enabled',
+          );
+          if (!hasAnyProxyValue || httpErr || httpsErr) {
             return;
           }
         } else {
           setHttpProxyError(null);
           setHttpsProxyError(null);
+          setProxyGroupError(null);
         }
         if (isEditingConfiguration || editSourceId) {
           const sourceIdToUpdate =
@@ -530,7 +547,21 @@ export const DiscoverySourceSetupModal: React.FC<
                   id="enable-proxy"
                   label="Enable proxy"
                   isChecked={enableProxy}
-                  onChange={(_, checked) => setEnableProxy(checked)}
+                  onChange={(_, checked) => {
+                    setEnableProxy(checked);
+                    if (!checked) {
+                      setProxyGroupError(null);
+                    } else {
+                      const hasAny = Boolean(
+                        httpProxy.trim() || httpsProxy.trim() || noProxy.trim(),
+                      );
+                      setProxyGroupError(
+                        hasAny
+                          ? null
+                          : 'At least one proxy field is required when proxy is enabled',
+                      );
+                    }
+                  }}
                 />
               </FormGroup>
 
@@ -544,18 +575,23 @@ export const DiscoverySourceSetupModal: React.FC<
                       placeholder="http://proxy.example.com:8080"
                       onChange={(_, value) => {
                         setHttpProxy(value);
-                        if (enableProxy) {
-                          if (!value.trim()) {
-                            setHttpProxyError(
-                              'HTTP proxy URL is required when proxy is enabled',
-                            );
-                          } else if (!/^http:\/\//i.test(value.trim())) {
-                            setHttpProxyError('URL must start with http://');
-                          } else {
-                            setHttpProxyError(null);
-                          }
+                        const trimmed = value.trim();
+                        if (trimmed && !/^http:\/\//i.test(trimmed)) {
+                          setHttpProxyError('URL must start with http://');
                         } else {
                           setHttpProxyError(null);
+                        }
+                        if (enableProxy) {
+                          const hasAny = Boolean(
+                            trimmed || httpsProxy.trim() || noProxy.trim(),
+                          );
+                          setProxyGroupError(
+                            hasAny
+                              ? null
+                              : 'At least one proxy field is required when proxy is enabled',
+                          );
+                        } else {
+                          setProxyGroupError(null);
                         }
                       }}
                       validated={httpProxyError ? 'error' : 'default'}
@@ -579,12 +615,23 @@ export const DiscoverySourceSetupModal: React.FC<
                       placeholder="https://proxy.example.com:8443"
                       onChange={(_, value) => {
                         setHttpsProxy(value);
-                        if (!value.trim()) {
-                          setHttpsProxyError(null);
-                        } else if (!/^https:\/\//i.test(value.trim())) {
+                        const trimmed = value.trim();
+                        if (trimmed && !/^https:\/\//i.test(trimmed)) {
                           setHttpsProxyError('URL must start with https://');
                         } else {
                           setHttpsProxyError(null);
+                        }
+                        if (enableProxy) {
+                          const hasAny = Boolean(
+                            httpProxy.trim() || trimmed || noProxy.trim(),
+                          );
+                          setProxyGroupError(
+                            hasAny
+                              ? null
+                              : 'At least one proxy field is required when proxy is enabled',
+                          );
+                        } else {
+                          setProxyGroupError(null);
                         }
                       }}
                       validated={httpsProxyError ? 'error' : 'default'}
@@ -606,7 +653,22 @@ export const DiscoverySourceSetupModal: React.FC<
                       type="text"
                       value={noProxy}
                       placeholder="one.domain.com,second.domain.com"
-                      onChange={(_, value) => setNoProxy(value)}
+                      onChange={(_, value) => {
+                        setNoProxy(value);
+                        if (enableProxy) {
+                          const trimmed = value.trim();
+                          const hasAny = Boolean(
+                            httpProxy.trim() || httpsProxy.trim() || trimmed,
+                          );
+                          setProxyGroupError(
+                            hasAny
+                              ? null
+                              : 'At least one proxy field is required when proxy is enabled',
+                          );
+                        } else {
+                          setProxyGroupError(null);
+                        }
+                      }}
                       onBlur={() =>
                         setNoProxy(
                           noProxy
@@ -767,6 +829,11 @@ export const DiscoverySourceSetupModal: React.FC<
             </TextContent>
           )}
         </Form>
+        {proxyGroupError && (
+          <Alert isInline variant="danger" title="Proxy configuration error">
+            {proxyGroupError}
+          </Alert>
+        )}
         {discoverySourcesContext.errorDownloadingSource && (
           <Alert isInline variant="danger" title="Add Environment error">
             {discoverySourcesContext.errorDownloadingSource.message}
@@ -793,8 +860,10 @@ export const DiscoverySourceSetupModal: React.FC<
             !!dnsError ||
             !!httpProxyError ||
             !!httpsProxyError ||
+            !!proxyGroupError ||
             !environmentName.trim() ||
-            (enableProxy && !httpProxy.trim()) ||
+            (enableProxy &&
+              !(httpProxy.trim() || httpsProxy.trim() || noProxy.trim())) ||
             (networkConfigType === 'static' &&
               (!dns.trim() ||
                 !subnetMask.trim() ||


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/ECOPROJECT-3372 and also with https://issues.redhat.com/browse/ECOPROJECT-3357

<img width="545" height="878" alt="image" src="https://github.com/user-attachments/assets/eb932463-0a4c-4b38-b221-fce8ee0a30b7" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline validation for HTTP/HTTPS proxy fields in the Discovery Source Setup modal with real-time error messages and a proxy configuration alert.
  * Submit blocked until proxy fields are valid when proxying is enabled; proxying disabled clears proxy errors.
  * Added a user-facing error-clear control that improves dismissal/clearing of source-related errors across flows.

* **Bug Fixes**
  * Prevents stale proxy/error states from persisting after modal close, reset, or changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->