### PR TITLE
ECOPROJECT-3801 | feat: add vCenter report label to assessment report titles

### DIFF
--- a/src/pages/report/ExampleReport.tsx
+++ b/src/pages/report/ExampleReport.tsx
@@ -539,11 +539,11 @@ const ExampleReport: React.FC = () => {
         {
           key: 3,
           to: '#',
-          children: 'Example Report',
+          children: 'Example - vCenter report',
           isActive: true,
         },
       ]}
-      title="Example Report"
+      title="Example - vCenter report"
       caption={
         <>
           Discovery VM status :{' '}

--- a/src/pages/report/Report.tsx
+++ b/src/pages/report/Report.tsx
@@ -188,11 +188,11 @@ const Inner: React.FC = () => {
         {
           key: 3,
           to: '#',
-          children: `${assessment.name || `Assessment ${id}`} report`,
+          children: `${assessment.name || `Assessment ${id}`} - vCenter report`,
           isActive: true,
         },
       ]}
-      title={`${assessment.name || `Assessment ${id}`} report`}
+      title={`${assessment.name || `Assessment ${id}`} - vCenter report`}
       caption={
         <Stack>
           <StackItem>
@@ -327,7 +327,7 @@ const Inner: React.FC = () => {
                 }
                 sourceData={discoverySourcesContext.sourceSelected as Source}
                 snapshot={last}
-                documentTitle={`${assessment.name || `Assessment ${id}`}${
+                documentTitle={`${assessment.name || `Assessment ${id}`} - vCenter report${
                   clusterView.isAggregateView
                     ? ''
                     : ` - ${clusterView.selectionLabel}`


### PR DESCRIPTION
This change addresses the feedback that users were unclear about
what the cluster report related to. The 'vCenter report' label
is now appended to assessment names in:
- Page title
- Breadcrumb
- PDF export document title

Signed-off-by: Jonathan Kilzi <jkilzi@redhat.com>

<img width="1338" height="740" alt="image" src="https://github.com/user-attachments/assets/b25c6219-f907-4e41-ba76-1fe605bd4bd2" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated report page titles, breadcrumbs, and downloadable document titles to use the suffix " - vCenter report" for clearer, consistent naming. Cluster/selection labels are now consistently appended after that suffix when applicable. No runtime behavior or data handling changes—these are UI text and formatting updates only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->