### PR TITLE
ECOPROJECT-3880 | fix: refresh environments table

### DIFF
--- a/src/pages/assessment/CreateFromOva.tsx
+++ b/src/pages/assessment/CreateFromOva.tsx
@@ -409,6 +409,7 @@ const CreateFromOva: React.FC = () => {
                 setSelectedEnvironmentId(newId);
               }
               setIsCreatingSource(false);
+              discoverySourcesContext.listSources();
             }}
             isDisabled={discoverySourcesContext.isDownloadingSource}
             onStartDownload={() => discoverySourcesContext.setDownloadUrl?.('')}

--- a/src/pages/environment/Environment.tsx
+++ b/src/pages/environment/Environment.tsx
@@ -352,6 +352,7 @@ export const Environment: React.FC = () => {
           onClose={() => {
             setEditSourceId(null);
             toggleDiscoverySourceSetupModal();
+            discoverySourcesContext.listSources();
           }}
           isDisabled={discoverySourcesContext.isDownloadingSource}
           onStartDownload={() => setIsOvaDownloading(true)}

--- a/src/pages/environment/sources-table/empty-state/EmptyState.tsx
+++ b/src/pages/environment/sources-table/empty-state/EmptyState.tsx
@@ -1,12 +1,13 @@
+/* eslint-disable simple-import-sort/imports */
 import React, { useCallback, useState } from 'react';
 
 import {
   Alert,
   Button,
-  EmptyState as PFEmptyState,
   EmptyStateActions,
   EmptyStateBody,
   EmptyStateFooter,
+  EmptyState as PFEmptyState,
   StackItem,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon, SearchIcon } from '@patternfly/react-icons';
@@ -24,8 +25,13 @@ export const EmptyState: React.FC = () => {
   ] = useState(false);
 
   const toggleDiscoverySourceSetupModal = useCallback((): void => {
-    setShouldShowDiscoverySetupModal((lastState) => !lastState);
-  }, []);
+    setShouldShowDiscoverySetupModal((lastState) => {
+      if (lastState === true) {
+        discoverySourcesContext.listSources();
+      }
+      return !lastState;
+    });
+  }, [discoverySourcesContext]);
 
   const handleTryAgain = useCallback(() => {
     if (!discoverySourcesContext.isLoadingSources) {


### PR DESCRIPTION
When a user wish to create a new environment for manual upload, he does not really need to press on the "Download OVA" as it is not needed for the process. yet, for this process in the GUI, the environment row is not shown to the user without triggering something on the screen. Now the environment appear when the user close the modal or click the download OVA button.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Discovery sources list now automatically refreshes after creating a new source and immediately after opening or closing the discovery setup modal. Newly added sources appear throughout the app without requiring manual page reload, keeping source lists current and consistent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->