### PR TITLE
ECOPROJECT-3829 | fix: fixings errors in breadcrumbs

### DIFF
--- a/src/pages/MigrationAssessmentPage.tsx
+++ b/src/pages/MigrationAssessmentPage.tsx
@@ -223,7 +223,6 @@ const MigrationAssessmentPage: React.FC = () => (
     breadcrumbs={[
       {
         key: 1,
-        to: '#',
         children: 'Migration assessment',
         isActive: true,
       },

--- a/src/pages/MigrationWizardPage.tsx
+++ b/src/pages/MigrationWizardPage.tsx
@@ -12,7 +12,7 @@ const MigrationWizardPage: React.FC = () => {
           to: '/openshift/migration-assessment',
           children: 'Migration assessment',
         },
-        { key: 2, to: '#', children: 'Guide', isActive: true },
+        { key: 2, children: 'Guide', isActive: true },
       ]}
       title="Welcome, let's start your migration journey from VMware to OpenShift."
     >

--- a/src/pages/assessment/AssessmentDetails.tsx
+++ b/src/pages/assessment/AssessmentDetails.tsx
@@ -99,7 +99,7 @@ const AssessmentDetails: React.FC = () => {
             to: '/openshift/migration-assessment/assessments',
             children: 'assessments',
           },
-          { key: 3, to: '#', children: 'Assessment not found', isActive: true },
+          { key: 3, children: 'Assessment not found', isActive: true },
         ]}
         title="Assessment details"
       >
@@ -149,7 +149,6 @@ const AssessmentDetails: React.FC = () => {
         },
         {
           key: 3,
-          to: '#',
           children: assessment.name || `Assessment ${id}`,
           isActive: true,
         },

--- a/src/pages/assessment/CreateFromOva.tsx
+++ b/src/pages/assessment/CreateFromOva.tsx
@@ -203,7 +203,7 @@ const CreateFromOva: React.FC = () => {
           to: '/openshift/migration-assessment/',
           children: 'assessments',
         },
-        { key: 3, to: '#', isActive: true, children: 'create new assessment' },
+        { key: 3, isActive: true, children: 'create new assessment' },
       ]}
       title="Create new migration assessment"
     >

--- a/src/pages/report/ExampleReport.tsx
+++ b/src/pages/report/ExampleReport.tsx
@@ -737,7 +737,6 @@ const ExampleReport: React.FC = () => {
         },
         {
           key: 3,
-          to: '#',
           children: 'Example - vCenter report',
           isActive: true,
         },

--- a/src/pages/report/Report.tsx
+++ b/src/pages/report/Report.tsx
@@ -98,7 +98,7 @@ const Inner: React.FC = () => {
             to: '/openshift/migration-assessment/assessments',
             children: 'assessments',
           },
-          { key: 3, to: '#', children: 'Assessment not found', isActive: true },
+          { key: 3, children: 'Assessment not found', isActive: true },
         ]}
         title="Assessment details"
       >
@@ -194,7 +194,6 @@ const Inner: React.FC = () => {
         },
         {
           key: 3,
-          to: '#',
           children: `${assessment.name || `Assessment ${id}`} - vCenter report`,
           isActive: true,
         },


### PR DESCRIPTION
When viewing an assessment report page, clicking the assessment name in the breadcrumb (the rightmost item) navigates the user to the base stage URL, completely outside of the migration-assessment application. 
Remove to: '#' from active breadcrumb items. PatternFly's BreadcrumbItem with isActive: true and no to prop renders as non-clickable text. 
Now active breadcrumbs no longer navigate or appear clickable.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Navigation Updates**
  * Breadcrumb items across migration assessment, migration guide, assessment details, assessment creation, and report pages are now non-clickable labels, removing navigation targets from specific breadcrumb entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->