### PR TITLE
ECOPROJECT-3630 | fix: show correct error in create assessment from OVA

### DIFF
--- a/src/migration-wizard/contexts/discovery-sources/Provider.tsx
+++ b/src/migration-wizard/contexts/discovery-sources/Provider.tsx
@@ -201,30 +201,54 @@ export const Provider: React.FC<PropsWithChildren> = (props) => {
 
       // Create different request based on sourceType
       if (sourceType === 'inventory' && jsonValue) {
-        const assessment = await assessmentApi.createAssessment({
-          assessmentForm: {
-            name: assessmentName,
-            sourceType: sourceType,
-            inventory:
-              typeof jsonValue === 'string' ? JSON.parse(jsonValue) : jsonValue,
-          },
-        });
-        await listAssessments();
-        return assessment;
+        try {
+          const assessment = await assessmentApi.createAssessment({
+            assessmentForm: {
+              name: assessmentName,
+              sourceType: sourceType,
+              inventory:
+                typeof jsonValue === 'string'
+                  ? JSON.parse(jsonValue)
+                  : jsonValue,
+            },
+          });
+          await listAssessments();
+          return assessment;
+        } catch (error: unknown) {
+          if (hasResponse(error)) {
+            const message = await extractResponseErrorMessage(error.response);
+            throw new Error(message);
+          }
+          throw coerceToError(
+            error,
+            'Unexpected API response while creating assessment.',
+          );
+        }
       } else if (sourceType === 'rvtools') {
         throw new Error(
           'RVTools assessments must be created using createRVToolsJob for async processing',
         );
       } else if (sourceType === 'agent' && sourceId) {
-        const assessment = await assessmentApi.createAssessment({
-          assessmentForm: {
-            sourceId: sourceId,
-            name: assessmentName,
-            sourceType: sourceType,
-          },
-        });
-        await listAssessments();
-        return assessment;
+        try {
+          const assessment = await assessmentApi.createAssessment({
+            assessmentForm: {
+              sourceId: sourceId,
+              name: assessmentName,
+              sourceType: sourceType,
+            },
+          });
+          await listAssessments();
+          return assessment;
+        } catch (error: unknown) {
+          if (hasResponse(error)) {
+            const message = await extractResponseErrorMessage(error.response);
+            throw new Error(message);
+          }
+          throw coerceToError(
+            error,
+            'Unexpected API response while creating assessment.',
+          );
+        }
       } else {
         throw new Error(
           `Invalid parameters for assessment creation: ${sourceType}`,


### PR DESCRIPTION
When we try to create an assessment with ova, with a name that is already exists in the assessment table, we expect to receive the same message when trying to do it from rvtools flow: "assessment with name 'X' already exists".

<img width="1054" height="787" alt="Captura desde 2026-01-21 11-40-44" src="https://github.com/user-attachments/assets/4c216b16-2424-4d0f-b3fa-9c8bbb3e8880" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust handling of API failures during assessment creation to prevent unclear errors.
  * Validation to guard against invalid or missing responses when creating assessments.
  * More accurate detection and display of duplicate-assessment name errors.

* **Improvements**
  * API errors now surface as clear, user-friendly messages in the form UI, with inline alerts for general errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->