### PR TITLE
ECOPROJECT-3671 | fix: Cancel RVTools upload properly

### DIFF
--- a/src/migration-wizard/contexts/discovery-sources/Provider.tsx
+++ b/src/migration-wizard/contexts/discovery-sources/Provider.tsx
@@ -105,6 +105,15 @@ export const Provider: React.FC<PropsWithChildren> = (props) => {
     },
   );
 
+  // Callback to delete assessment (used when cancelling a completed job)
+  const handleDeleteAssessment = useCallback(
+    async (assessmentId: string) => {
+      await assessmentApi.deleteAssessment({ id: assessmentId });
+      await listAssessments();
+    },
+    [assessmentApi, listAssessments],
+  );
+
   // RVTools Job State Hook
   const {
     currentJob,
@@ -116,6 +125,7 @@ export const Provider: React.FC<PropsWithChildren> = (props) => {
   } = useRVToolsJob({
     jobApi,
     onJobCompleted: listAssessments,
+    onDeleteAssessment: handleDeleteAssessment,
   });
 
   const [createAssessmentState, createAssessment] = useAsyncFn(

--- a/src/pages/assessment/hooks/useRVToolsJob.ts
+++ b/src/pages/assessment/hooks/useRVToolsJob.ts
@@ -1,10 +1,9 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useInterval } from 'react-use';
 
 import { JobApi } from '@migration-planner-ui/api-client/apis';
 import { Job, JobStatus } from '@migration-planner-ui/api-client/models';
 
-import { useAsyncFnResetError } from '../../../hooks/useAsyncFnResetError';
 import {
   JOB_POLLING_INTERVAL,
   TERMINAL_JOB_STATUSES,
@@ -13,6 +12,7 @@ import {
 interface UseRVToolsJobProps {
   jobApi: JobApi;
   onJobCompleted: () => void;
+  onDeleteAssessment?: (assessmentId: string) => Promise<void>;
 }
 
 interface UseRVToolsJobReturn {
@@ -30,10 +30,15 @@ interface UseRVToolsJobReturn {
 export const useRVToolsJob = ({
   jobApi,
   onJobCompleted,
+  onDeleteAssessment,
 }: UseRVToolsJobProps): UseRVToolsJobReturn => {
   // RVTools Job State
   const [currentJob, setCurrentJob] = useState<Job | null>(null);
   const [jobPollingDelay, setJobPollingDelay] = useState<number | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [createError, setCreateError] = useState<Error | undefined>(undefined);
+  // AbortController ref to cancel in-flight API requests
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   // Job polling (separate from existing sources/assessments polling)
   useInterval(() => {
@@ -56,39 +61,112 @@ export const useRVToolsJob = ({
     }
   }, jobPollingDelay);
 
-  // Create RVTools job
-  const [createRVToolsJobState, createRVToolsJob] = useAsyncFnResetError(
-    async (name: string, file: File) => {
-      const job = await jobApi.createRVToolsAssessment({ name, file });
-      setCurrentJob(job);
-      setJobPollingDelay(JOB_POLLING_INTERVAL);
-      return job;
+  // Create RVTools job with AbortController support
+  const createRVToolsJob = useCallback(
+    async (name: string, file: File): Promise<Job | undefined> => {
+      // Abort any previous in-flight request
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+      // Create new AbortController for this request
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
+
+      setIsCreating(true);
+      setCreateError(undefined);
+
+      try {
+        const job = await jobApi.createRVToolsAssessment(
+          { name, file },
+          { signal: abortController.signal },
+        );
+
+        // Check if aborted before setting state - cancel the backend job if needed
+        if (abortController.signal.aborted) {
+          // Job was created on backend but user cancelled - cancel it
+          if (job?.id && !TERMINAL_JOB_STATUSES.includes(job.status)) {
+            jobApi.cancelJob({ id: job.id }).catch(() => {});
+          }
+          return undefined;
+        }
+
+        setCurrentJob(job);
+        setJobPollingDelay(JOB_POLLING_INTERVAL);
+        setIsCreating(false);
+        return job;
+      } catch (err) {
+        // Don't set error state if the request was aborted
+        if (abortController.signal.aborted) {
+          return undefined;
+        }
+        setCreateError(err as Error);
+        setIsCreating(false);
+        throw err;
+      }
     },
+    [jobApi],
   );
 
-  // Cancel job
+  // Cancel job and abort any in-flight requests
   const cancelRVToolsJob = useCallback(async () => {
-    if (currentJob && !TERMINAL_JOB_STATUSES.includes(currentJob.status)) {
+    // Abort any in-flight API request
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+      abortControllerRef.current = null;
+    }
+    if (currentJob) {
+      // Fetch latest job status from server (local state may be stale)
+      let latestJob: Job | null = null;
       try {
-        await jobApi.cancelJob({ id: currentJob.id });
+        latestJob = await jobApi.getJob({ id: currentJob.id });
       } catch (err) {
-        console.error('Failed to cancel job:', err);
+        // If we can't fetch, use local state
+        latestJob = currentJob;
+      }
+
+      if (!TERMINAL_JOB_STATUSES.includes(latestJob.status)) {
+        // Job is still running - cancel it
+        try {
+          await jobApi.cancelJob({ id: latestJob.id });
+        } catch (err) {
+          console.error('Failed to cancel job:', err);
+        }
+      } else if (
+        latestJob.status === JobStatus.Completed &&
+        latestJob.assessmentId &&
+        onDeleteAssessment
+      ) {
+        // Job already completed - delete the created assessment
+        try {
+          await onDeleteAssessment(latestJob.assessmentId);
+        } catch (err) {
+          console.error('Failed to delete assessment:', err);
+        }
       }
     }
     setCurrentJob(null);
     setJobPollingDelay(null);
-  }, [currentJob, jobApi]);
+    setIsCreating(false);
+    setCreateError(undefined);
+  }, [currentJob, jobApi, onDeleteAssessment]);
 
-  // Clear job state
+  // Clear job state and abort any in-flight requests
   const clearRVToolsJob = useCallback(() => {
+    // Abort any in-flight API request
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+      abortControllerRef.current = null;
+    }
     setCurrentJob(null);
     setJobPollingDelay(null);
+    setIsCreating(false);
+    setCreateError(undefined);
   }, []);
 
   return {
     currentJob,
-    isCreatingRVToolsJob: createRVToolsJobState.loading,
-    errorCreatingRVToolsJob: createRVToolsJobState.error as Error | undefined,
+    isCreatingRVToolsJob: isCreating,
+    errorCreatingRVToolsJob: createError,
     createRVToolsJob,
     cancelRVToolsJob,
     clearRVToolsJob,


### PR DESCRIPTION
Add AbortController support to cancel in-flight API requests when user closes the RVTools upload modal. This ensures the modal opens clean on reopen without stale loading state.

Also handles the race condition where the job completes between polling intervals by fetching the latest job status before cancelling. If the job already completed, the created assessment is automatically deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job cancellation now immediately aborts in-flight requests for faster cancellation and reduced resource usage
  * Assessments are automatically cleaned up when associated jobs are deleted or canceled, maintaining data consistency
  * Enhanced state management ensures proper resource cleanup during all cancellation operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->