### PR TITLE
ECOPROJECT-3828 | fix: incorrect Discovery VM status in report

### DIFF
--- a/src/pages/report/Report.tsx
+++ b/src/pages/report/Report.tsx
@@ -64,6 +64,12 @@ const Inner: React.FC = () => {
     ) {
       await discoverySourcesContext.listAssessments();
     }
+    if (
+      !discoverySourcesContext.sources ||
+      discoverySourcesContext.sources.length === 0
+    ) {
+      await discoverySourcesContext.listSources();
+    }
   });
 
   const assessment = discoverySourcesContext.assessments.find(


### PR DESCRIPTION
While testing the ova agent flow, I created a new environment and logged in with the vcenter credentials - it then moved from 'Waiting for credentials' to "Ready". also it is reflected when we make an api call to it:

```
$ curl -k https://<vm-agent-ip>:3333/api/v1/status | jq {
 "status": "up-to-date",
 "connected": "true",
 "statusInfo": "Inventory successfully collected",
 "agentStateUpdateSuccessful": "true",
 "inventoryUpdateSuccessful": "true"
}
```
We then created a new assessment from this environment, and the report generated was showing the Discovery VM status as 'Not connected' although it is. We've solved this issue.

<img width="728" height="227" alt="Captura desde 2026-01-13 16-06-18" src="https://github.com/user-attachments/assets/8c069061-5add-46aa-95bf-deef8a1a79dd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where discovery sources could be missing or empty on initialization. The application now ensures sources are properly populated during startup before proceeding with other operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->