### PR TITLE
ECOPROJECT-3892 | fix: make critical error alerts persistent and more visible

### DIFF
--- a/src/migration-wizard/steps/connect/ConnectStep.tsx
+++ b/src/migration-wizard/steps/connect/ConnectStep.tsx
@@ -1,6 +1,7 @@
 import { Source } from "@migration-planner-ui/api-client/models";
 import {
   Alert,
+  AlertActionCloseButton,
   AlertActionLink,
   Button,
   Content,
@@ -68,14 +69,15 @@ export const ConnectStep: React.FC = () => {
   ]);
 
   useEffect(() => {
-    if (uploadMessage) {
+    if (uploadMessage && !isUploadError) {
+      // Only auto-dismiss success messages, keep error messages persistent
       const timeout = setTimeout(() => {
         setUploadMessage(null);
       }, 5000); // dissapears after 5 seconds
 
       return () => clearTimeout(timeout);
     }
-  }, [uploadMessage]);
+  }, [uploadMessage, isUploadError]);
 
   useEffect(() => {
     if (isOvaDownloading) {
@@ -90,6 +92,41 @@ export const ConnectStep: React.FC = () => {
   return (
     <>
       <Stack hasGutter>
+        {/* Critical error alerts at the top for visibility */}
+        {uploadMessage && isUploadError && (
+          <StackItem>
+            <Alert
+              isInline
+              variant="danger"
+              title={uploadMessage}
+              actionClose={
+                <AlertActionCloseButton
+                  onClose={() => setUploadMessage(null)}
+                />
+              }
+            />
+          </StackItem>
+        )}
+
+        {discoverySourcesContext.errorDownloadingSource && (
+          <StackItem>
+            <Alert
+              isInline
+              variant="danger"
+              title="Download Environment error"
+              actionClose={
+                <AlertActionCloseButton
+                  onClose={() => {
+                    discoverySourcesContext.clearErrors({ downloading: true });
+                  }}
+                />
+              }
+            >
+              {discoverySourcesContext.errorDownloadingSource.message}
+            </Alert>
+          </StackItem>
+        )}
+
         <StackItem>
           <Content component="h2">Connect your VMware environment</Content>
         </StackItem>
@@ -169,14 +206,6 @@ export const ConnectStep: React.FC = () => {
           </StackItem>
         )}
 
-        {discoverySourcesContext.errorDownloadingSource && (
-          <StackItem>
-            <Alert isInline variant="danger" title="Download Environment error">
-              {discoverySourcesContext.errorDownloadingSource.message}
-            </Alert>
-          </StackItem>
-        )}
-
         {sourceSelected?.agent &&
           sourceSelected?.agent.status === "waiting-for-credentials" && (
             <StackItem>
@@ -229,13 +258,9 @@ export const ConnectStep: React.FC = () => {
             </StackItem>
           )}
 
-        {uploadMessage && (
+        {uploadMessage && !isUploadError && (
           <StackItem>
-            <Alert
-              isInline
-              variant={isUploadError ? "danger" : "success"}
-              title={uploadMessage}
-            />
+            <Alert isInline variant="success" title={uploadMessage} />
           </StackItem>
         )}
       </Stack>

--- a/src/migration-wizard/steps/connect/sources-table/SourcesTable.tsx
+++ b/src/migration-wizard/steps/connect/sources-table/SourcesTable.tsx
@@ -155,7 +155,6 @@ export const SourcesTable: React.FC<{
                       whiteSpace: "normal",
                       minWidth: "120px",
                       maxWidth: "200px",
-                      textAlign: "right",
                     }}
                   >
                     {Columns.Actions}
@@ -170,7 +169,10 @@ export const SourcesTable: React.FC<{
                   const agent = source.agent;
                   return (
                     <Tr key={source.id}>
-                      <Td dataLabel={Columns.Name}>
+                      <Td
+                        dataLabel={Columns.Name}
+                        style={{ verticalAlign: "top" }}
+                      >
                         <Radio
                           id={source.id}
                           name="source-selection"
@@ -186,7 +188,10 @@ export const SourcesTable: React.FC<{
                           }
                         />
                       </Td>
-                      <Td dataLabel={Columns.CredentialsUrl}>
+                      <Td
+                        dataLabel={Columns.CredentialsUrl}
+                        style={{ verticalAlign: "top" }}
+                      >
                         {agent !== undefined && !source.onPremises ? (
                           <Link to={agent.credentialUrl} target="_blank">
                             {agent.credentialUrl}
@@ -195,7 +200,10 @@ export const SourcesTable: React.FC<{
                           "-"
                         )}
                       </Td>
-                      <Td dataLabel={Columns.Status}>
+                      <Td
+                        dataLabel={Columns.Status}
+                        style={{ verticalAlign: "top" }}
+                      >
                         <AgentStatusView
                           status={agent ? agent.status : "not-connected"}
                           statusInfo={
@@ -208,31 +216,39 @@ export const SourcesTable: React.FC<{
                           }
                         />
                       </Td>
-                      <Td dataLabel={Columns.Hosts}>
+                      <Td
+                        dataLabel={Columns.Hosts}
+                        style={{ verticalAlign: "top" }}
+                      >
                         {source?.inventory?.vcenter?.infra.totalHosts ??
                           VALUE_NOT_AVAILABLE}
                       </Td>
-                      <Td dataLabel={Columns.VMs}>
+                      <Td
+                        dataLabel={Columns.VMs}
+                        style={{ verticalAlign: "top" }}
+                      >
                         {source?.inventory?.vcenter?.vms.total ??
                           VALUE_NOT_AVAILABLE}
                       </Td>
-                      <Td dataLabel={Columns.Networks}>
+                      <Td
+                        dataLabel={Columns.Networks}
+                        style={{ verticalAlign: "top" }}
+                      >
                         {source?.inventory?.vcenter?.infra.networks?.length ??
                           VALUE_NOT_AVAILABLE}
                       </Td>
-                      <Td dataLabel={Columns.Datastores}>
+                      <Td
+                        dataLabel={Columns.Datastores}
+                        style={{ verticalAlign: "top" }}
+                      >
                         {source?.inventory?.vcenter?.infra.datastores?.length ??
                           VALUE_NOT_AVAILABLE}
                       </Td>
-                      <Td dataLabel={Columns.Actions}>
-                        <div
-                          style={{
-                            display: "flex",
-                            justifyContent: "flex-end",
-                            alignItems: "center",
-                            gap: "8px",
-                          }}
-                        >
+                      <Td
+                        dataLabel={Columns.Actions}
+                        style={{ verticalAlign: "top" }}
+                      >
+                        <div className="pf-v6-u-display-flex pf-v6-u-justify-content-flex-end pf-v6-u-align-items-center pf-v6-u-gap-sm">
                           {source.name !== "Example" && (
                             <RemoveSourceAction
                               sourceId={source.id}

--- a/src/pages/environment/Environment.tsx
+++ b/src/pages/environment/Environment.tsx
@@ -1,5 +1,6 @@
 import {
   Alert,
+  AlertActionCloseButton,
   AlertActionLink,
   Button,
   Content,
@@ -78,14 +79,15 @@ export const Environment: React.FC = () => {
   ];
 
   useEffect(() => {
-    if (uploadMessage) {
+    if (uploadMessage && !isUploadError) {
+      // Only auto-dismiss success messages, keep error messages persistent
       const timeout = setTimeout(() => {
         setUploadMessage(null);
       }, 5000); // dissapears after 5 seconds
 
       return () => clearTimeout(timeout);
     }
-  }, [uploadMessage]);
+  }, [uploadMessage, isUploadError]);
 
   useEffect(() => {
     if (isOvaDownloading) {
@@ -115,6 +117,43 @@ export const Environment: React.FC = () => {
           marginBottom: "10px",
         }}
       >
+        {/* Critical error alerts at the top for visibility */}
+        {uploadMessage && isUploadError && (
+          <div style={{ marginBottom: "16px" }}>
+            <Alert
+              isInline
+              variant="danger"
+              title="Upload error"
+              actionClose={
+                <AlertActionCloseButton
+                  onClose={() => setUploadMessage(null)}
+                />
+              }
+            >
+              {uploadMessage}
+            </Alert>
+          </div>
+        )}
+
+        {discoverySourcesContext.errorDownloadingSource && (
+          <div style={{ marginBottom: "16px" }}>
+            <Alert
+              isInline
+              variant="danger"
+              title="Download Environment error"
+              actionClose={
+                <AlertActionCloseButton
+                  onClose={() => {
+                    discoverySourcesContext.clearErrors({ downloading: true });
+                  }}
+                />
+              }
+            >
+              {discoverySourcesContext.errorDownloadingSource.message}
+            </Alert>
+          </div>
+        )}
+
         <Toolbar inset={{ default: "insetNone" }}>
           <ToolbarContent>
             <ToolbarItem>
@@ -301,14 +340,6 @@ export const Environment: React.FC = () => {
         </StackItem>
       )}
 
-      {discoverySourcesContext.errorDownloadingSource && (
-        <StackItem>
-          <Alert isInline variant="danger" title="Download Environment error">
-            {discoverySourcesContext.errorDownloadingSource.message}
-          </Alert>
-        </StackItem>
-      )}
-
       {sourceSelected?.agent &&
         sourceSelected?.agent.status === "waiting-for-credentials" && (
           <StackItem>
@@ -337,13 +368,9 @@ export const Environment: React.FC = () => {
           </StackItem>
         )}
 
-      {uploadMessage && (
+      {uploadMessage && !isUploadError && (
         <StackItem>
-          <Alert
-            isInline
-            variant={isUploadError ? "danger" : "success"}
-            title={isUploadError ? "Upload error" : "Upload success"}
-          >
+          <Alert isInline variant="success" title="Upload success">
             {uploadMessage}
           </Alert>
         </StackItem>

--- a/src/pages/environment/sources-table/SourcesTable.tsx
+++ b/src/pages/environment/sources-table/SourcesTable.tsx
@@ -364,7 +364,6 @@ export const SourcesTable: React.FC<SourceTableProps> = ({
                       whiteSpace: "normal",
                       minWidth: "120px",
                       maxWidth: "200px",
-                      textAlign: "right",
                     }}
                     screenReaderText="Actions"
                   >
@@ -384,8 +383,16 @@ export const SourcesTable: React.FC<SourceTableProps> = ({
                   const isUploadAllowed = !source?.agent || source?.onPremises;
                   return (
                     <Tr key={source.id}>
-                      <Td dataLabel={Columns.Name}>{source.name}</Td>
-                      <Td dataLabel={Columns.Status}>
+                      <Td
+                        dataLabel={Columns.Name}
+                        style={{ verticalAlign: "top" }}
+                      >
+                        {source.name}
+                      </Td>
+                      <Td
+                        dataLabel={Columns.Status}
+                        style={{ verticalAlign: "top" }}
+                      >
                         <AgentStatusView
                           status={agent ? agent.status : "not-connected"}
                           statusInfo={
@@ -404,23 +411,38 @@ export const SourcesTable: React.FC<SourceTableProps> = ({
                           updatedAt={source?.updatedAt}
                         />
                       </Td>
-                      <Td dataLabel={Columns.Hosts}>
+                      <Td
+                        dataLabel={Columns.Hosts}
+                        style={{ verticalAlign: "top" }}
+                      >
                         {source?.inventory?.vcenter?.infra.totalHosts ??
                           VALUE_NOT_AVAILABLE}
                       </Td>
-                      <Td dataLabel={Columns.VMs}>
+                      <Td
+                        dataLabel={Columns.VMs}
+                        style={{ verticalAlign: "top" }}
+                      >
                         {source?.inventory?.vcenter?.vms.total ??
                           VALUE_NOT_AVAILABLE}
                       </Td>
-                      <Td dataLabel={Columns.Networks}>
+                      <Td
+                        dataLabel={Columns.Networks}
+                        style={{ verticalAlign: "top" }}
+                      >
                         {source?.inventory?.vcenter?.infra.networks?.length ??
                           VALUE_NOT_AVAILABLE}
                       </Td>
-                      <Td dataLabel={Columns.Datastores}>
+                      <Td
+                        dataLabel={Columns.Datastores}
+                        style={{ verticalAlign: "top" }}
+                      >
                         {source?.inventory?.vcenter?.infra.datastores?.length ??
                           VALUE_NOT_AVAILABLE}
                       </Td>
-                      <Td dataLabel={Columns.LastSeen}>
+                      <Td
+                        dataLabel={Columns.LastSeen}
+                        style={{ verticalAlign: "top" }}
+                      >
                         {source?.updatedAt ? (
                           <Tooltip
                             content={new Date(
@@ -435,7 +457,7 @@ export const SourcesTable: React.FC<SourceTableProps> = ({
                       </Td>
                       <Td
                         dataLabel={Columns.Actions}
-                        style={{ textAlign: "right" }}
+                        style={{ verticalAlign: "top" }}
                       >
                         {uploadOnly ? (
                           <>


### PR DESCRIPTION
With this PR we make critical error alerts persistent and more visible:

- Error alerts now persist until manually dismissed by user
- Added close buttons to all danger variant alerts
- Moved error alerts to top of ConnectStep and Environment pages
- Success messages continue to auto-dismiss after 5 seconds



https://github.com/user-attachments/assets/04f84a30-9fdc-402e-a990-cd40e46f1d3f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upload and download error alerts now persist until manually dismissed; only non-error success messages auto-dismiss.

* **UI/UX Improvements**
  * Error alerts moved to top of page with explicit close actions for clarity.
  * Table layout improved with top-aligned cells and refined action alignment for clearer data presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->