### PR TITLE
NO-JIRA | fix: close filters dropdown when we open a modal

### DIFF
--- a/src/pages/assessment/Assessment.tsx
+++ b/src/pages/assessment/Assessment.tsx
@@ -152,6 +152,23 @@ const Assessment: React.FC<Props> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rvtoolsOpenToken]);
 
+  // Close filter dropdown whenever any modal in this page opens
+  React.useEffect(() => {
+    if (
+      isModalOpen ||
+      isUpdateModalOpen ||
+      isDeleteModalOpen ||
+      isStartingPageModalOpen
+    ) {
+      setIsFilterDropdownOpen(false);
+    }
+  }, [
+    isModalOpen,
+    isUpdateModalOpen,
+    isDeleteModalOpen,
+    isStartingPageModalOpen,
+  ]);
+
   const handleUpdateAssessment = (assessmentId: string): void => {
     const assessment = assessments.find(
       (a) => (a as AssessmentModel).id === assessmentId,

--- a/src/pages/environment/Environment.tsx
+++ b/src/pages/environment/Environment.tsx
@@ -99,6 +99,13 @@ export const Environment: React.FC = () => {
     }
   }, [isOvaDownloading]);
 
+  // Close filter dropdown whenever any modal in this page opens
+  useEffect(() => {
+    if (shouldShowDiscoverySourceSetupModal || isTroubleshootingOpen) {
+      setIsFilterDropdownOpen(false);
+    }
+  }, [shouldShowDiscoverySourceSetupModal, isTroubleshootingOpen]);
+
   return (
     <>
       <div


### PR DESCRIPTION
Close filters dropdown when we open a modal


https://github.com/user-attachments/assets/91cf2371-03d9-45e1-b963-80bd13923206



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed filter dropdowns remaining visible when opening modals on the Assessment and Environment pages, improving UI consistency and providing a cleaner user experience during modal interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->