### PR TITLE
NO-JIRA | fix: solving errors running standalone mode

### DIFF
--- a/webpack.standalone.js
+++ b/webpack.standalone.js
@@ -38,6 +38,16 @@ module.exports = (env, argv) => {
           // path.resolve(__dirname, 'node_modules/@migration-planner-ui/agent-client/src'),
         ],
       },
+      // Allow extensionless ESM imports (e.g., './Label') inside the api-client dist
+      {
+        test: /\.js$/,
+        include: [
+          path.resolve(__dirname, 'node_modules/@migration-planner-ui/api-client/dist')
+        ],
+        resolve: {
+          fullySpecified: false,
+        },
+      },
       {
         test: /\.css$/,
         use: ['style-loader', 'css-loader'],
@@ -102,7 +112,6 @@ module.exports = (env, argv) => {
       './UploadRvtoolsFile200Response': path.resolve(__dirname, 'node_modules/@migration-planner-ui/api-client/dist/models/UploadRvtoolsFile200Response.js'),
       './Network': path.resolve(__dirname, 'node_modules/@migration-planner-ui/api-client/dist/models/Network.js'),
       './Host': path.resolve(__dirname, 'node_modules/@migration-planner-ui/api-client/dist/models/Host.js'),
-      './Label': path.resolve(__dirname, 'node_modules/@migration-planner-ui/api-client/dist/models/Label.js'),
       './Histogram': path.resolve(__dirname, 'node_modules/@migration-planner-ui/api-client/dist/models/Histogram.js'),
       './MigrationIssue': path.resolve(__dirname, 'node_modules/@migration-planner-ui/api-client/dist/models/MigrationIssue.js'),
       './OsInfo': path.resolve(__dirname, 'node_modules/@migration-planner-ui/api-client/dist/models/OsInfo.js'),


### PR DESCRIPTION
- Problem 1: PatternFly’s Chip imports components/Label, but Webpack was resolving a different Label (the API client’s model), causing the “export 'Label' not found” warning.
Fix: Removed the ./Label alias from webpack.standalone.js so PatternFly’s own Label component resolves correctly.
- Problem 2: After removing that alias, the API client (ESM package with "type": "module") uses extensionless relative imports like ./Label, which Webpack treats as “fully specified” and fails to resolve.
Fix: Added a targeted rule so extensionless ESM imports inside @migration-planner-ui/api-client/dist are allowed without reintroducing global aliases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to properly resolve module imports from a dependency package.
  * Removed an unused alias from the build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->