### PR TITLE
ECOPROJECT-3870 | feat: Enhance snapshot validation for legacy inventory schema

### DIFF
--- a/.cursor/plans/ecoproject-3870_fix_plan_7acf8795.plan.md
+++ b/.cursor/plans/ecoproject-3870_fix_plan_7acf8795.plan.md
@@ -1,0 +1,51 @@
+---
+name: ECOPROJECT-3870 fix plan
+overview: Adjust the assessment data validation to recognize legacy v1 inventory shapes so old assessments can open their reports without warnings or disabled actions.
+todos:
+  - id: update-validation
+    content: Expand hasUsefulData for legacy inventory shapes
+    status: completed
+  - id: add-tests
+    content: Add unit tests for legacy snapshots behavior
+    status: completed
+  - id: sanity-check
+    content: Verify AssessmentsTable uses new logic for report availability
+    status: completed
+---
+
+# Plan
+
+## Context
+
+- Current report availability is driven by `hasUsefulData()` in [`src/pages/assessment/utils/snapshotParser.ts`](src/pages/assessment/utils/snapshotParser.ts), which only checks `lastSnapshot.inventory?.clusters`.
+- The attached legacy v1 inventory example (`old-inventory-scheme.json`) has useful data under `inventory.infra` and `inventory.vms` but no `inventory.clusters`, so it is incorrectly flagged as unusable.
+- The report itself already handles legacy inventory shapes (`inventory.infra`, `inventory.vcenter.infra`, `snapshot.infra`, etc.) in [`src/pages/report/Report.tsx`](src/pages/report/Report.tsx).
+
+## Approach
+
+1. Update `hasUsefulData()` to treat a snapshot as “useful” if any legacy inventory paths are present on the latest snapshot:
+
+- `lastSnapshot.inventory?.clusters` (current behavior)
+- `lastSnapshot.inventory?.vcenter?.infra` or `lastSnapshot.inventory?.vcenter?.vms`
+- `lastSnapshot.inventory?.infra` or `lastSnapshot.inventory?.vms` (matches legacy v1 JSON example)
+- `lastSnapshot.infra` or `lastSnapshot.vms` (top-level legacy)
+
+2. Keep the logic “latest snapshot only” but ensure it’s aligned with what the report can render, so old v1 assessments are no longer blocked.
+
+3. Add unit tests for the updated behavior in a new test file (e.g., [`src/pages/assessment/utils/snapshotParser.test.ts`](src/pages/assessment/utils/snapshotParser.test.ts)):
+
+- returns `false` with no snapshots
+- returns `true` when `inventory.vcenter.infra` exists but `inventory.clusters` is missing
+- returns `true` when `inventory.infra`/`inventory.vms` exist (legacy v1 example)
+- returns `true` when top-level `infra`/`vms` exist
+- returns `false` when latest snapshot lacks any expected inventory fields
+
+## Notes
+
+- This keeps the UI warnings and disabled actions tied strictly to “no usable inventory” rather than “no clusters field,” which is what breaks legacy v1 data.
+- If we later decide to consider “any snapshot” (not only latest) as usable, we can extend the logic, but that’s not required to fix ECOPROJECT-3870.
+
+## Files to change
+
+- [`src/pages/assessment/utils/snapshotParser.ts`](src/pages/assessment/utils/snapshotParser.ts)
+- [`src/pages/assessment/utils/snapshotParser.test.ts`](src/pages/assessment/utils/snapshotParser.test.ts)

--- a/.cursor/plans/ecoproject-3870_v1-v2_check_2807bd84.plan.md
+++ b/.cursor/plans/ecoproject-3870_v1-v2_check_2807bd84.plan.md
@@ -1,0 +1,44 @@
+---
+name: ECOPROJECT-3870 v1-v2 check
+overview: Refine snapshot validation to distinguish v2 inventory by clusters presence/value, and fall back to v1 legacy fields when clusters is missing or null, plus update tests.
+todos:
+  - id: update-validation
+    content: Refine v2/v1 detection using clusters property
+    status: completed
+  - id: update-tests
+    content: Update snapshotParser tests for v2/v1 cases
+    status: completed
+  - id: sanity-check
+    content: Confirm AssessmentsTable uses hasUsefulData
+    status: completed
+---
+
+# Plan
+
+## Context
+
+- `hasUsefulData()` in [`src/pages/assessment/utils/snapshotParser.ts`](src/pages/assessment/utils/snapshotParser.ts) decides whether report actions are enabled.
+- Legacy v1 payloads (see `old-inventory-scheme.json`) contain `inventory.infra` and `inventory.vms` but no `inventory.clusters`.
+- You confirmed v2 should be detected only when `inventory` has its own `clusters` property and its value is not `null`/`undefined`.
+
+## Approach
+
+1. Update `hasUsefulData()` to explicitly detect v2 vs v1:
+
+- Compute `hasClustersProp = inventory && Object.prototype.hasOwnProperty.call(inventory, 'clusters')`.
+- If `hasClustersProp` and `inventory.clusters != null`, treat as v2 and return `true` (clusters exists, even if empty).
+- Otherwise, treat as v1 and return `true` only if any legacy fields exist: `inventory.infra`, `inventory.vms`, `inventory.vcenter.infra`, `inventory.vcenter.vms`, `snapshot.infra`, or `snapshot.vms`.
+
+2. Update tests in [`src/pages/assessment/utils/snapshotParser.test.ts`](src/pages/assessment/utils/snapshotParser.test.ts) to cover:
+
+- v2: clusters present and non-null → `true`
+- v2: clusters present but null → fall back to v1 check
+- v1: `inventory.infra`/`inventory.vms` present without clusters → `true` (matches example JSON)
+- latest snapshot without any of these fields → `false`
+
+3. Ensure `AssessmentsTable` continues to use `hasUsefulData()` as the single gate for enabling report actions (no additional code changes expected).
+
+## Files to change
+
+- [`src/pages/assessment/utils/snapshotParser.ts`](src/pages/assessment/utils/snapshotParser.ts)
+- [`src/pages/assessment/utils/snapshotParser.test.ts`](src/pages/assessment/utils/snapshotParser.test.ts)

