### PR TITLE
ECOPROJECT-3468 | fix: add a share aggregated data checkbox

### DIFF
--- a/src/pages/assessment/CreateAssessmentModal.tsx
+++ b/src/pages/assessment/CreateAssessmentModal.tsx
@@ -2,6 +2,7 @@ import { Job, JobStatus } from "@migration-planner-ui/api-client/models";
 import {
   Alert,
   Button,
+  Checkbox,
   type DropEvent,
   FileUpload,
   Form,
@@ -84,6 +85,9 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
   const [filename, setFilename] = useState("");
   const [isFileLoading, _setIsFileLoading] = useState(false);
   const [selectedEnvironmentId, setSelectedEnvironmentId] = useState("");
+
+  // Consent to share aggregated data (RVTools only)
+  const [rvtoolsConsentChecked, setRvtoolsConsentChecked] = useState(false);
 
   const [nameValidationError, setNameValidationError] = useState("");
   const [fileValidationError, setFileValidationError] = useState("");
@@ -277,6 +281,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
     setSelectedEnvironmentId("");
     setNameErrorDismissed(true);
     setFileErrorDismissed(true);
+    setRvtoolsConsentChecked(false);
     onClose();
   };
 
@@ -286,6 +291,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
 
   const isButtonDisabled =
     !isFormValid ||
+    (mode === "rvtools" && !rvtoolsConsentChecked) ||
     isLoading ||
     !!nameErrorToDisplay ||
     !!fileValidationError ||
@@ -448,6 +454,18 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
                     </HelperTextItem>
                   </HelperText>
                 </FormHelperText>
+              )}
+              {mode === "rvtools" && (
+                <div style={{ marginTop: "8px" }}>
+                  <Checkbox
+                    id="rvtools-data-share-consent"
+                    label="I agree to share aggregated data about my environment with Red Hat."
+                    isChecked={rvtoolsConsentChecked}
+                    onChange={(_event, checked) => {
+                      setRvtoolsConsentChecked(Boolean(checked));
+                    }}
+                  />
+                </div>
               )}
             </FormGroup>
           )}


### PR DESCRIPTION
While uploading RVTools will be a checbox that the user agree to share aggregated data with RH.
The behaivour is:
-  If user doesn't check the option to share aggregated data we disable the "Create assessment" button
- We don't save anything in the database, we only allow or not to create the assessment with rvTools

https://github.com/user-attachments/assets/a14407b9-ba7d-4326-9b71-8633c1fb960b


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a data-sharing consent checkbox to the assessment creation form in RVTools mode so users can opt in to sharing aggregated data with Red Hat.
  * Submission and certain file actions in RVTools mode are disabled until consent is given.

* **Bug Fixes**
  * Consent state is cleared when the form is closed or reset to avoid accidental retention.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->