### PR TITLE
ECOPROJECT-3609 | fix: solving margin issues in CPU overcommitment view

### DIFF
--- a/src/pages/report/assessment-report/ClustersOverview.css
+++ b/src/pages/report/assessment-report/ClustersOverview.css
@@ -25,7 +25,7 @@
   justify-content: center;
   gap: 6px 24px; /* row-gap, column-gap */
   flex-wrap: wrap;
-  margin-top: 148px;
+  margin-top: 20%;
 }
 
 .cpu-overcommit__legend-item {
@@ -52,7 +52,7 @@
     gap: 20px;
   }
   .cpu-overcommit__legend {
-    margin-top: 64px;
+    margin-top: 20%;
     gap: 6px 20px;
   }
 }
@@ -70,7 +70,7 @@
     border-radius: 10px;
   }
   .cpu-overcommit__legend {
-    margin-top: 32px;
+    margin-top: 20%;
     gap: 6px 16px;
   }
   .cpu-overcommit__legend-text {

--- a/src/pages/report/assessment-report/ClustersOverview.tsx
+++ b/src/pages/report/assessment-report/ClustersOverview.tsx
@@ -100,7 +100,7 @@ export const ClustersOverview: React.FC<ClustersOverviewProps> = ({
 
       const formatRatio = (r: number): string => {
         const formatted = r % 1 === 0 ? r.toFixed(0) : r.toFixed(2);
-        return `1:${formatted.replace(/(?:\.0+|(\.\d*[1-9]))0+$/, '$1')}`;
+        return `${formatted.replace(/(?:\.0+|(\.\d*[1-9]))0+$/, '$1')}`;
       };
 
       const slices = top.map((item, idx) => ({
@@ -109,7 +109,6 @@ export const ClustersOverview: React.FC<ClustersOverviewProps> = ({
         countDisplay: formatRatio(item.value),
         legendCategory: `Cluster ${idx + 1}`,
       }));
-
       const legendCategories = slices.map((s) => s.legendCategory);
       return {
         chartData: slices,
@@ -317,7 +316,7 @@ export const ClustersOverview: React.FC<ClustersOverviewProps> = ({
     const top = withValue.slice(0, TOP_N);
     const formatRatio = (r: number): string => {
       const formatted = r % 1 === 0 ? r.toFixed(0) : r.toFixed(2);
-      return `1:${formatted.replace(/(?:\.0+|(\.\d*[1-9]))0+$/, '$1')}`;
+      return `${formatted.replace(/(?:\.0+|(\.\d*[1-9]))0+$/, '$1')}`;
     };
     const slices = top.map((item, idx) => ({
       name: formatRatio(item.value),


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/ECOPROJECT-3609

Solving margin issues in CPU overcommitment view.

<img width="590" height="521" alt="Captura desde 2025-12-09 15-35-34" src="https://github.com/user-attachments/assets/1c1da7ef-6854-462f-88ba-75739ee1a292" />
<img width="742" height="520" alt="Captura desde 2025-12-09 15-35-09" src="https://github.com/user-attachments/assets/a1686a14-0325-42f6-8e23-7b46122845c4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsive spacing for the CPU overcommit legend using percentage-based top margins across all breakpoints.

* **Bug Fixes**
  * Adjusted CPU commitment ratio labeling to remove a leading prefix, clarifying chart and export displays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->