### PR TITLE
NO-JIRA | refactor: Update jspdf dependency to version 4.0.0 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "github-markdown-css": "^5.8.1",
         "html2canvas-pro": "^1.6.0",
         "humanize-plus": "^1.8.2",
-        "jspdf": "^3.0.1",
+        "jspdf": "^4.0.0",
         "lodash": "^4.17.21",
         "react": "^18.3.1",
         "react-content-loader": "^6.2.0",
@@ -11162,9 +11162,9 @@
       }
     },
     "node_modules/jspdf": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.4.tgz",
-      "integrity": "sha512-dc6oQ8y37rRcHn316s4ngz/nOjayLF/FFxBF4V9zamQKRqXxyiH1zagkCdktdWhtoQId5K20xt1lB90XzkB+hQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.0.0.tgz",
+      "integrity": "sha512-w12U97Z6edKd2tXDn3LzTLg7C7QLJlx0BPfM3ecjK2BckUl9/81vZ+r5gK4/3KQdhAcEZhENUxRhtgYBj75MqQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "github-markdown-css": "^5.8.1",
     "html2canvas-pro": "^1.6.0",
     "humanize-plus": "^1.8.2",
-    "jspdf": "^3.0.1",
+    "jspdf": "^4.0.0",
     "lodash": "^4.17.21",
     "react": "^18.3.1",
     "react-content-loader": "^6.2.0",


### PR DESCRIPTION
- Addresses a critical severity vulnerability in jspdf: Local File Inclusion/Path Traversal vulnerability - https://github.com/advisories/GHSA-f8cm-6447-x5h2

Signed-off-by: Jonathan Kilzi <jkilzi@redhat.com>
