### PR TITLE
ECOPROJECT-3704 | fix: use upgradeRecommendation field to show info about the OS that must be upgraded

### DIFF
--- a/src/components/MigrationChart.tsx
+++ b/src/components/MigrationChart.tsx
@@ -144,21 +144,13 @@ const MigrationChart: React.FC<MigrationChartProps> = ({
                             {item.name}
                           </Content>
                         </FlexItem>
-                        {item.infoText &&
-                        item.infoText !== '' &&
-                        item.infoText !== undefined ? (
+                        {item.infoText ? (
                           <FlexItem>
                             <Popover
                               className="upgrade-recommendation-popover"
                               position="bottom"
                               headerContent="Upgrade to get support"
-                              bodyContent={
-                                <div>
-                                  This operating system must be upgraded to a
-                                  supported version in order to be supported by
-                                  Red Hat.
-                                </div>
-                              }
+                              bodyContent={<div>{item.infoText}</div>}
                             >
                               <Button
                                 type="button"


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/ECOPROJECT-3704

Currently presenting the recommendation update is based on hard coded string for all the OSs. We can use more specific message that returns from the backend


https://github.com/user-attachments/assets/ebaeea9b-ab56-4b3c-bc3b-a415953cc6a0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Migration information popover now displays dynamic, context-specific content drawn from each item's data instead of a static message.

* **Bug Fixes**
  * Simplified conditional handling to ensure the popover only shows when relevant content exists.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->