### PR TITLE
ECOPROJECT-3610 | fix: Add disk types info to PDF exported

### DIFF
--- a/src/pages/report/assessment-report/Dashboard.css
+++ b/src/pages/report/assessment-report/Dashboard.css
@@ -46,33 +46,3 @@
   border-radius: 10px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 }
-
-.dashboard-card-print#vm-migration-status {
-  height: 500px !important;
-  overflow: hidden;
-}
-
-.dashboard-card-print #os-distribution {
-  height: 1500px !important;
-  max-height: 1500px !important;
-  overflow: hidden;
-}
-
-.dashboard-card-print #clusters-overview,
-.dashboard-card-print #storage-overview,
-.dashboard-card-print #warnings-table,
-.dashboard-card-print #errors-table {
-  height: auto !important;
-  max-height: none !important;
-  overflow: visible !important;
-}
-.table-without-border {
-  border: none !important;
-}
-.dashboard-card-print #hosts,
-.dashboard-card-print #cpu-cores,
-.dashboard-card-print #total-memory {
-  height: 100px !important;
-  max-height: 100px !important;
-  overflow: hidden;
-}

--- a/src/pages/report/assessment-report/ErrorTable.tsx
+++ b/src/pages/report/assessment-report/ErrorTable.tsx
@@ -16,7 +16,7 @@ export const ErrorTable: React.FC<ErrorTableProps> = ({
   errors,
   isExportMode = false,
 }) => {
-  const tableHeight = isExportMode ? '100%' : '325px';
+  const tableHeight = isExportMode ? 'none !important' : '325px';
   return (
     <Card
       className={isExportMode ? 'dashboard-card-print' : 'dashboard-card'}

--- a/src/pages/report/assessment-report/StorageOverview.tsx
+++ b/src/pages/report/assessment-report/StorageOverview.tsx
@@ -367,6 +367,65 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
           <>
             <div style={{ marginBottom: '24px' }}>
               <div style={{ fontWeight: 600, marginBottom: 8 }}>
+                {VIEW_MODE_LABELS['vmCountByDiskType']}
+              </div>
+              <Chart
+                ariaTitle="VM count by disk type"
+                ariaDesc="Vertical bar chart of VM counts grouped by disk type"
+                theme={smallFontTheme}
+                containerComponent={
+                  <ChartVoronoiContainer
+                    responsive
+                    labels={({ datum }) => `${datum.x}: ${Number(datum.y)} VMs`}
+                    constrainToVisibleArea
+                    labelComponent={<ChartTooltip style={{ fontSize: 8 }} />}
+                  />
+                }
+                domain={{
+                  y: [0, maxDiskTypeCount],
+                }}
+                domainPadding={{ x: [12, 12] }}
+                padding={{ top: 10, bottom: 10, left: 20, right: 20 }}
+                height={180}
+                width={500}
+              >
+                <ChartAxis
+                  dependentAxis
+                  style={{
+                    axis: { stroke: 'none' },
+                    tickLabels: { fill: 'none' },
+                    grid: { stroke: 'none' },
+                  }}
+                />
+                <ChartAxis
+                  tickValues={diskTypeChartData.map((d) => d.name)}
+                  tickFormat={(x) => {
+                    const item = diskTypeChartData.find((d) => d.name === x);
+                    return item ? [`${item.name}`, `(${item.count} VMs)`] : x;
+                  }}
+                  style={{
+                    axis: { stroke: 'none' },
+                    tickLabels: { fontSize: 8 },
+                  }}
+                />
+                <ChartBar
+                  barWidth={28}
+                  data={diskTypeChartData.map((d) => ({
+                    x: d.name,
+                    y: d.count,
+                  }))}
+                  style={{
+                    data: {
+                      fill: ({ index }: { index: number }) =>
+                        diskTypeBarColors[index % diskTypeBarColors.length],
+                    },
+                    labels: { fontSize: 8 },
+                  }}
+                />
+              </Chart>
+            </div>
+            <div style={{ marginBottom: '24px' }}>
+              <div style={{ fontWeight: 600, marginBottom: 8 }}>
                 {VIEW_MODE_LABELS['vmCount']}
               </div>
               <MigrationDonutChart

--- a/src/pages/report/assessment-report/WarningsTable.tsx
+++ b/src/pages/report/assessment-report/WarningsTable.tsx
@@ -16,7 +16,7 @@ export const WarningsTable: React.FC<WarningsTableProps> = ({
   warnings,
   isExportMode = false,
 }) => {
-  const tableHeight = isExportMode ? '100%' : '325px';
+  const tableHeight = isExportMode ? 'none !important' : '325px';
   return (
     <Card
       className={isExportMode ? 'dashboard-card-print' : 'dashboard-card'}


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/ECOPROJECT-3610
Add disk types info to PDF exported:
<img width="345" height="674" alt="image" src="https://github.com/user-attachments/assets/19f74139-b800-4035-aa22-390242286576" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added VM count-by-disk-type bar chart to assessment report exports.

* **Bug Fixes**
  * Removed rigid print/layout height and overflow constraints so report sections render with normal flow.
  * Relaxed table height limits in export mode for more flexible, consistent table rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->