### PR TITLE
ECOPROJECT-3427 | fix: Assessment table columns name not cut off

### DIFF
--- a/src/pages/assessment/AssessmentsTable.tsx
+++ b/src/pages/assessment/AssessmentsTable.tsx
@@ -327,31 +327,31 @@ export const AssessmentsTable: React.FC<Props> = ({
       >
         <Thead>
           <Tr>
-            <Th sort={nameSortParams} style={{ whiteSpace: 'nowrap' }}>
+            <Th sort={nameSortParams} modifier="wrap">
               {Columns.Name}
             </Th>
-            <Th sort={sourceTypeSortParams} style={{ whiteSpace: 'nowrap' }}>
+            <Th sort={sourceTypeSortParams} modifier="wrap">
               {Columns.SourceType}
             </Th>
-            <Th sort={lastUpdatedSortParams} style={{ whiteSpace: 'nowrap' }}>
+            <Th sort={lastUpdatedSortParams} modifier="wrap">
               {Columns.LastUpdated}
             </Th>
-            <Th sort={ownerSortParams} style={{ whiteSpace: 'nowrap' }}>
+            <Th sort={ownerSortParams} modifier="wrap">
               {Columns.Owner}
             </Th>
-            <Th sort={hostsSortParams} style={{ whiteSpace: 'nowrap' }}>
+            <Th sort={hostsSortParams} modifier="wrap">
               {Columns.Hosts}
             </Th>
-            <Th sort={vmsSortParams} style={{ whiteSpace: 'nowrap' }}>
+            <Th sort={vmsSortParams} modifier="wrap">
               {Columns.VMs}
             </Th>
-            <Th sort={networksSortParams} style={{ whiteSpace: 'nowrap' }}>
+            <Th sort={networksSortParams} modifier="wrap">
               {Columns.Networks}
             </Th>
-            <Th sort={datastoresSortParams} style={{ whiteSpace: 'nowrap' }}>
+            <Th sort={datastoresSortParams} modifier="wrap">
               {Columns.Datastores}
             </Th>
-            <Th style={{ whiteSpace: 'nowrap' }} screenReaderText="Actions">
+            <Th modifier="wrap" screenReaderText="Actions">
               {Columns.Actions}
             </Th>
           </Tr>


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/ECOPROJECT-3427

<img width="1034" height="431" alt="Captura desde 2025-11-03 10-54-04" src="https://github.com/user-attachments/assets/87528c55-085c-45ee-a25d-469eb67239c0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced text wrapping in Assessments table headers for improved readability and consistent display across all column headers and action controls. Provides a cleaner interface while preserving sorting functionality and data rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->