### PR TITLE
ECOPROJECT-3587 | fix: add data to example report

### DIFF
--- a/src/pages/report/ExampleReport.tsx
+++ b/src/pages/report/ExampleReport.tsx
@@ -19,7 +19,7 @@ const inventoryData = {
   vcenterId: '502d878c-af91-4a6f-93e9-61c4a1986172',
   clusters: {
     'Cluster 1': {
-      infra: { host: Array(7).fill({}) },
+      infra: { cpuOverCommitment: 1.87, host: Array(7).fill({}) },
       vms: { total: 100 },
     },
     'Cluster 2': {
@@ -33,6 +33,7 @@ const inventoryData = {
     },
     infra: {
       clustersPerDatacenter: [2],
+      cpuOverCommitment: 1.87,
       datastores: [
         {
           diskId: 'mpx.vmhba0:C0:T1:L0',
@@ -216,72 +217,141 @@ const inventoryData = {
         yellow: 3,
       },
       hostsPerCluster: [7, 3],
+      hosts: [
+        {
+          cpuCores: 32,
+          cpuSockets: 2,
+          id: 'host-64',
+          memoryMB: 261797,
+          model: 'ProLiant DL380 Gen10',
+          vendor: 'HPE',
+        },
+        {
+          cpuCores: 32,
+          cpuSockets: 2,
+          id: 'host-36',
+          memoryMB: 261797,
+          model: 'ProLiant DL380 Gen10',
+          vendor: 'HPE',
+        },
+        {
+          cpuCores: 32,
+          cpuSockets: 2,
+          id: 'host-40',
+          memoryMB: 261797,
+          model: 'ProLiant DL380 Gen10',
+          vendor: 'HPE',
+        },
+        {
+          cpuCores: 32,
+          cpuSockets: 2,
+          id: 'host-3152',
+          memoryMB: 261797,
+          model: 'ProLiant DL380 Gen10',
+          vendor: 'HPE',
+        },
+        {
+          cpuCores: 32,
+          cpuSockets: 2,
+          id: 'host-12657',
+          memoryMB: 261797,
+          model: 'ProLiant DL380 Gen10',
+          vendor: 'HPE',
+        },
+        {
+          cpuCores: 32,
+          cpuSockets: 2,
+          id: 'host-12642',
+          memoryMB: 261797,
+          model: 'ProLiant DL380 Gen10',
+          vendor: 'HPE',
+        },
+        {
+          cpuCores: 32,
+          cpuSockets: 2,
+          id: 'host-3078',
+          memoryMB: 261797,
+          model: 'ProLiant DL380 Gen10',
+          vendor: 'HPE',
+        },
+      ],
       networks: [
         {
           dvswitch: '',
           name: 'vDSwitch0',
           type: 'dvswitch',
           vlanId: '',
+          vmsCount: 0,
         },
         {
           dvswitch: 'vDSwitch0',
           name: 'v371_10.46.49.x',
           type: 'distributed',
           vlanId: '371',
+          vmsCount: 121,
         },
         {
           dvswitch: 'vDSwitch0',
           name: 'VM Network',
           type: 'distributed',
           vlanId: '341',
+          vmsCount: 7,
         },
         {
           dvswitch: 'vDSwitch0',
           name: '3par_net1',
           type: 'distributed',
           vlanId: '',
+          vmsCount: 32,
         },
         {
           dvswitch: 'vDSwitch0',
           name: 'v375_10.46.52.x',
           type: 'distributed',
           vlanId: '375',
+          vmsCount: 0,
         },
         {
           dvswitch: 'vDSwitch0',
           name: 'Management Network',
           type: 'distributed',
           vlanId: '341',
+          vmsCount: 2,
         },
         {
           dvswitch: 'vDSwitch0',
           name: 'vDSwitch0-DVUplinks',
           type: 'distributed',
           vlanId: '0-4094',
+          vmsCount: 0,
         },
         {
           dvswitch: 'vDSwitch0',
           name: 'v376_10.46.52.128/25',
           type: 'distributed',
           vlanId: '376',
+          vmsCount: 0,
         },
         {
           dvswitch: 'vDSwitch0',
           name: 'vMotion',
           type: 'distributed',
           vlanId: '375',
+          vmsCount: 0,
         },
         {
           dvswitch: 'vDSwitch0',
           name: 'v374_10.46.53.125/25',
           type: 'distributed',
           vlanId: '374',
+          vmsCount: 0,
         },
         {
           dvswitch: 'vDSwitch0',
           name: 'v370_10.46.48.x',
           type: 'distributed',
           vlanId: '370',
+          vmsCount: 0,
         },
         {
           dvswitch: 'vDSwitch0',
@@ -294,24 +364,28 @@ const inventoryData = {
           name: 'eco-gpfs-net01',
           type: 'distributed',
           vlanId: '',
+          vmsCount: 0,
         },
         {
           dvswitch: '',
           name: 'test-dummy-dswitch',
           type: 'dvswitch',
           vlanId: '',
+          vmsCount: 0,
         },
         {
           dvswitch: 'test-dummy-dswitch',
           name: 'test-dummy-dswit-DVUplinks-52745',
           type: 'distributed',
           vlanId: '0-4094',
+          vmsCount: 0,
         },
         {
           dvswitch: 'test-dummy-dswitch',
           name: 'DPortGroup',
           type: 'distributed',
           vlanId: '',
+          vmsCount: 0,
         },
       ],
       totalClusters: 2,
@@ -370,6 +444,29 @@ const inventoryData = {
           totalSizeTB: 2900.98,
           vmCount: 36,
         },
+      },
+      diskTypes: {
+        NFS: {
+          totalSizeTB: 0.16,
+          vmCount: 2,
+        },
+        VMFS: {
+          totalSizeTB: 16.33,
+          vmCount: 186,
+        },
+      },
+      distributionByCpuTier: {
+        '0-4': 76,
+        '17-32': 8,
+        '5-8': 80,
+        '9-16': 32,
+      },
+      distributionByMemoryTier: {
+        '0-4': 8,
+        '17-32': 64,
+        '33-64': 48,
+        '5-16': 64,
+        '65-128': 12,
       },
       migrationWarnings: [
         {
@@ -457,6 +554,17 @@ const inventoryData = {
           label: 'Disk - scsi0:4 does not have CBT enabled',
         },
       ],
+      nicCount: {
+        histogram: {
+          data: [3, 185, 8, 0, 1, 0, 3],
+          minValue: 0,
+          step: 1,
+        },
+        total: 223,
+        totalForMigratable: 0,
+        totalForMigratableWithWarnings: 214,
+        totalForNotMigratable: 9,
+      },
       notMigratableReasons: [
         {
           assessment:
@@ -465,30 +573,121 @@ const inventoryData = {
           label: 'Independent disk detected',
         },
       ],
-      os: {
-        'AlmaLinux (64-bit)': 1,
-        'Amazon Linux 2 (64-bit)': 1,
-        'CentOS 7 (64-bit)': 1,
-        'CentOS 8 (64-bit)': 1,
-        'Data ONTAP9.15.1': 1,
-        'Debian GNU/Linux 12 (64-bit)': 1,
-        'Debian GNU/Linux 7 (64-bit)': 1,
-        'Microsoft Windows 10 (64-bit)': 4,
-        'Microsoft Windows 11 (64-bit)': 2,
-        'Microsoft Windows Server 2019 (64-bit)': 4,
-        'Microsoft Windows Server 2022 (64-bit)': 3,
-        'Microsoft Windows Server 2025 (64-bit)': 2,
-        'Other (32-bit)': 7,
-        'Other 2.6.x Linux (64-bit)': 16,
-        'Other 3.x or later Linux (64-bit)': 1,
-        'Other 5.x Linux (64-bit)': 1,
-        'Other Linux (64-bit)': 2,
-        'Red Hat Enterprise Linux 8 (64-bit)': 49,
-        'Red Hat Enterprise Linux 9 (64-bit)': 59,
-        'Red Hat Fedora (64-bit)': 21,
-        'Ubuntu Linux (64-bit)': 4,
-        'VMware ESXi 8.0 or later': 7,
-        'VMware Photon OS (64-bit)': 3,
+      osInfo: {
+        '': {
+          count: 2,
+          supported: false,
+        },
+        'AlmaLinux (64-bit)': {
+          count: 1,
+          supported: false,
+        },
+        'Amazon Linux 2 (64-bit)': {
+          count: 2,
+          supported: false,
+          upgradeRecommendation:
+            'The guest operating system: Amazon Linux 2 (64-bit) is not currently supported. The operating system can be upgraded to Red Hat Enterprise Linux 8',
+        },
+        'CentOS 7 (64-bit)': {
+          count: 1,
+          supported: false,
+          upgradeRecommendation:
+            'The guest operating system: CentOS 7 (64-bit) is not currently supported. The operating system can be upgraded to Red Hat Enterprise Linux 7',
+        },
+        'CentOS 8 (64-bit)': {
+          count: 1,
+          supported: false,
+          upgradeRecommendation:
+            'The guest operating system: CentOS 8 (64-bit) is not currently supported. The operating system can be upgraded to Red Hat Enterprise Linux 8',
+        },
+        'Data ONTAP9.15.1': {
+          count: 1,
+          supported: false,
+        },
+        'Debian GNU/Linux 12 (64-bit)': {
+          count: 1,
+          supported: false,
+        },
+        'Debian GNU/Linux 9 (64-bit)': {
+          count: 1,
+          supported: false,
+        },
+        'FreeBSD Pre-11 versions (64-bit)': {
+          count: 1,
+          supported: false,
+        },
+        'Microsoft Windows 10 (64-bit)': {
+          count: 4,
+          supported: true,
+        },
+        'Microsoft Windows 11 (64-bit)': {
+          count: 3,
+          supported: true,
+        },
+        'Microsoft Windows Server 2019 (64-bit)': {
+          count: 4,
+          supported: true,
+        },
+        'Microsoft Windows Server 2022 (64-bit)': {
+          count: 3,
+          supported: true,
+        },
+        'Microsoft Windows Server 2025 (64-bit)': {
+          count: 2,
+          supported: true,
+        },
+        'Other (32-bit)': {
+          count: 7,
+          supported: false,
+        },
+        'Other 2.6.x Linux (64-bit)': {
+          count: 19,
+          supported: false,
+        },
+        'Other 3.x or later Linux (64-bit)': {
+          count: 1,
+          supported: false,
+        },
+        'Other 5.x Linux (64-bit)': {
+          count: 1,
+          supported: false,
+        },
+        'Other Linux (64-bit)': {
+          count: 2,
+          supported: false,
+        },
+        'Red Hat Enterprise Linux 7 (64-bit)': {
+          count: 1,
+          supported: true,
+        },
+        'Red Hat Enterprise Linux 8 (64-bit)': {
+          count: 45,
+          supported: true,
+        },
+        'Red Hat Enterprise Linux 9 (64-bit)': {
+          count: 76,
+          supported: true,
+        },
+        'Red Hat Fedora (32-bit)': {
+          count: 1,
+          supported: false,
+        },
+        'Red Hat Fedora (64-bit)': {
+          count: 6,
+          supported: false,
+        },
+        'Ubuntu Linux (64-bit)': {
+          count: 5,
+          supported: false,
+        },
+        'VMware ESXi 8.0 or later': {
+          count: 5,
+          supported: false,
+        },
+        'VMware Photon OS (64-bit)': {
+          count: 4,
+          supported: false,
+        },
       },
       powerStates: {
         poweredOff: 116,


### PR DESCRIPTION
In the example report we have to add some missing data.

<img width="1547" height="691" alt="image" src="https://github.com/user-attachments/assets/857f2a7e-ff5d-436b-82c7-d13903d5c827" />

For example, for Operating Systems we need to add unsupported OS. And also add info for other fields like cpuOverCommitment, distributionByCpuTier, distributionByMemoryTier ....

<img width="774" height="524" alt="image" src="https://github.com/user-attachments/assets/f5b6b86c-0d51-44d8-ae94-f71600bfd2e5" />
<img width="774" height="524" alt="image" src="https://github.com/user-attachments/assets/49c4df1c-c99e-42fe-a7a9-0aa1150ffb0b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced infrastructure reporting with CPU over-commitment metrics for better capacity visibility.
  * Expanded host inventory details including CPU cores, sockets, memory, and hardware specifications.
  * Added VM inventory statistics with disk type distribution and CPU/memory tier breakdown.
  * Improved OS tracking with support status and upgrade recommendations.
  * Enhanced migration analytics with network interface count data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->