### PR TITLE
ECOPROJECT-3417 | fix: solving errors with filters in PF6

### DIFF
--- a/src/components/FilterPill.tsx
+++ b/src/components/FilterPill.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import { Button } from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
+
+type Props = {
+  label: string;
+  onClear: () => void;
+  ariaLabel?: string;
+};
+
+const FilterPill: React.FC<Props> = ({ label, onClear, ariaLabel }) => {
+  return (
+    <span
+      style={{
+        background: '#e7e7e7',
+        borderRadius: '12px',
+        padding: '2px 6px 2px 8px',
+        fontSize: '12px',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '4px',
+      }}
+    >
+      <span>{label}</span>
+      <Button
+        icon={<TimesIcon />}
+        variant="plain"
+        aria-label={ariaLabel || `Remove ${label}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          onClear();
+        }}
+        style={{ padding: 0, height: '18px', width: '18px' }}
+      />
+    </span>
+  );
+};
+
+FilterPill.displayName = 'FilterPill';
+
+export default FilterPill;

--- a/src/pages/assessment/Assessment.tsx
+++ b/src/pages/assessment/Assessment.tsx
@@ -9,8 +9,6 @@ import {
   DropdownList,
   InputGroup,
   InputGroupItem,
-  Label,
-  LabelGroup,
   MenuToggle,
   MenuToggleElement,
   SearchInput,
@@ -21,6 +19,7 @@ import {
 import { FilterIcon, TimesIcon } from '@patternfly/react-icons';
 
 import { ConfirmationModal } from '../../components/ConfirmationModal';
+import FilterPill from '../../components/FilterPill';
 import { useDiscoverySources } from '../../migration-wizard/contexts/discovery-sources/Context';
 import StartingPageModal from '../starting-page/StartingPageModal';
 
@@ -449,49 +448,33 @@ const Assessment: React.FC<Props> = ({
                 Filters
               </span>
 
-              <LabelGroup>
-                {selectedSourceTypes.map((t) => (
-                  <Label
-                    variant="outline"
-                    key={`chip-st-${t}`}
-                    onClose={() =>
+              {selectedSourceTypes
+                .filter((t) => t === 'discovery' || t === 'rvtools')
+                .map((t) => (
+                  <FilterPill
+                    key={t}
+                    label={`source type=${
+                      t === 'discovery' ? 'discovery ova' : 'rvtools'
+                    }`}
+                    ariaLabel={`Remove source type ${
+                      t === 'discovery' ? 'discovery ova' : 'rvtools'
+                    }`}
+                    onClear={() =>
                       toggleSourceType(t as 'discovery' | 'rvtools')
                     }
-                    closeBtnAriaLabel={`Remove source type ${t}`}
-                  >
-                    {`source type=${t === 'discovery' ? 'discovery ova' : 'rvtools'}`}
-                  </Label>
+                  />
                 ))}
 
-                {(() => {
-                  const MAX_OWNER_CHIPS = 1;
-                  const visibleOwners = selectedOwners.slice(
-                    0,
-                    MAX_OWNER_CHIPS,
-                  );
-                  const overflow = selectedOwners.length - visibleOwners.length;
-                  return (
-                    <>
-                      {visibleOwners.map((owner) => (
-                        <Label
-                          variant="outline"
-                          key={`chip-owner-${owner}`}
-                          onClose={() => toggleOwner(owner)}
-                          closeBtnAriaLabel={`Remove owner ${owner}`}
-                        >
-                          {`owner=${owner}`}
-                        </Label>
-                      ))}
-                      {overflow > 0 && (
-                        <Label
-                          variant="outline"
-                          key="owners-overflow"
-                        >{`${overflow} more`}</Label>
-                      )}
-                    </>
-                  );
-                })()}
-              </LabelGroup>
+              {selectedOwners
+                .filter((o) => typeof o === 'string' && o.trim() !== '')
+                .map((owner) => (
+                  <FilterPill
+                    key={owner}
+                    label={`owner=${owner}`}
+                    ariaLabel={`Remove owner ${owner}`}
+                    onClear={() => toggleOwner(owner)}
+                  />
+                ))}
 
               <Button
                 icon={<TimesIcon />}

--- a/src/pages/environment/Environment.tsx
+++ b/src/pages/environment/Environment.tsx
@@ -10,8 +10,6 @@ import {
   DropdownList,
   InputGroup,
   InputGroupItem,
-  Label,
-  LabelGroup,
   MenuToggle,
   MenuToggleElement,
   SearchInput,
@@ -22,6 +20,7 @@ import {
 } from '@patternfly/react-core';
 import { FilterIcon, PlusCircleIcon, TimesIcon } from '@patternfly/react-icons';
 
+import FilterPill from '../../components/FilterPill';
 import { useDiscoverySources } from '../../migration-wizard/contexts/discovery-sources/Context';
 
 import { DiscoverySourceSetupModal } from './sources-table/empty-state/DiscoverySourceSetupModal';
@@ -221,36 +220,37 @@ export const Environment: React.FC = () => {
                 Filters
               </span>
 
-              <LabelGroup>
-                {(() => {
-                  const MAX_STATUS_CHIPS = 1;
-                  const visible = selectedStatuses.slice(0, MAX_STATUS_CHIPS);
-                  const overflow = selectedStatuses.length - visible.length;
-                  const labelMap = new Map(
-                    statusOptions.map((s) => [s.key, s.label]),
-                  );
-                  return (
-                    <>
-                      {visible.map((key) => (
-                        <Label
-                          variant="outline"
-                          key={`chip-status-${key}`}
-                          onClose={() => toggleStatus(key)}
-                          closeBtnAriaLabel={`Remove status ${key}`}
-                        >
-                          {`status=${labelMap.get(key) ?? key}`}
-                        </Label>
-                      ))}
-                      {overflow > 0 && (
-                        <Label
-                          variant="outline"
-                          key="status-overflow"
-                        >{`${overflow} more`}</Label>
-                      )}
-                    </>
-                  );
-                })()}
-              </LabelGroup>
+              {((): JSX.Element => {
+                const MAX_STATUS_CHIPS = 6;
+                const visible = selectedStatuses.slice(0, MAX_STATUS_CHIPS);
+                const overflow = selectedStatuses.length - visible.length;
+                const hidden = selectedStatuses.slice(MAX_STATUS_CHIPS);
+                const labelMap = new Map(
+                  statusOptions.map((s) => [s.key, s.label]),
+                );
+                return (
+                  <>
+                    {visible.map((key) => (
+                      <FilterPill
+                        key={`chip-status-${key}`}
+                        label={`status=${labelMap.get(key) ?? key}`}
+                        ariaLabel={`Remove status ${labelMap.get(key) ?? key}`}
+                        onClear={() => toggleStatus(key)}
+                      />
+                    ))}
+                    {overflow > 0 && (
+                      <FilterPill
+                        key="status-overflow"
+                        label={`${overflow} more`}
+                        ariaLabel="Remove hidden statuses"
+                        onClear={() => {
+                          hidden.forEach((k) => toggleStatus(k));
+                        }}
+                      />
+                    )}
+                  </>
+                );
+              })()}
 
               <Button
                 icon={<TimesIcon />}


### PR DESCRIPTION
Related with https://issues.redhat.com/browse/ECOPROJECT-3417

<img width="1487" height="592" alt="Captura desde 2025-10-27 15-42-16" src="https://github.com/user-attachments/assets/fe6021c2-f1c2-4c06-b9b8-289ce85ab922" />
<img width="1478" height="713" alt="Captura desde 2025-10-27 15-42-03" src="https://github.com/user-attachments/assets/3e11ef67-b58e-4c25-adcd-6b8f8dd1c0a1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new filter pill component for cleaner filtering UI with individual clear actions.
  * Enhanced assessment page filtering with improved source type and owner management.
  * Expanded environment status display to show up to 6 visible statuses with better overflow handling and granular clearing controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->