--- a/src/pages/assessment/utils/snapshotParser.test.ts
+++ b/src/pages/assessment/utils/snapshotParser.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Snapshot as SnapshotModel } from '@migration-planner-ui/api-client/models';
+
+import { hasUsefulData } from './snapshotParser';
+
+const buildSnapshot = (
+  createdAt: string,
+  data: Partial<SnapshotModel>,
+): SnapshotModel => {
+  return {
+    createdAt,
+    ...data,
+  } as unknown as SnapshotModel;
+};
+
+const buildLegacySnapshot = (
+  createdAt: string,
+  data: Record<string, unknown>,
+): SnapshotModel => {
+  return {
+    createdAt,
+    ...data,
+  } as unknown as SnapshotModel;
+};
+
+describe('hasUsefulData', () => {
+  it('returns false when snapshots are empty', () => {
+    expect(hasUsefulData(undefined)).toBe(false);
+    expect(hasUsefulData([])).toBe(false);
+  });
+
+  it('returns true when clusters is present and non-null', () => {
+    const snapshots = [
+      buildSnapshot('2024-01-01T00:00:00Z', {
+        inventory: {
+          vcenterId: 'vcenter-1',
+          clusters: {},
+        } as unknown as SnapshotModel['inventory'],
+      }),
+    ];
+
+    expect(hasUsefulData(snapshots)).toBe(true);
+  });
+
+  it('returns false when clusters is null even if legacy inventory data exists', () => {
+    const snapshots = [
+      buildSnapshot('2024-01-01T00:00:00Z', {
+        inventory: {
+          vcenterId: 'vcenter-1',
+          clusters: null,
+          infra: { totalHosts: 7 },
+        } as unknown as SnapshotModel['inventory'],
+      }),
+    ];
+
+    expect(hasUsefulData(snapshots)).toBe(false);
+  });
+
+  it('returns true when legacy inventory.infra or inventory.vms exists', () => {
+    const snapshots = [
+      buildSnapshot('2024-01-01T00:00:00Z', {
+        inventory: {
+          infra: { totalHosts: 7 },
+          vms: { total: 217 },
+        } as unknown as SnapshotModel['inventory'],
+      }),
+    ];
+
+    expect(hasUsefulData(snapshots)).toBe(true);
+  });
+
+  it('returns true when legacy top-level infra or vms exists', () => {
+    const snapshots = [
+      buildLegacySnapshot('2024-01-01T00:00:00Z', {
+        infra: { totalHosts: 3 },
+        vms: { total: 12 },
+      }),
+    ];
+
+    expect(hasUsefulData(snapshots)).toBe(true);
+  });
+
+  it('returns false when latest snapshot lacks inventory data', () => {
+    const snapshots = [
+      buildLegacySnapshot('2024-01-01T00:00:00Z', {
+        inventory: { infra: { totalHosts: 1 } },
+      }),
+      buildSnapshot('2024-01-02T00:00:00Z', {
+        inventory: {
+          vcenterId: 'vcenter-1',
+          clusters: null,
+        } as unknown as SnapshotModel['inventory'],
+      }),
+    ];
+
+    expect(hasUsefulData(snapshots)).toBe(false);
+  });
+});


### PR DESCRIPTION
- Introduced a new JSON file (`old-inventory-scheme.json`) to support legacy v1 inventory structures.
- Updated `hasUsefulData()` function to recognize legacy inventory paths, ensuring old assessments can open reports without warnings.
- Added unit tests to validate the new behavior for both v1 and v2 inventory cases.

Signed-off-by: Jonathan Kilzi <jkilzi@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of inventory data across current and legacy formats so assessments correctly recognize usable snapshots.

* **Tests**
  * Added comprehensive unit tests covering current and legacy inventory scenarios, null/absent fields, and edge cases.

* **Documentation**
  * Added new plan documents outlining the validation approach, test strategy, and implementation notes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->