### PR TITLE
ECOPROJECT-3366: fix errors on refresh create assessment page

### DIFF
--- a/src/pages/assessment/Assessment.tsx
+++ b/src/pages/assessment/Assessment.tsx
@@ -393,6 +393,9 @@ const Assessment: React.FC<Props> = ({ assessments, isLoading }) => {
                       onClick={() =>
                         navigate(
                           '/openshift/migration-assessment/assessments/create',
+                          {
+                            state: { reset: true },
+                          },
                         )
                       }
                     >

--- a/src/pages/assessment/EmptyTableBanner.tsx
+++ b/src/pages/assessment/EmptyTableBanner.tsx
@@ -129,7 +129,9 @@ const EmptyTableBanner: React.FC<Props> = ({ onOpenModal }) => {
               key="agent"
               component="button"
               onClick={() =>
-                navigate('/openshift/migration-assessment/assessments/create')
+                navigate('/openshift/migration-assessment/assessments/create', {
+                  state: { reset: true },
+                })
               }
             >
               With discovery OVA

--- a/src/pages/environment/sources-table/SourcesTable.tsx
+++ b/src/pages/environment/sources-table/SourcesTable.tsx
@@ -212,7 +212,9 @@ export const SourcesTable: React.FC<SourceTableProps> = ({
   const handleCreateAssessment = (sourceId: string): void => {
     discoverySourcesContext.setAssessmentFromAgent?.(true);
     discoverySourcesContext.selectSourceById?.(sourceId);
-    navigate('/openshift/migration-assessment/assessments/create');
+    navigate('/openshift/migration-assessment/assessments/create', {
+      state: { reset: true },
+    });
   };
 
   // Show spinner until all data is loaded

--- a/src/pages/starting-page/StartingPageModal.tsx
+++ b/src/pages/starting-page/StartingPageModal.tsx
@@ -40,7 +40,9 @@ const StartingPageModal: React.FC<Props> = ({
   const handleCreateFromOVA = (): void => {
     setIsDropdownOpen(false);
     onClose();
-    navigate('/openshift/migration-assessment/assessments/create');
+    navigate('/openshift/migration-assessment/assessments/create', {
+      state: { reset: true },
+    });
   };
 
   return (


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/ECOPROJECT-3366

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Draft auto-save/restore for the assessment creation form (session persistence).
  * Loading spinner while a new source is being created; sources list shown only when ready.
  * Preselection of newly created environment after setup completes (avoids overriding restored or existing selections).

* **Bug Fixes**
  * Source setup modal closes immediately and refreshes data in background.
  * Cancel and successful submit consistently clear draft state and return/navigation behavior is unified.

* **UX**
  * Creation flow navigation now supports a reset flag to reinitialize form state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->