### PR TITLE
ECOPROJECT-3782 | fix: Hosts and Networks cards fail to side-stack when filtering by specific cluster

### DIFF
--- a/src/pages/report/assessment-report/Dashboard.tsx
+++ b/src/pages/report/assessment-report/Dashboard.tsx
@@ -182,22 +182,36 @@ export const Dashboard: React.FC<Props> = ({
                   exportAllViews={exportAllViews}
                 />
               </GalleryItem>
+              <GalleryItem>
+                <NetworkOverview
+                  infra={infra}
+                  nicCount={vms.nicCount}
+                  distributionByNicCount={vms.distributionByNicCount}
+                  isExportMode={isExportMode}
+                  exportAllViews={exportAllViews}
+                />
+              </GalleryItem>
             </Gallery>
           </GridItem>
         )}
-        <GridItem span={12} data-export-block={isExportMode ? '4' : undefined}>
-          <Gallery hasGutter minWidths={{ default: '300px', md: '45%' }}>
-            <GalleryItem>
-              <NetworkOverview
-                infra={infra}
-                nicCount={vms.nicCount}
-                distributionByNicCount={vms.distributionByNicCount}
-                isExportMode={isExportMode}
-                exportAllViews={exportAllViews}
-              />
-            </GalleryItem>
-          </Gallery>
-        </GridItem>
+        {isAggregateView && (
+          <GridItem
+            span={12}
+            data-export-block={isExportMode ? '4a' : undefined}
+          >
+            <Gallery hasGutter minWidths={{ default: '300px', md: '45%' }}>
+              <GalleryItem>
+                <NetworkOverview
+                  infra={infra}
+                  nicCount={vms.nicCount}
+                  distributionByNicCount={vms.distributionByNicCount}
+                  isExportMode={isExportMode}
+                  exportAllViews={exportAllViews}
+                />
+              </GalleryItem>
+            </Gallery>
+          </GridItem>
+        )}
         <GridItem span={12} data-export-block={isExportMode ? '5' : undefined}>
           <Gallery hasGutter minWidths={{ default: '300px', md: '45%' }}>
             <GalleryItem>


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/ECOPROJECT-3782

In the assessment report, when we examine a specific cluster (not all clusters), the Clusters card is removed as expected, but the Hosts distribution by model and the Networks cards are placed one above the other instead of next to each other.


https://github.com/user-attachments/assets/491c9553-99a0-4084-b468-4ead44804639



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized Network Overview placement in the assessment report dashboard: the Network Overview now appears within both aggregate and non-aggregate layouts and is no longer shown as a standalone element.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->