### PR TITLE
ECOPROJECT-3300 | feat: Add host distribution by model to the report

### DIFF
--- a/src/components/MigrationDonutChart.tsx
+++ b/src/components/MigrationDonutChart.tsx
@@ -13,6 +13,7 @@ interface MigrationDonutChartProps {
   data: OSData[];
   legend?: Record<string, string>;
   customColors?: Record<string, string>;
+  legendWidth?: number;
   height?: number;
   width?: number;
   title?: string;
@@ -45,6 +46,7 @@ const MigrationDonutChart: React.FC<MigrationDonutChartProps> = ({
   data,
   legend,
   customColors,
+  legendWidth,
   height = 260,
   width = 420,
   title,
@@ -193,13 +195,15 @@ const MigrationDonutChart: React.FC<MigrationDonutChartProps> = ({
           display: 'flex',
           justifyContent: 'center',
           marginLeft: marginLeft,
+          overflowX: 'hidden',
+          overflowY: 'hidden',
         }}
       >
         <ChartLegend
           data={legendData}
           orientation="horizontal"
           height={200}
-          width={800}
+          width={legendWidth ?? 800}
           itemsPerRow={itemsPerRow}
           style={{
             labels: { fontSize: labelFontSize },

--- a/src/pages/report/assessment-report/Dashboard.tsx
+++ b/src/pages/report/assessment-report/Dashboard.tsx
@@ -17,6 +17,7 @@ import {
 import { ClustersOverview } from './ClustersOverview';
 import { CpuAndMemoryOverview } from './CpuAndMemoryOverview';
 import { ErrorTable } from './ErrorTable';
+import { HostsOverview } from './HostsOverview';
 import { NetworkOverview } from './NetworkOverview';
 import { OSDistribution } from './OSDistribution';
 import { StorageOverview } from './StorageOverview';
@@ -119,6 +120,7 @@ export const Dashboard: React.FC<Props> = ({
             </GalleryItem>
           </Gallery>
         </GridItem>
+
         <GridItem span={12} data-export-block={isExportMode ? '4' : undefined}>
           <Gallery hasGutter minWidths={{ default: '300px', md: '45%' }}>
             <GalleryItem>
@@ -132,6 +134,17 @@ export const Dashboard: React.FC<Props> = ({
                 clusters={clusters}
               />
             </GalleryItem>
+            <GalleryItem>
+              <HostsOverview
+                hosts={infra.hosts}
+                isExportMode={isExportMode}
+                exportAllViews={exportAllViews}
+              />
+            </GalleryItem>
+          </Gallery>
+        </GridItem>
+        <GridItem span={12} data-export-block={isExportMode ? '4' : undefined}>
+          <Gallery hasGutter minWidths={{ default: '300px', md: '45%' }}>
             <GalleryItem>
               <NetworkOverview infra={infra} isExportMode={isExportMode} />
             </GalleryItem>

--- a/src/pages/report/assessment-report/HostsOverview.tsx
+++ b/src/pages/report/assessment-report/HostsOverview.tsx
@@ -1,0 +1,149 @@
+import React, { useMemo } from 'react';
+
+import { Host } from '@migration-planner-ui/api-client/models';
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  Flex,
+  FlexItem,
+} from '@patternfly/react-core';
+
+import MigrationDonutChart from '../../../components/MigrationDonutChart';
+
+type HostLike = {
+  model?: unknown;
+};
+
+interface HostsOverviewProps {
+  hosts?: Array<Host>;
+  isExportMode?: boolean;
+  exportAllViews?: boolean;
+}
+
+// Keep the same extended palette style used by other overview widgets
+const colorPalette = [
+  '#0066cc',
+  '#5e40be',
+  '#b6a6e9',
+  '#73c5c5',
+  '#b98412',
+  '#28a745',
+  '#f0ad4e',
+  '#d9534f',
+  '#009596',
+  '#6a6e73',
+];
+
+export const HostsOverview: React.FC<HostsOverviewProps> = ({
+  hosts,
+  isExportMode = false,
+}) => {
+  const { slices, legend, totalHosts } = useMemo(() => {
+    const asArray: HostLike[] = Array.isArray(hosts)
+      ? (hosts as HostLike[])
+      : [];
+
+    // Build counts per model, defaulting to "Unknown model" if not available
+    const countsMap = asArray.reduce(
+      (acc, h) => {
+        const raw =
+          typeof h?.model === 'string'
+            ? h.model
+            : typeof h?.model === 'number'
+              ? String(h.model)
+              : '';
+        const name = raw && raw.trim() !== '' ? raw.trim() : 'Unknown model';
+        acc[name] = (acc[name] || 0) + 1;
+        return acc;
+      },
+      {} as Record<string, number>,
+    );
+
+    const entries = Object.entries(countsMap)
+      .map(([model, count]) => ({ model, count }))
+      .sort((a, b) => b.count - a.count);
+
+    const totalHosts = asArray.length;
+    const TOP_N = 5;
+    const top = entries.slice(0, TOP_N);
+    const rest = entries.slice(TOP_N);
+    const restSum = rest.reduce((acc, e) => acc + e.count, 0);
+
+    const slices = top.map((e) => ({
+      name: e.model,
+      count: e.count,
+      countDisplay: `${e.count} hosts`,
+      legendCategory: e.model,
+    }));
+    if (restSum > 0) {
+      slices.push({
+        name: 'Other models',
+        count: restSum,
+        countDisplay: `${restSum} hosts`,
+        legendCategory: 'Other models',
+      });
+    }
+
+    const legendCategories = slices.map((s) => s.legendCategory);
+    const legendMap: Record<string, string> = {};
+    legendCategories.forEach((cat, idx) => {
+      legendMap[cat] = colorPalette[idx % colorPalette.length];
+    });
+
+    return { slices, legend: legendMap, totalHosts };
+  }, [hosts]);
+
+  return (
+    <Card
+      className={isExportMode ? 'dashboard-card-print' : 'dashboard-card'}
+      id="hosts-overview"
+      style={{ overflow: 'hidden' }}
+    >
+      <CardTitle>
+        <Flex
+          justifyContent={{ default: 'justifyContentSpaceBetween' }}
+          alignItems={{ default: 'alignItemsCenter' }}
+          style={{ width: '100%' }}
+        >
+          <FlexItem>
+            <div>
+              <div>
+                <i className="fas fa-server" /> Host distribution by model
+              </div>
+              {!isExportMode && (
+                <div style={{ color: '#6a6e73', fontSize: '0.85rem' }}>
+                  Top 5 models
+                </div>
+              )}
+            </div>
+          </FlexItem>
+        </Flex>
+      </CardTitle>
+      <CardBody>
+        <MigrationDonutChart
+          data={slices}
+          height={300}
+          width={420}
+          donutThickness={9}
+          titleFontSize={34}
+          legend={legend}
+          legendWidth={680}
+          title={`${totalHosts}`}
+          subTitle="Hosts"
+          subTitleColor="#9a9da0"
+          itemsPerRow={2}
+          labelFontSize={16}
+          marginLeft="0%"
+          tooltipLabelFormatter={({ datum, percent }) =>
+            `${datum.countDisplay}\n${percent.toFixed(1)}%`
+          }
+        />
+      </CardBody>
+    </Card>
+  );
+};
+
+HostsOverview.displayName = 'HostsOverview';
+
+export default HostsOverview;


### PR DESCRIPTION
[ECOPROJECT-3300](https://issues.redhat.com//browse/ECOPROJECT-3300) | feat: Add host distribution by model to the report

Related to https://issues.redhat.com/browse/ECOPROJECT-3300

<img width="774" height="548" alt="image" src="https://github.com/user-attachments/assets/cc806c8f-7ede-4aa0-bfcc-951f3a36d860" />

Screen capture:

https://github.com/user-attachments/assets/9c36a952-b586-451d-b05b-1d41267459c5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Hosts Overview visualization to the assessment report dashboard, displaying host model distribution in an interactive donut chart with top models and aggregated "Other models" category.
  * Enhanced chart legend customization with configurable width for improved layout flexibility and readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->