### PR TITLE
ECOPROJECT-3431 | fix: Changes in VM Migration Status component

### DIFF
--- a/src/pages/report/assessment-report/VMMigrationStatus.tsx
+++ b/src/pages/report/assessment-report/VMMigrationStatus.tsx
@@ -22,7 +22,10 @@ export const VMMigrationStatus: React.FC<VmMigrationStatusProps> = ({
   ];
 
   return (
-    <Card className={isExportMode ? 'dashboard-card-print' : 'dashboard-card'}>
+    <Card
+      className={isExportMode ? 'dashboard-card-print' : 'dashboard-card'}
+      style={{ height: '340px !important', overflow: 'hidden' }}
+    >
       <CardTitle>
         <VirtualMachineIcon /> VM Migration Status
       </CardTitle>
@@ -36,7 +39,6 @@ export const VMMigrationStatus: React.FC<VmMigrationStatusProps> = ({
         >
           <ChartDonut
             ariaDesc="VM Migration Status"
-            ariaTitle="VM Migration"
             data={chartData}
             labels={({ datum }) => `${datum.x}: ${datum.y}`}
             colorScale={['#28a745', '#dc3545']}


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/ECOPROJECT-3431

In the VM Migration Status component we need to:
- Remove unnecessary white-space
- Remove duplicated tooltip

<img width="752" height="352" alt="image" src="https://github.com/user-attachments/assets/c942ab4d-bf72-4849-b997-02d7ed84fd30" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted card layout constraints in the VM Migration Status report.

* **Accessibility**
  * Updated screen reader attribute handling in the VM Migration Status report chart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->