### PR TITLE
ECOPROJECT-3398 | fix: clicking on "how does it work" and choosing "From rvtools" has to open the 'Create assessment from RvTools' modal

### DIFF
--- a/src/pages/MigrationAssessmentPage.tsx
+++ b/src/pages/MigrationAssessmentPage.tsx
@@ -142,7 +142,9 @@ const _WelcomePage: React.FC = () => (
   </Bullseye>
 );
 
-export const MigrationAssessmentPageContent: React.FC = () => {
+export const MigrationAssessmentPageContent: React.FC<{
+  rvtoolsOpenToken?: string;
+}> = ({ rvtoolsOpenToken }) => {
   const discoverySourcesContext = useDiscoverySources();
   const [assessments, setAssessments] = useState<Assessment[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -208,7 +210,13 @@ export const MigrationAssessmentPageContent: React.FC = () => {
   }
 
   // Always show assessment component
-  return <AssessmentPage assessments={assessments} isLoading={isLoading} />;
+  return (
+    <AssessmentPage
+      assessments={assessments}
+      isLoading={isLoading}
+      rvtoolsOpenToken={rvtoolsOpenToken}
+    />
+  );
 };
 
 const MigrationAssessmentPage: React.FC = () => (

--- a/src/pages/MigrationPage.tsx
+++ b/src/pages/MigrationPage.tsx
@@ -24,6 +24,9 @@ const MigrationPage: React.FC<Props> = ({ initialTabKey }) => {
     typeof initialTabKey === 'number' ? initialTabKey : 0,
   );
   const [isStartingPageModalOpen, setIsStartingPageModalOpen] = useState(false);
+  const [rvtoolsOpenToken, setRvtoolsOpenToken] = useState<string | undefined>(
+    undefined,
+  );
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -87,7 +90,9 @@ const MigrationPage: React.FC<Props> = ({ initialTabKey }) => {
               id="assessments-tab-content"
               style={{ padding: 0, marginTop: '24px' }}
             >
-              <MigrationAssessmentPageContent />
+              <MigrationAssessmentPageContent
+                rvtoolsOpenToken={rvtoolsOpenToken}
+              />
             </TabContent>
           </Tab>
 
@@ -110,7 +115,11 @@ const MigrationPage: React.FC<Props> = ({ initialTabKey }) => {
       <StartingPageModal
         isOpen={isStartingPageModalOpen}
         onClose={() => setIsStartingPageModalOpen(false)}
-        onOpenRVToolsModal={() => setActiveTabKey(0)}
+        onOpenRVToolsModal={() => {
+          // Switch to Assessments tab and trigger RVTools modal opening
+          setActiveTabKey(0);
+          setRvtoolsOpenToken(`${Date.now()}-${Math.random()}`);
+        }}
       />
     </>
   );

--- a/src/pages/assessment/Assessment.tsx
+++ b/src/pages/assessment/Assessment.tsx
@@ -32,9 +32,15 @@ import UpdateAssessment from './UpdateAssessment';
 type Props = {
   assessments: AssessmentModel[];
   isLoading?: boolean;
+  // When this token changes, the component should open the RVTools modal.
+  rvtoolsOpenToken?: string;
 };
 
-const Assessment: React.FC<Props> = ({ assessments, isLoading }) => {
+const Assessment: React.FC<Props> = ({
+  assessments,
+  isLoading,
+  rvtoolsOpenToken,
+}) => {
   const navigate = useNavigate();
   const discoverySourcesContext = useDiscoverySources();
   const [search, setSearch] = useState('');
@@ -137,6 +143,15 @@ const Assessment: React.FC<Props> = ({ assessments, isLoading }) => {
   const handleCloseModal = (): void => {
     setIsModalOpen(false);
   };
+
+  // Open RVTools modal when the trigger token changes
+  React.useEffect(() => {
+    if (rvtoolsOpenToken) {
+      handleOpenModal('rvtools');
+    }
+    // We intentionally only react to token changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rvtoolsOpenToken]);
 
   const handleUpdateAssessment = (assessmentId: string): void => {
     const assessment = assessments.find(


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/ECOPROJECT-3398

Clicking on "how does it work" and choosing "From rvtools" has to open the 'Create assessment from RvTools' modal


https://github.com/user-attachments/assets/576d24f1-7e94-42d2-b818-f645c2a90194



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced RVTools modal integration with automatic opening capability when triggered during the migration assessment workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->