### PR TITLE
ECOPROJECT-3671 | refactor: Simplify RVTools upload lifecycle and cancel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14029,11 +14029,10 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
       },

--- a/src/migration-wizard/contexts/discovery-sources/@types/DiscoverySources.d.ts
+++ b/src/migration-wizard/contexts/discovery-sources/@types/DiscoverySources.d.ts
@@ -114,6 +114,7 @@ declare namespace DiscoverySources {
     // RVTools Job Methods
     createRVToolsJob: (name: string, file: File) => Promise<Job | unknown>;
     cancelRVToolsJob: () => Promise<void>;
-    clearRVToolsJob: () => void;
+    // Callback setter for job success (navigation)
+    setOnJobSuccess?: (callback: (assessmentId: string) => void) => void;
   };
 }

--- a/src/migration-wizard/contexts/discovery-sources/Provider.tsx
+++ b/src/migration-wizard/contexts/discovery-sources/Provider.tsx
@@ -2,6 +2,7 @@ import React, {
   type PropsWithChildren,
   useCallback,
   useEffect,
+  useRef,
   useState,
 } from 'react';
 import { useAsyncFn, useInterval } from 'react-use';
@@ -16,7 +17,6 @@ import {
 import {
   Agent,
   Assessment,
-  JobStatus,
   Source,
   UpdateInventoryFromJSON,
 } from '@migration-planner-ui/api-client/models';
@@ -26,9 +26,9 @@ import { useInjection } from '@migration-planner-ui/ioc';
 import { useAsyncFnResetError } from '../../../hooks/useAsyncFnResetError';
 import { Symbols } from '../../../main/Symbols';
 
+import { useRVToolsJob } from '../../../pages/assessment/hooks/useRVToolsJob';
 import { DiscoverySources } from './@types/DiscoverySources';
 import { Context } from './Context';
-import { useRVToolsJob } from '../../../pages/assessment/hooks/useRVToolsJob';
 
 // Use a shared constant to avoid recreating empty array references on each render
 const EMPTY_ARRAY: unknown[] = [];
@@ -52,6 +52,9 @@ export const Provider: React.FC<PropsWithChildren> = (props) => {
   // It is used by sourceTable to show Back button.
   const [assessmentFromAgentState, setAssessmentFromAgent] =
     useState<boolean>(false);
+
+  // Callback ref for job success - set by consuming component (Assessment.tsx)
+  const onJobSuccessRef = useRef<((assessmentId: string) => void) | null>(null);
 
   const sourceApi = useInjection<SourceApiInterface>(Symbols.SourceApi);
   const agentsApi = useInjection<AgentApiInterface>(Symbols.AgentApi);
@@ -114,17 +117,35 @@ export const Provider: React.FC<PropsWithChildren> = (props) => {
     [assessmentApi, listAssessments],
   );
 
-  // RVTools Job State Hook
+  // Callback for successful job completion - calls the ref callback if set
+  const handleJobSuccess = useCallback(
+    (assessmentId: string) => {
+      listAssessments();
+      if (onJobSuccessRef.current) {
+        onJobSuccessRef.current(assessmentId);
+      }
+    },
+    [listAssessments],
+  );
+
+  // Setter for the success callback - used by consuming components
+  const setOnJobSuccess = useCallback(
+    (callback: (assessmentId: string) => void) => {
+      onJobSuccessRef.current = callback;
+    },
+    [],
+  );
+
+  // RVTools Job State Hook - uses onSuccess callback pattern
   const {
     currentJob,
     isCreatingRVToolsJob,
     errorCreatingRVToolsJob,
     createRVToolsJob,
     cancelRVToolsJob,
-    clearRVToolsJob,
   } = useRVToolsJob({
     jobApi,
-    onJobCompleted: listAssessments,
+    onSuccess: handleJobSuccess,
     onDeleteAssessment: handleDeleteAssessment,
   });
 
@@ -151,7 +172,6 @@ export const Provider: React.FC<PropsWithChildren> = (props) => {
         await listAssessments();
         return assessment;
       } else if (sourceType === 'rvtools') {
-        // RVTools assessments should use createRVToolsJob instead
         throw new Error(
           'RVTools assessments must be created using createRVToolsJob for async processing',
         );
@@ -691,7 +711,8 @@ export const Provider: React.FC<PropsWithChildren> = (props) => {
     // RVTools Job Methods
     createRVToolsJob,
     cancelRVToolsJob,
-    clearRVToolsJob,
+    // Callback setter for job success
+    setOnJobSuccess,
   };
 
   return <Context.Provider value={ctx}>{children}</Context.Provider>;

--- a/src/pages/assessment/Assessment.tsx
+++ b/src/pages/assessment/Assessment.tsx
@@ -1,10 +1,7 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import {
-  Assessment as AssessmentModel,
-  JobStatus,
-} from '@migration-planner-ui/api-client/models';
+import { Assessment as AssessmentModel } from '@migration-planner-ui/api-client/models';
 import {
   Button,
   Dropdown,
@@ -26,7 +23,6 @@ import FilterPill from '../../components/FilterPill';
 import { useDiscoverySources } from '../../migration-wizard/contexts/discovery-sources/Context';
 import StartingPageModal from '../starting-page/StartingPageModal';
 
-import { TERMINAL_JOB_STATUSES } from './utils/rvToolsJobUtils';
 import AssessmentsTable from './AssessmentsTable';
 import CreateAssessmentModal, { AssessmentMode } from './CreateAssessmentModal';
 import EmptyTableBanner from './EmptyTableBanner';
@@ -69,9 +65,6 @@ const Assessment: React.FC<Props> = ({
   const [selectedOwners, setSelectedOwners] = useState<string[]>([]);
 
   // Show the starting page modal only once on mount when there are no assessments.
-  // If the user has assessments, mark the modal as shown to prevent it from appearing
-  // after deleting the last assessment.
-  // hasShowStartingPageModal prevents the modal to pop up if the user deletes the last assessment.
   React.useEffect(() => {
     if (!isLoading) {
       if (assessments.length === 0 && !hasShownStartingPageModal.current) {
@@ -144,7 +137,6 @@ const Assessment: React.FC<Props> = ({
     errorCreatingRVToolsJob,
     createRVToolsJob,
     cancelRVToolsJob,
-    clearRVToolsJob,
   } = discoverySourcesContext;
 
   const handleOpenModal = (mode: AssessmentMode): void => {
@@ -153,36 +145,28 @@ const Assessment: React.FC<Props> = ({
     setIsDropdownOpen(false);
   };
 
-  // Handle modal close (X button) - should also cancel job if processing
+  // Handle modal close - cancel handles everything (running job or completed assessment)
   const handleCloseModal = useCallback((): void => {
-    if (currentJob && !TERMINAL_JOB_STATUSES.includes(currentJob.status)) {
-      cancelRVToolsJob(); // Cancel in-progress job
-    } else {
-      clearRVToolsJob(); // Just clear state if job is done
-    }
-    setIsModalOpen(false);
-  }, [currentJob, cancelRVToolsJob, clearRVToolsJob]);
-
-  // Cancel handler - actually cancels the job and closes modal
-  const handleCancelJob = useCallback(async (): Promise<void> => {
-    await cancelRVToolsJob();
+    cancelRVToolsJob();
     setIsModalOpen(false);
   }, [cancelRVToolsJob]);
 
-  // Handle job completion - navigate to report ONLY on success
-  useEffect(() => {
-    if (currentJob?.status === JobStatus.Completed && currentJob.assessmentId) {
-      const assessmentId = currentJob.assessmentId;
-      // Clear job state first
-      clearRVToolsJob();
-      // Close modal
+  // Handle successful job completion - navigate to report
+  // This is called by the hook's onSuccess callback via context
+  const handleJobSuccess = useCallback(
+    (assessmentId: string) => {
       setIsModalOpen(false);
-      // Navigate to report
       navigate(
         `/openshift/migration-assessment/assessments/${assessmentId}/report`,
       );
-    }
-  }, [currentJob, clearRVToolsJob, navigate]);
+    },
+    [navigate],
+  );
+
+  // Store the success handler in context for the hook to use
+  React.useEffect(() => {
+    discoverySourcesContext.setOnJobSuccess?.(handleJobSuccess);
+  }, [handleJobSuccess, discoverySourcesContext]);
 
   // Open RVTools modal when the trigger token changes
   React.useEffect(() => {
@@ -278,18 +262,13 @@ const Assessment: React.FC<Props> = ({
     }
   };
 
-  // Update submit handler for RVTools mode
-  // Modal stays open - progress bar will show job status
+  // Submit handler for RVTools mode - starts job, modal stays open
   const handleSubmitAssessment = async (
     name: string,
     file: File | null,
   ): Promise<void> => {
     if (!file) throw new Error('File is required for RVTools assessment');
-
-    // Start async job - modal stays open, progress bar appears
-    // Navigation happens via useEffect when job completes
     await createRVToolsJob(name, file);
-    // NOTE: Do NOT close modal or navigate here - wait for job completion
   };
 
   return (
@@ -568,7 +547,6 @@ const Assessment: React.FC<Props> = ({
         error={errorCreatingRVToolsJob}
         selectedEnvironment={null}
         job={currentJob}
-        onCancelJob={handleCancelJob}
       />
 
       <UpdateAssessment

--- a/src/pages/assessment/utils/rvToolsJobUtils.ts
+++ b/src/pages/assessment/utils/rvToolsJobUtils.ts
@@ -1,7 +1,7 @@
 import { JobStatus } from '@migration-planner-ui/api-client/models';
 
 // Constants for job polling
-export const JOB_POLLING_INTERVAL = 2000;
+export const JOB_POLLING_INTERVAL = 500;
 
 export const TERMINAL_JOB_STATUSES: JobStatus[] = [
   JobStatus.Completed,


### PR DESCRIPTION
Refactor the RVTools upload flow to use a callback-based pattern where the hook manages all job state and calls onSuccess only when job completes without cancel. This eliminates race conditions and scattered cancel logic.

Changes:
- useRVToolsJob: Use onSuccess(assessmentId) callback instead of onJobCompleted. Success callback only fires when job completes AND cancel wasn't requested (checked via synchronous ref).
- Assessment.tsx: Remove navigation useEffect, use setOnJobSuccess callback for navigation, simplify handleCloseModal to just call cancelRVToolsJob().
- CreateAssessmentModal: Remove onCancelJob prop, handleClose just resets form and calls onClose(). Parent handles all cancel logic.
- Provider.tsx: Update hook usage with new onSuccess callback pattern.

Fixes:
- Double cancel calls when closing modal
- Polling continues after cancel
- Navigation races with cancel when job completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable RVTools job handling to avoid race conditions; navigation to assessment results now triggers reliably when jobs complete.
  * Modal close behavior simplified and consistently cancels in-progress jobs.

* **Refactor**
  * Job lifecycle and callback wiring reworked to improve stability of submission and result navigation.

* **Chores**
  * Faster job polling interval for quicker job completion detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->