### PR TITLE
ECOPROJECT-3701 | fix: solving errors with network distribution by NIC count in Network card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "hasInstallScript": true,
       "dependencies": {
         "@emotion/css": "^11.13.0",
-        "@migration-planner-ui/api-client": "^0.0.35",
-        "@migration-planner-ui/ioc": "^0.0.35",
+        "@migration-planner-ui/api-client": "^0.0.36",
+        "@migration-planner-ui/ioc": "^0.0.36",
         "@patternfly/react-charts": "7.4.9",
         "@patternfly/react-core": "^6.2.2",
         "@patternfly/react-icons": "6.4.0",
@@ -1685,15 +1685,15 @@
       "license": "MIT"
     },
     "node_modules/@migration-planner-ui/api-client": {
-      "version": "0.0.35",
-      "resolved": "https://registry.npmjs.org/@migration-planner-ui/api-client/-/api-client-0.0.35.tgz",
-      "integrity": "sha512-7nhS8npat47VlVqJLc3U9kKQRUlj91yfgCHZsnDl8S7053WuTiJLgd+/GEP3X+kNVNE2bOC8CebtLjCrRvmmkA==",
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@migration-planner-ui/api-client/-/api-client-0.0.36.tgz",
+      "integrity": "sha512-rq3eGCHYEPa71TFfLP8hAwggXuS/nGbZqPRZ5dq5GRlFNo/0YAvAAIC1L8GpHRvv3I+NK0Pt0dPzrERn5YF90w==",
       "license": "Apache-2.0"
     },
     "node_modules/@migration-planner-ui/ioc": {
-      "version": "0.0.35",
-      "resolved": "https://registry.npmjs.org/@migration-planner-ui/ioc/-/ioc-0.0.35.tgz",
-      "integrity": "sha512-6e3sAmfWrJJOkbGlDnvG+FSvK4Vyn+cpQvvpkwYQWNm3QQ+vF/JHc2cdVozg9rr3LhAlQkFdRHKiDKsyd+45Kw==",
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@migration-planner-ui/ioc/-/ioc-0.0.36.tgz",
+      "integrity": "sha512-1RBnFjsR8mbvC9tz/cc4vPV65Su7AmqAhjdj/Nj+dkkUKoD723pd8S6qDBeC3GENkydXrDCqjdb7EACgpepkcQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   },
   "dependencies": {
     "@emotion/css": "^11.13.0",
-    "@migration-planner-ui/api-client": "^0.0.35",
-    "@migration-planner-ui/ioc": "^0.0.35",
+    "@migration-planner-ui/api-client": "^0.0.36",
+    "@migration-planner-ui/ioc": "^0.0.36",
     "@patternfly/react-charts": "7.4.9",
     "@patternfly/react-core": "^6.2.2",
     "@patternfly/react-icons": "6.4.0",

--- a/src/pages/report/assessment-report/Dashboard.tsx
+++ b/src/pages/report/assessment-report/Dashboard.tsx
@@ -191,6 +191,7 @@ export const Dashboard: React.FC<Props> = ({
               <NetworkOverview
                 infra={infra}
                 nicCount={vms.nicCount}
+                distributionByNicCount={vms.distributionByNicCount}
                 isExportMode={isExportMode}
                 exportAllViews={exportAllViews}
               />


### PR DESCRIPTION
Related with https://issues.redhat.com/browse/ECOPROJECT-3701

- For old assessments we need to use vms.nicCount.histogram to show this info
<img width="779" height="525" alt="Captura desde 2026-01-08 14-32-25" src="https://github.com/user-attachments/assets/24510453-ad41-44df-9a7d-766c8fe71d5d" />

- For new assessments we need to use vms.distributionByNicCount to show this info
<img width="779" height="525" alt="Captura desde 2026-01-08 14-27-20" src="https://github.com/user-attachments/assets/657ff624-af6c-430b-98aa-8464c51e9eb7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network Overview chart now supports explicit NIC-count distribution input, producing clearer NIC-count slices, consistent labeling, sorted bucket presentation, and accurate totals with a fallback to existing histogram data.

* **Chores**
  * Bumped two internal package versions to the latest patch releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->