### PR TITLE
ECOPROJECT-3798 | fix: add RVTools prerequisites to the upload modal in the UI

### DIFF
--- a/src/pages/assessment/CreateAssessmentModal.tsx
+++ b/src/pages/assessment/CreateAssessmentModal.tsx
@@ -136,6 +136,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
     fileDescription: string;
     allowedExtensions: string[];
     accept: string;
+    fileLink?: string;
   } => {
     switch (mode) {
       case 'inventory':
@@ -153,6 +154,8 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
           fileDescription: 'Select an Excel file from RVTools (max 50 MiB)',
           accept: '.xlsx,.xls',
           allowedExtensions: ['xlsx', 'xls'],
+          fileLink:
+            'https://kubev2v.github.io/assisted-migration-docs/docs/tutorial/#prerequisites-rvtools-file-requirements',
         };
       case 'agent':
         return {
@@ -403,6 +406,16 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
               }}
             >
               {config.fileDescription}
+              <br />
+              {config.fileLink && (
+                <a
+                  href={config.fileLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  RVTools File Requirements
+                </a>
+              )}
             </div>
             <FileUpload
               id="assessment-file"


### PR DESCRIPTION
We decided to add a link to the RVTools File Requirements page in the blog: https://kubev2v.github.io/assisted-migration-docs/docs/tutorial/#prerequisites-rvtools-file-requirements

<img width="826" height="380" alt="image" src="https://github.com/user-attachments/assets/d5e5912d-4b95-4139-aa1c-9d6943c78c2c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assessment creation modal now displays optional file requirement links to assist users during setup. For RVTools assessments, users can access a direct link to comprehensive file requirements documentation positioned beneath the file description. This helps users quickly understand required file formats, specifications, and other important technical details before uploading files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->