### PR TITLE
ECOPROJECT-3442 | fix: changes in last seen column in environments table

### DIFF
--- a/src/pages/environment/sources-table/Columns.ts
+++ b/src/pages/environment/sources-table/Columns.ts
@@ -7,5 +7,5 @@ export const enum Columns {
   Networks = 'Networks',
   Datastores = 'Datastores',
   Actions = 'Actions',
-  LastSeen = 'Last seen',
+  LastSeen = 'Last updated',
 }


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/ECOPROJECT-3442

- Change "Last seen" text by "Last updated"
- Show info about the time that has passed since the last update (for example, 2 weeks) and then when user hovers in the text we can see the last updated date

<img width="1456" height="423" alt="Captura desde 2025-11-05 11-25-42" src="https://github.com/user-attachments/assets/e41f3006-16ac-4e12-b4b7-6be2aac10f55" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sources table now shows relative timestamps (e.g., "2 hours ago") with full timestamps visible on hover.
* **UI**
  * Renamed column header from "Last seen" to "Last updated" for clearer meaning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->