### PR TITLE
ECOPROJECT-3543 | fix: avoid menu overflow in assesments and sources table

### DIFF
--- a/src/pages/assessment/AssessmentsTable.tsx
+++ b/src/pages/assessment/AssessmentsTable.tsx
@@ -318,7 +318,14 @@ export const AssessmentsTable: React.FC<Props> = ({
     );
   }
   return (
-    <div style={{ width: '100%', maxHeight: '450px', overflow: 'auto' }}>
+    <div
+      style={{
+        width: '100%',
+        maxHeight: '450px',
+        overflowY: 'auto',
+        overflowX: 'visible',
+      }}
+    >
       <Table
         aria-label="Assessments table"
         variant="compact"
@@ -431,7 +438,10 @@ export const AssessmentsTable: React.FC<Props> = ({
                   </Tooltip>
                   <Dropdown
                     isOpen={openDropdowns[row.id] || false}
-                    popperProps={{ appendTo: () => document.body }}
+                    popperProps={{
+                      appendTo: () => document.body,
+                      position: 'end',
+                    }}
                     onOpenChange={(isOpen) =>
                       setOpenDropdowns((prev) => ({
                         ...prev,

--- a/src/pages/environment/sources-table/SourcesTable.tsx
+++ b/src/pages/environment/sources-table/SourcesTable.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable simple-import-sort/imports */
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMount, useUnmount } from 'react-use';
@@ -21,10 +22,10 @@ import { useDiscoverySources } from '../../../migration-wizard/contexts/discover
 import { uploadInventoryFile } from '../../../utils/uploadInventory';
 
 import { UploadInventoryAction } from './actions/UploadInventoryAction';
-import { EmptyState } from './empty-state/EmptyState';
 import { AgentStatusView } from './AgentStatusView';
 import { Columns } from './Columns';
 import { DEFAULT_POLLING_DELAY, VALUE_NOT_AVAILABLE } from './Constants';
+import { EmptyState } from './empty-state/EmptyState';
 
 type SourceTableProps = {
   onUploadResult?: (message: string, isError?: boolean) => void;
@@ -453,7 +454,10 @@ export const SourcesTable: React.FC<SourceTableProps> = ({
                         ) : (
                           <Dropdown
                             isOpen={openDropdowns[source.id] || false}
-                            popperProps={{ appendTo: () => document.body }}
+                            popperProps={{
+                              appendTo: () => document.body,
+                              position: 'end',
+                            }}
                             onOpenChange={(isOpen) =>
                               setOpenDropdowns((prev) => ({
                                 ...prev,


### PR DESCRIPTION
The menu opened by clicking on the "three dots" (or ⋮) icon associated with each migration assessment row is displayed partially off-screen when clicked. We've solved this in assessments table and also in sources table:

<img width="1482" height="463" alt="Captura desde 2026-01-09 14-34-02" src="https://github.com/user-attachments/assets/4964ae01-3067-45ad-8117-91b360c92399" />

<img width="1482" height="463" alt="image" src="https://github.com/user-attachments/assets/b54e2d3f-ccaf-49ea-a410-4a4e722d25c1" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll behavior in data tables.
  * Enhanced dropdown menu positioning for better usability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->