### PR TITLE
ECOPROJECT-3525 | feat: Add information on VM if Operating Systems are migraetable to RHEL

### DIFF
--- a/src/components/MigrationChart.css
+++ b/src/components/MigrationChart.css
@@ -1,0 +1,13 @@
+.upgrade-recommendation-popover
+  .popover-override
+  .pf-v5-c-popover__close
+  .pf-v5-c-button.pf-m-plain {
+  color: #151515;
+}
+
+.upgrade-recommendation-popover
+  .popover-override
+  .pf-v5-c-popover__close
+  .pf-v5-c-button.pf-m-plain:hover {
+  color: #000;
+}

--- a/src/components/MigrationChart.tsx
+++ b/src/components/MigrationChart.tsx
@@ -1,18 +1,23 @@
 import React, { useMemo } from 'react';
 
 import {
+  Button,
   Content,
   ContentVariants,
   Flex,
   FlexItem,
-  Tooltip,
+  Popover,
 } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 import { Table, Tbody, Td, Tr } from '@patternfly/react-table';
+
+import './MigrationChart.css';
 
 interface OSData {
   name: string;
   count: number;
   legendCategory: string;
+  infoText?: string;
 }
 
 interface MigrationChartProps {
@@ -20,6 +25,7 @@ interface MigrationChartProps {
   legend?: Record<string, string>;
   dataLength?: DLength;
   maxHeight?: string;
+  barHeight?: number;
 }
 
 type DLength =
@@ -45,6 +51,7 @@ const MigrationChart: React.FC<MigrationChartProps> = ({
   legend,
   dataLength = 40,
   maxHeight = '200px',
+  barHeight = 8,
 }: MigrationChartProps) => {
   const dynamicLegend = useMemo(() => {
     return data.reduce(
@@ -116,23 +123,54 @@ const MigrationChart: React.FC<MigrationChartProps> = ({
                 {data.map((item, index) => (
                   <Tr key={index}>
                     <Td width={dataLength} style={{ paddingLeft: '0px' }}>
-                      <Tooltip content={<div>{item.name}</div>} exitDelay={0}>
-                        <Content
-                          component={ContentVariants.p}
-                          style={{
-                            fontSize: 'clamp(0.4rem, 0.7vw, 1.1rem)',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            wordBreak: 'break-word',
-                            display: '-webkit-box',
-                            WebkitLineClamp: 1, // Number of lines to show
-                            textTransform: 'capitalize',
-                            WebkitBoxOrient: 'vertical',
-                          }}
-                        >
-                          {item.name}
-                        </Content>
-                      </Tooltip>
+                      <Flex
+                        alignItems={{ default: 'alignItemsCenter' }}
+                        spaceItems={{ default: 'spaceItemsSm' }}
+                      >
+                        <FlexItem>
+                          <Content
+                            component={ContentVariants.p}
+                            style={{
+                              fontSize: 'clamp(0.4rem, 0.7vw, 1.1rem)',
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              wordBreak: 'break-word',
+                              display: '-webkit-box',
+                              WebkitLineClamp: 1,
+                              textTransform: 'capitalize',
+                              WebkitBoxOrient: 'vertical',
+                            }}
+                          >
+                            {item.name}
+                          </Content>
+                        </FlexItem>
+                        {item.infoText &&
+                        item.infoText !== '' &&
+                        item.infoText !== undefined ? (
+                          <FlexItem>
+                            <Popover
+                              className="upgrade-recommendation-popover"
+                              position="bottom"
+                              headerContent="Upgrade to get support"
+                              bodyContent={
+                                <div>
+                                  This operating system must be upgraded to a
+                                  supported version in order to be supported by
+                                  Red Hat.
+                                </div>
+                              }
+                            >
+                              <Button
+                                type="button"
+                                aria-label="Open operating system upgrade information"
+                                variant="plain"
+                              >
+                                <InfoCircleIcon color="#6a6ec8" />
+                              </Button>
+                            </Popover>
+                          </FlexItem>
+                        ) : null}
+                      </Flex>
                     </Td>
                     <Td>
                       {/* Visual Bar */}
@@ -140,7 +178,7 @@ const MigrationChart: React.FC<MigrationChartProps> = ({
                         <div
                           style={{
                             position: 'relative',
-                            height: '8px',
+                            height: `${barHeight}px`,
                             backgroundColor: '#F5F5F5',
                             overflow: 'hidden',
                           }}

--- a/src/pages/report/assessment-report/Dashboard.tsx
+++ b/src/pages/report/assessment-report/Dashboard.tsx
@@ -50,22 +50,35 @@ export const Dashboard: React.FC<Props> = ({
           acc[osName] = {
             count: osInfo.count,
             supported: osInfo.supported,
+            upgradeRecommendation: osInfo.upgradeRecommendation,
           };
           return acc;
         },
-        {} as { [osName: string]: { count: number; supported: boolean } },
+        {} as {
+          [osName: string]: {
+            count: number;
+            supported: boolean;
+            upgradeRecommendation: string;
+          };
+        },
       )
     : Object.entries(vms.os).reduce(
         (acc, [osName, count]) => {
           acc[osName] = {
             count: count,
             supported: true, // Default to supported when using fallback data
+            upgradeRecommendation: '',
           };
           return acc;
         },
-        {} as { [osName: string]: { count: number; supported: boolean } },
+        {} as {
+          [osName: string]: {
+            count: number;
+            supported: boolean;
+            upgradeRecommendation: string;
+          };
+        },
       );
-
   return (
     <PageSection hasBodyWrapper={false}>
       <Grid hasGutter>

--- a/src/pages/report/assessment-report/OSDistribution.tsx
+++ b/src/pages/report/assessment-report/OSDistribution.tsx
@@ -1,6 +1,16 @@
 import React from 'react';
 
-import { Card, CardBody, CardTitle } from '@patternfly/react-core';
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  Content,
+  ContentVariants,
+  Flex,
+  FlexItem,
+  Icon,
+} from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 
 import MigrationChart from '../../../components/MigrationChart';
 
@@ -9,6 +19,7 @@ interface OSDistributionProps {
     [osName: string]: {
       count: number;
       supported: boolean;
+      upgradeRecommendation: string;
     };
   };
   isExportMode?: boolean;
@@ -18,6 +29,9 @@ export const OSDistribution: React.FC<OSDistributionProps> = ({
   osData,
   isExportMode = false,
 }) => {
+  const hasUpgradeRecommendation = Object.values(osData).some(
+    (o) => o.upgradeRecommendation && o.upgradeRecommendation.trim() !== '',
+  );
   return (
     <Card
       className={isExportMode ? 'dashboard-card-print' : 'dashboard-card'}
@@ -27,6 +41,27 @@ export const OSDistribution: React.FC<OSDistributionProps> = ({
         <i className="fas fa-database" /> Operating Systems
       </CardTitle>
       <CardBody>
+        {hasUpgradeRecommendation ? (
+          <Flex
+            alignItems={{ default: 'alignItemsCenter' }}
+            spaceItems={{ default: 'spaceItemsSm' }}
+            style={{ marginBottom: '8px' }}
+          >
+            <FlexItem>
+              <Icon>
+                <InfoCircleIcon color="#6a6ec8" />
+              </Icon>
+            </FlexItem>
+            <FlexItem>
+              <Content
+                component={ContentVariants.p}
+                style={{ fontWeight: 500 }}
+              >
+                OS must be upgraded to be supported
+              </Content>
+            </FlexItem>
+          </Flex>
+        ) : null}
         <OSBarChart osData={osData} isExportMode={isExportMode} />
       </CardBody>
     </Card>
@@ -34,7 +69,13 @@ export const OSDistribution: React.FC<OSDistributionProps> = ({
 };
 
 interface OSBarChartProps {
-  osData: { [osName: string]: { count: number; supported: boolean } };
+  osData: {
+    [osName: string]: {
+      count: number;
+      supported: boolean;
+      upgradeRecommendation?: string;
+    };
+  };
   isExportMode?: boolean;
 }
 
@@ -49,13 +90,16 @@ export const OSBarChart: React.FC<OSBarChartProps> = ({
   const chartData = sorted.map(([os, osInfo]) => ({
     name: os,
     count: osInfo.count,
-    legendCategory: osInfo.supported ? 'Supported' : 'Not Supported',
+    legendCategory: osInfo.supported
+      ? 'Supported by Red Hat'
+      : 'Not supported by Red Hat',
+    infoText: osInfo.upgradeRecommendation,
   }));
 
   // Define custom colors: green for supported, red for not supported
   const customLegend = {
-    Supported: '#28a745', // Green
-    'Not Supported': '#d9534f', // Red
+    'Supported by Red Hat': '#28a745', // Green
+    'Not supported by Red Hat': '#d9534f', // Red
   };
 
   const tableHeight = isExportMode ? 'auto !important' : '350px';
@@ -64,6 +108,7 @@ export const OSBarChart: React.FC<OSBarChartProps> = ({
       data={chartData}
       legend={customLegend}
       maxHeight={tableHeight}
+      barHeight={12}
     />
   );
 };


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/ECOPROJECT-3525

Add information on VM if Operating Systems are migraetable to RHEL

<img width="709" height="416" alt="Captura desde 2025-12-12 09-03-07" src="https://github.com/user-attachments/assets/14b4ba4f-c45e-435e-9e1b-ae2bdeae3c08" />
<img width="709" height="416" alt="Captura desde 2025-12-12 09-03-00" src="https://github.com/user-attachments/assets/c20dd4d1-24e6-40d6-a3d0-137964dbd140" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Migration charts show upgrade recommendations via an informational popover beside item names (info icon).
  * OS distribution includes upgrade-recommendation notices and now labels support as "Supported by Red Hat" / "Not supported by Red Hat".
  * Bar heights are now adjustable for improved visualization (updated default sizing).

* **Style**
  * Updated styling for upgrade-recommendation popovers, including hover color behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->