### PR TITLE
ECOPROJECT-3472 | fix: UI review 4-11-2025

### DIFF
--- a/src/pages/assessment/Assessment.tsx
+++ b/src/pages/assessment/Assessment.tsx
@@ -245,7 +245,7 @@ const Assessment: React.FC<Props> = ({
       if (!file) throw new Error('File is required for RVTools assessment');
 
       // Create the assessment with RVTools file (only RVTools mode supported)
-      await discoverySourcesContext.createAssessment(
+      const assessment = await discoverySourcesContext.createAssessment(
         name,
         'rvtools',
         undefined, // jsonValue not used for rvtools mode
@@ -253,8 +253,9 @@ const Assessment: React.FC<Props> = ({
         file, // rvToolFile
       );
 
-      // Refresh assessments list after successful creation
-      await discoverySourcesContext.listAssessments();
+      navigate(
+        `/openshift/migration-assessment/assessments/${assessment.id}/report`,
+      );
     } catch (error) {
       console.error('Failed to create assessment:', error);
       throw error; // Re-throw so the modal can handle it

--- a/src/pages/assessment/AssessmentDetails.tsx
+++ b/src/pages/assessment/AssessmentDetails.tsx
@@ -179,7 +179,7 @@ const AssessmentDetails: React.FC = () => {
         >
           <div>
             <Content>
-              <Content component="small">Discover VM status</Content>
+              <Content component="small">Discovery VM status</Content>
               <AgentStatusView
                 status={agent ? agent.status : 'not-connected'}
                 statusInfo={

--- a/src/pages/assessment/AssessmentsTable.tsx
+++ b/src/pages/assessment/AssessmentsTable.tsx
@@ -10,6 +10,7 @@ import {
   MenuToggle,
   MenuToggleElement,
   Spinner,
+  Tooltip,
 } from '@patternfly/react-core';
 import {
   ConnectedIcon,
@@ -351,7 +352,11 @@ export const AssessmentsTable: React.FC<Props> = ({
             <Th sort={datastoresSortParams} modifier="wrap">
               {Columns.Datastores}
             </Th>
-            <Th modifier="wrap" screenReaderText="Actions">
+            <Th
+              modifier="fitContent"
+              screenReaderText="Actions"
+              style={{ whiteSpace: 'nowrap' }}
+            >
               {Columns.Actions}
             </Th>
           </Tr>
@@ -396,25 +401,35 @@ export const AssessmentsTable: React.FC<Props> = ({
               <Td dataLabel={Columns.VMs}>{row.vms}</Td>
               <Td dataLabel={Columns.Networks}>{row.networks}</Td>
               <Td dataLabel={Columns.Datastores}>{row.datastores}</Td>
-              <Td dataLabel={Columns.Actions}>
+              <Td
+                dataLabel={Columns.Actions}
+                style={{
+                  verticalAlign: 'middle',
+                  paddingTop: 0,
+                  paddingBottom: 0,
+                }}
+              >
                 <div
                   style={{
                     display: 'flex',
                     alignItems: 'center',
                     gap: '8px',
+                    height: '100%',
                   }}
                 >
-                  <Button
-                    variant="plain"
-                    aria-label="Open assessment"
-                    icon={<MonitoringIcon />}
-                    style={{ color: '#0066cc' }}
-                    onClick={() =>
-                      navigate(
-                        `/openshift/migration-assessment/assessments/${row.id}/report`,
-                      )
-                    }
-                  />
+                  <Tooltip content="Show assessment report">
+                    <Button
+                      variant="plain"
+                      aria-label="Open assessment"
+                      icon={<MonitoringIcon style={{ color: '#0066cc' }} />}
+                      style={{ padding: 0 }}
+                      onClick={() =>
+                        navigate(
+                          `/openshift/migration-assessment/assessments/${row.id}/report`,
+                        )
+                      }
+                    />
+                  </Tooltip>
                   <Dropdown
                     isOpen={openDropdowns[row.id] || false}
                     popperProps={{ appendTo: () => document.body }}
@@ -431,6 +446,7 @@ export const AssessmentsTable: React.FC<Props> = ({
                         variant="plain"
                         onClick={() => toggleDropdown(row.id)}
                         icon={<EllipsisVIcon />}
+                        style={{ padding: 0 }}
                       ></MenuToggle>
                     )}
                   >

--- a/src/pages/environment/sources-table/AgentStatusView.tsx
+++ b/src/pages/environment/sources-table/AgentStatusView.tsx
@@ -141,7 +141,9 @@ export const AgentStatusView: React.FC<AgentStatusView.Props> = (props) => {
       <SplitItem>
         {isWaitingForCredentials ||
         uploadedManually ||
-        (hasStatusInfo && status !== 'not-connected') ? (
+        (hasStatusInfo &&
+          status !== 'not-connected' &&
+          status !== 'up-to-date') ? (
           <Popover
             aria-label={statusView && statusView.text}
             headerContent={statusView && statusView.text}

--- a/src/pages/starting-page/StartingPage.tsx
+++ b/src/pages/starting-page/StartingPage.tsx
@@ -81,10 +81,10 @@ const createCards = (
           Select your target OpenShift Cluster to fit your migration data
         </Content>
         <span
-          className="pf-v5-c-label pf-m-purple pf-m-compact"
+          className="pf-v6-c-label pf-m-purple pf-m-compact"
           style={{ marginTop: '6px', display: 'inline-block' }}
         >
-          Coming soon
+          <span className="pf-v6-c-label__content">Coming soon</span>
         </span>
       </Content>
     </CardBody>
@@ -109,10 +109,10 @@ const createCards = (
           your migration timeline
         </Content>
         <span
-          className="pf-v5-c-label pf-m-purple pf-m-compact"
+          className="pf-v6-c-label pf-m-purple pf-m-compact"
           style={{ marginTop: '6px', display: 'inline-block' }}
         >
-          Coming soon
+          <span className="pf-v6-c-label__content">Coming soon</span>
         </span>
       </Content>
     </CardBody>


### PR DESCRIPTION
1. Changes in Assessments table: blue icon for show assessment report and tooltip
<img width="1744" height="107" alt="Captura desde 2025-11-05 11-48-56" src="https://github.com/user-attachments/assets/8d3695df-a5a8-4936-89c0-122f150191f4" />

2. Change text 'Discover status' for 'Discovery status'
<img width="412" height="340" alt="Captura desde 2025-11-05 11-53-40" src="https://github.com/user-attachments/assets/3da37a9a-59d2-4ee6-a647-6fcfa382a14f" />

3. After creating assessment with RvTools we redirect to the assessment report not to the list


https://github.com/user-attachments/assets/c816464d-2c79-4d57-a431-ff30348df6e1



4. Remove tooltip for 'Ready' environments
<img width="409" height="119" alt="Captura desde 2025-11-05 13-40-16" src="https://github.com/user-attachments/assets/84668a09-b146-407f-9c4d-425cfbd60c8e" />

5. 'Coming soon' text in Getting Started modal needs to be more clear
<img width="1092" height="456" alt="Captura desde 2025-11-05 14-22-14" src="https://github.com/user-attachments/assets/621b94c5-6073-4dfe-b14c-230dc02a5058" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added tooltip to the Open assessment button for improved guidance

* **Bug Fixes**
  - Corrected label text to "Discovery VM status"
  - Assessment creation now navigates directly to the new report
  - Refined agent status display to show plain status when up-to-date

* **Style**
  - Improved assessments table layout and spacing
  - Updated badge/label styling to current design utilities
<!-- end of auto-generated comment: release notes by coderabbit.ai -->