### PR TITLE
ECOPROJECT-3572 | fix:OS Support Visualization Issue with High VM Count

### DIFF
--- a/src/components/MigrationChart.tsx
+++ b/src/components/MigrationChart.tsx
@@ -53,6 +53,8 @@ const MigrationChart: React.FC<MigrationChartProps> = ({
   maxHeight = '200px',
   barHeight = 8,
 }: MigrationChartProps) => {
+  // Ensure tiny percentages still render a visible colored segment
+  const MIN_BAR_PX = 3;
   const dynamicLegend = useMemo(() => {
     return data.reduce(
       (acc, current) => {
@@ -188,11 +190,13 @@ const MigrationChart: React.FC<MigrationChartProps> = ({
                               sumOfAllCounts > 0
                                 ? (item.count / sumOfAllCounts) * 100
                                 : 0;
+                            const hasValue = barWidth > 0;
                             return (
                               <div
                                 style={{
                                   height: '100%',
                                   width: `${barWidth}%`,
+                                  minWidth: hasValue ? `${MIN_BAR_PX}px` : '0',
                                   backgroundColor: `${getColor(
                                     item.legendCategory,
                                   )}`,


### PR DESCRIPTION
When the total number of virtual machines is high, the operating systems card does not display the supported/unsupported color (green/red) for small groups of operating systems

<img width="854" height="494" alt="Captura desde 2026-01-09 13-45-49" src="https://github.com/user-attachments/assets/aa596cde-82a5-4af4-9228-1b3fc09845e5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visibility of small data segments in the migration chart by ensuring minimal bar widths remain visible, making all percentage values discernible at a glance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->