### PR TITLE
ECOPROJECT-3587 | fix: fixing Discovery VM status in example report page

### DIFF
--- a/src/pages/report/ExampleReport.tsx
+++ b/src/pages/report/ExampleReport.tsx
@@ -749,7 +749,7 @@ const ExampleReport: React.FC = () => {
           <Icon size="md" isInline>
             <CheckCircleIcon color={globalSuccessColor100.value} />
           </Icon>{' '}
-          Connected
+          Ready
           <br />
           This is an example report showcasing the migration assessment
           dashboard


### PR DESCRIPTION
When using agent ova flow the Discovery VM status should be 'Ready' and not 'Connected'

<img width="1152" height="157" alt="image" src="https://github.com/user-attachments/assets/a93c7535-5c07-49d5-b38f-e8adcce714c3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated status label text to correctly reflect the current state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->