### PR TITLE
ECOPROJECT-3874 | fix: show errors when user tries to upload old inventory files

### DIFF
--- a/src/migration-wizard/contexts/discovery-sources/@types/DiscoverySources.d.ts
+++ b/src/migration-wizard/contexts/discovery-sources/@types/DiscoverySources.d.ts
@@ -36,7 +36,7 @@ declare namespace DiscoverySources {
     selectSource: (source: Source) => void;
     selectSourceById: (sourceId: string) => void;
     getSourceById: (sourceId: string) => Source;
-    updateInventory: (sourceId: string, jsonValue: string) => void;
+    updateInventory: (sourceId: string, jsonValue: string) => Promise<Source>;
     isUpdatingInventory: boolean;
     errorUpdatingInventory?: Error;
     downloadSourceUrl?: string;

--- a/src/pages/assessment/CreateFromOva.tsx
+++ b/src/pages/assessment/CreateFromOva.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import {
+  ActionGroup,
   Alert,
   AlertActionLink,
   Button,
@@ -41,6 +42,8 @@ const CreateFromOva: React.FC = () => {
     React.useState<boolean>(false);
   const [isCreatingSource, setIsCreatingSource] =
     React.useState<boolean>(false);
+  const [uploadMessage, setUploadMessage] = React.useState<string | null>(null);
+  const [isUploadError, setIsUploadError] = React.useState<boolean>(false);
 
   const createdSourceId = discoverySourcesContext.sourceCreatedId || '';
   const createdSource = createdSourceId
@@ -104,6 +107,12 @@ const CreateFromOva: React.FC = () => {
       // ignore storage failures
     }
   }, [name, useExisting, selectedEnvironmentId]);
+
+  // Clear any upload status messages when switching environments
+  React.useEffect(() => {
+    setUploadMessage(null);
+    setIsUploadError(false);
+  }, [selectedEnvironmentId]);
 
   React.useEffect(() => {
     if (discoverySourcesContext.assessmentFromAgentState) {
@@ -257,7 +266,7 @@ const CreateFromOva: React.FC = () => {
             </ol>
           </Content>
 
-          <div style={{ marginTop: '16px' }}>
+          <div className="pf-v6-u-mt-md">
             <Checkbox
               id="use-existing-env"
               label="Select existing environment"
@@ -292,23 +301,45 @@ const CreateFromOva: React.FC = () => {
             </FormGroup>
           )}
           {isCreatingSource && (
-            <div style={{ marginTop: '16px' }}>
+            <div className="pf-v6-u-mt-md">
               <Spinner />
             </div>
           )}
           {useExisting && selectedEnvironmentId && !isCreatingSource && (
-            <div style={{ marginTop: '16px' }}>
+            <div className="pf-v6-u-mt-md">
               <SourcesTable
                 onlySourceId={selectedEnvironmentId}
                 uploadOnly={true}
+                onUploadResult={(message, isError) => {
+                  setUploadMessage(message ?? null);
+                  setIsUploadError(Boolean(isError));
+                }}
                 onUploadSuccess={async () => {
                   await discoverySourcesContext.listSources();
                 }}
               />
             </div>
           )}
+          {uploadMessage && (
+            <div className="pf-v6-u-mt-md">
+              <Alert
+                isInline
+                variant={isUploadError ? 'danger' : 'success'}
+                title={isUploadError ? 'Upload error' : 'Upload success'}
+              >
+                {uploadMessage}
+              </Alert>
+            </div>
+          )}
+          {!uploadMessage && discoverySourcesContext.errorUpdatingInventory && (
+            <div className="pf-v6-u-mt-md">
+              <Alert isInline variant="danger" title="Upload error">
+                {discoverySourcesContext.errorUpdatingInventory.message}
+              </Alert>
+            </div>
+          )}
           {!isCreatingSource && (
-            <div style={{ marginTop: '8px' }}>
+            <div className="pf-v6-u-mt-sm">
               <Button
                 variant="secondary"
                 onClick={() => setIsSetupModalOpen(true)}
@@ -319,7 +350,7 @@ const CreateFromOva: React.FC = () => {
             </div>
           )}
           {createdSource?.agent?.status === 'waiting-for-credentials' && (
-            <div style={{ marginTop: '16px' }}>
+            <div className="pf-v6-u-mt-md">
               <Alert
                 isInline
                 variant="custom"
@@ -347,7 +378,7 @@ const CreateFromOva: React.FC = () => {
             </div>
           )}
 
-          <div style={{ marginTop: '24px', display: 'flex', gap: '12px' }}>
+          <ActionGroup className="pf-v6-u-mt-lg">
             <Button
               variant="primary"
               isDisabled={
@@ -361,7 +392,7 @@ const CreateFromOva: React.FC = () => {
             <Button variant="link" onClick={handleCancel}>
               Cancel
             </Button>
-          </div>
+          </ActionGroup>
         </Form>
 
         {isSetupModalOpen && (


### PR DESCRIPTION
We are now preventing from the user to upload an old inventory that does not include the proper structure added in the last sprint.

Currently, when a user will try to upload an old inventory, the backend will show a proper message:

`API Error: request body has an error: doesn't match schema #/components/schemas/UpdateInventory: Error at "/inventory/vcenter/vms": property "vms" is missing `

but the UI show the user that the upload was successful (although nothing happend and the environment is still with status "Not connected"). We've added an error alert to the users in these cases.

<img width="931" height="430" alt="image" src="https://github.com/user-attachments/assets/f9943509-cf71-4409-9bca-b7f03246bbcf" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer, more user-friendly error messages for upload failures, server-side errors, and missing/invalid content.
  * Explicit handling and reporting for unsupported or malformed upload formats and legacy schema imports.
  * More robust handling of backend update failures with improved error reporting.

* **New Features**
  * Inline success and failure alerts shown after uploads.
  * Upload flow reliably refreshes source listings on successful import.

* **Style**
  * Improved UI layout and spacing for upload sections and action areas.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->