### PR TITLE
ECOPROJECT-3299 | feat: add info about VMs distribution by NIC count in Network card

### DIFF
--- a/src/pages/report/assessment-report/Dashboard.tsx
+++ b/src/pages/report/assessment-report/Dashboard.tsx
@@ -146,7 +146,11 @@ export const Dashboard: React.FC<Props> = ({
         <GridItem span={12} data-export-block={isExportMode ? '4' : undefined}>
           <Gallery hasGutter minWidths={{ default: '300px', md: '45%' }}>
             <GalleryItem>
-              <NetworkOverview infra={infra} isExportMode={isExportMode} />
+              <NetworkOverview
+                infra={infra}
+                nicCount={vms.nicCount}
+                isExportMode={isExportMode}
+              />
             </GalleryItem>
           </Gallery>
         </GridItem>


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/ECOPROJECT-3299

Add info about VMs distribution by NIC count in Network card

<img width="770" height="534" alt="Captura desde 2025-12-24 11-38-10" src="https://github.com/user-attachments/assets/019a144f-fdce-4d05-a8c5-17d5ad532a9d" />


https://github.com/user-attachments/assets/ba6fdf8f-dd01-4829-995b-e88872ab5ac8



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NIC (Network Interface Card) count visualization to the assessment report dashboard.
  * Introduced a new view mode to display VM distribution by NIC count with a breakdown chart.
  * NIC count view option is now available when not in export mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->