### PR TITLE
ECOPROJECT-3366 | fix: persist content on refreshing create new assessment page - followup

### DIFF
--- a/src/pages/assessment/CreateFromOva.tsx
+++ b/src/pages/assessment/CreateFromOva.tsx
@@ -65,6 +65,17 @@ const CreateFromOva: React.FC = () => {
       } catch (e) {
         // ignore
       }
+      // Clear the reset flag from history so future visits don't re-reset
+      try {
+        navigate(
+          `${location.pathname}${location.search}${location.hash || ''}`,
+          {
+            replace: true,
+          },
+        );
+      } catch (e) {
+        // ignore navigation issues
+      }
       return;
     }
     try {
@@ -83,7 +94,7 @@ const CreateFromOva: React.FC = () => {
     } catch (e) {
       // ignore invalid storage contents
     }
-  }, [location]);
+  }, [location, navigate]);
 
   // Persist draft to session on change
   React.useEffect(() => {


### PR DESCRIPTION


https://github.com/user-attachments/assets/a8814300-daad-4b64-8120-60b0ee7a5043





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * After completing an assessment reset, the app now clears the temporary reset indicator from the URL/history so the reset state won’t reappear when using the back button or refreshing.
  * Navigation during the reset flow is more robust—transitions won’t interrupt the user experience if a navigation step fails, improving consistency when returning to the assessment creation page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->