### PR TITLE
ECOPROJECT-3672 | fix: Increase job polling interval for RVTools

### DIFF
--- a/src/pages/assessment/utils/rvToolsJobUtils.ts
+++ b/src/pages/assessment/utils/rvToolsJobUtils.ts
@@ -1,7 +1,7 @@
 import { JobStatus } from '@migration-planner-ui/api-client/models';
 
 // Constants for job polling
-export const JOB_POLLING_INTERVAL = 500;
+export const JOB_POLLING_INTERVAL = 1000;
 
 export const TERMINAL_JOB_STATUSES: JobStatus[] = [
   JobStatus.Completed,


### PR DESCRIPTION
Updated the JOB_POLLING_INTERVAL constant from 500ms to 1000ms to reduce the frequency of job status checks, improving performance and reducing server load during RVTools operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated polling intervals for assessment job status checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->