### PR TITLE
ECOPROJECT-3793 | fix: disable file operations during RVTools job processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # vscode config
 # .vscode/*
+.cursor/**/*
 
 
 # ide config

--- a/src/pages/assessment/CreateAssessmentModal.tsx
+++ b/src/pages/assessment/CreateAssessmentModal.tsx
@@ -92,6 +92,10 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
   // Helper to check if job is processing
   const isJobProcessing = job && !TERMINAL_JOB_STATUSES.includes(job.status);
 
+  // Helper to check if file operations should be disabled (RVTools mode during job creation/processing)
+  const isFileOperationsDisabled =
+    mode === 'rvtools' && (isLoading || isJobProcessing);
+
   // Derive error from job failure
   const jobError = React.useMemo(() => {
     return job?.status === JobStatus.Failed
@@ -175,6 +179,11 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
     _event: React.ChangeEvent<HTMLInputElement> | React.DragEvent<HTMLElement>,
     file: File,
   ): void => {
+    // Prevent file changes during RVTools job creation/processing
+    if (isFileOperationsDisabled) {
+      return;
+    }
+
     setFileErrorDismissed(true);
 
     const maxSize = 52428800; // 50 MiB
@@ -208,6 +217,11 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
   };
 
   const handleFileClear = (): void => {
+    // Prevent file clearing during RVTools job creation/processing
+    if (isFileOperationsDisabled) {
+      return;
+    }
+
     setSelectedFile(null);
     setFilename('');
     setFileValidationError('');
@@ -283,12 +297,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
     >
       Create Migration Assessment
     </Button>,
-    <Button
-      key="cancel"
-      variant="link"
-      onClick={handleClose}
-      isDisabled={isLoading && !isJobProcessing}
-    >
+    <Button key="cancel" variant="link" onClick={handleClose}>
       Cancel
     </Button>,
     isJobProcessing && job && (
@@ -409,6 +418,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
               validated={fileValidationError ? 'error' : 'default'}
               accept={config.accept}
               hideDefaultPreview
+              isDisabled={isFileOperationsDisabled}
             />
             {fileValidationError && (
               <FormHelperText>


### PR DESCRIPTION
Added logic to prevent file changes and clearing during RVTools job creation or processing in the CreateAssessmentModal component. Updated the .gitignore to exclude cursor files.

Signed-off-by: Jonathan Kilzi <jkilzi@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File operations are now disabled while RVTools jobs are processing or loading, preventing user interactions with file uploads during active job execution.

* **Chores**
  * Updated ignore patterns for development environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->