### PR TITLE
NO-JIRA | fix: incorrect bar width calculation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10432,9 +10432,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/components/MigrationChart.tsx
+++ b/src/components/MigrationChart.tsx
@@ -60,6 +60,12 @@ const MigrationChart: React.FC<MigrationChartProps> = ({
     ).result;
   }, [data]);
 
+  // Calculate the sum of all count values to normalize bar widths
+  const sumOfAllCounts = useMemo(() => {
+    if (!data || data.length === 0) return 1;
+    return data.reduce((sum, item) => sum + item.count, 0) || 1;
+  }, [data]);
+
   const chartLegend = legend ? legend : Object.assign({}, ...dynamicLegend);
   const getColor = (name: string): string => chartLegend[name];
 
@@ -139,16 +145,24 @@ const MigrationChart: React.FC<MigrationChartProps> = ({
                             overflow: 'hidden',
                           }}
                         >
-                          <div
-                            style={{
-                              height: '100%',
-                              width: `${item.count}%`,
-                              backgroundColor: `${getColor(
-                                item.legendCategory,
-                              )}`,
-                              transition: 'width 0.3s ease',
-                            }}
-                          />
+                          {(() => {
+                            const barWidth =
+                              sumOfAllCounts > 0
+                                ? (item.count / sumOfAllCounts) * 100
+                                : 0;
+                            return (
+                              <div
+                                style={{
+                                  height: '100%',
+                                  width: `${barWidth}%`,
+                                  backgroundColor: `${getColor(
+                                    item.legendCategory,
+                                  )}`,
+                                  transition: 'width 0.3s ease',
+                                }}
+                              />
+                            );
+                          })()}
                         </div>
                       </div>
                     </Td>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5257,9 +5257,9 @@ js-cookie@^2.2.1:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz"
+  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION

<img width="1403" height="601" alt="Screenshot from 2025-11-17 18-30-19" src="https://github.com/user-attachments/assets/d5e28d6a-6abf-4cf9-9f57-b363dbad2adb" />

Before - bar width is max for count above 100  
After - Fix. normalized according to the total count.  


Signed-off-by: Aviel Segev <asegev@redhat.com>
