### PR TITLE
NO-JIRA | fix: Update jspdf to fix security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11034,9 +11034,9 @@
       }
     },
     "node_modules/jspdf": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.0.0.tgz",
-      "integrity": "sha512-w12U97Z6edKd2tXDn3LzTLg7C7QLJlx0BPfM3ecjK2BckUl9/81vZ+r5gK4/3KQdhAcEZhENUxRhtgYBj75MqQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.1.0.tgz",
+      "integrity": "sha512-xd1d/XRkwqnsq6FP3zH1Q+Ejqn2ULIJeDZ+FTKpaabVpZREjsJKRJwuokTNgdqOU+fl55KgbvgZ1pRTSWCP2kQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
@@ -11046,7 +11046,7 @@
       "optionalDependencies": {
         "canvg": "^3.0.11",
         "core-js": "^3.6.0",
-        "dompurify": "^3.2.4",
+        "dompurify": "^3.3.1",
         "html2canvas": "^1.0.0-rc.5"
       }
     },


### PR DESCRIPTION
## Summary

Fixed high severity security vulnerabilities in `jspdf` package by updating from version 4.0.0 to 4.1.0.

## Security Issues Fixed

- Shared State Race Condition in addJS Plugin (GHSA-cjw8-79x6-5cj4)
- PDF Injection in AcroFormChoiceField allowing Arbitrary JavaScript Execution (GHSA-pqxr-3g65-p328)
- Denial of Service (DoS) via Unvalidated BMP Dimensions in BMPDecoder (GHSA-95fx-jjr5-f39c)
- Stored XMP Metadata Injection (Spoofing & Integrity Violation) (GHSA-vm32-vv63-w422)

## Changes

- Updated `jspdf` from `^4.0.0` to `^4.1.0`
- Updated `dompurify` dependency (from `^3.2.4` to `^3.3.1`) as part of the jspdf update

## Verification

- ✅ Security scan passes with 0 vulnerabilities
- ✅ All packages updated successfully

## Testing

- Run `make security-scan` to verify no vulnerabilities
- Run `make build` to ensure build still wo- Run `make test` to ensure tests pass