### PR TITLE
ECOPROJECT-3803 | add missing UX data to the report

### DIFF
--- a/src/pages/report/Report.tsx
+++ b/src/pages/report/Report.tsx
@@ -150,6 +150,7 @@ const Inner: React.FC = () => {
     ? discoverySourcesContext.getSourceById(assessment.sourceId)
     : undefined;
   const agent = source?.agent;
+  const clusterCount = clusters ? Object.keys(clusters).length : 0;
 
   const handleClusterSelect = (
     _event: React.MouseEvent<Element, MouseEvent> | undefined,
@@ -232,6 +233,27 @@ const Inner: React.FC = () => {
             {lastUpdatedText !== '-'
               ? `Last updated: ${lastUpdatedText}`
               : '[Last updated time stamp]'}
+          </StackItem>
+          <StackItem>
+            {clusterCount > 0 ? (
+              typeof vms?.total === 'number' ? (
+                <>
+                  Detected <strong>{vms?.total} VMS</strong> in{' '}
+                  <strong>
+                    {clusterCount} {clusterCount === 1 ? 'cluster' : 'clusters'}
+                  </strong>
+                </>
+              ) : (
+                <>
+                  Detected{' '}
+                  <strong>
+                    {clusterCount} {clusterCount === 1 ? 'cluster' : 'clusters'}
+                  </strong>
+                </>
+              )
+            ) : (
+              'No clusters detected'
+            )}
           </StackItem>
           <StackItem>
             <Select


### PR DESCRIPTION
In the top of the report page we have to add info about the detected VMS and clusters

<img width="522" height="220" alt="Captura desde 2026-01-12 13-17-47" src="https://github.com/user-attachments/assets/89028d0f-4f7d-4685-94b4-0c4c1dc91efa" />
<img width="522" height="220" alt="Captura desde 2026-01-12 13-11-17" src="https://github.com/user-attachments/assets/14dfe08c-5750-4f38-bc3a-282ff05f726a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the report header to show cluster detection status. When clusters are present, displays the number of detected VMs (if available) and the cluster count with correct singular/plural phrasing. When no clusters are found, displays "No clusters detected."

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->