### PR TITLE
ECOPROJECT-3967 | feat: Implement separate CPU and memory overcommit ratios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "hasInstallScript": true,
       "dependencies": {
         "@emotion/css": "^11.13.0",
-        "@migration-planner-ui/api-client": "^0.0.37",
-        "@migration-planner-ui/ioc": "^0.0.36",
+        "@migration-planner-ui/api-client": "^0.0.38",
+        "@migration-planner-ui/ioc": "^0.0.38",
         "@patternfly/react-charts": "7.4.9",
         "@patternfly/react-core": "^6.4.0",
         "@patternfly/react-icons": "^6.4.0",
@@ -1930,15 +1930,15 @@
       "license": "MIT"
     },
     "node_modules/@migration-planner-ui/api-client": {
-      "version": "0.0.37",
-      "resolved": "https://registry.npmjs.org/@migration-planner-ui/api-client/-/api-client-0.0.37.tgz",
-      "integrity": "sha512-odEKmsWgSQdLKYliUxCpNjbpG/LKSBBAuEfc3hVY1f3QQgLNw2OiWDOxZX/xh3DESeXYAgl5pELws/YY4MXmyQ==",
+      "version": "0.0.38",
+      "resolved": "https://registry.npmjs.org/@migration-planner-ui/api-client/-/api-client-0.0.38.tgz",
+      "integrity": "sha512-dNZZ8PO6KUf4rQKrg2/mwZhdJJAlqnFZLUf+2xlGycXZJFtLmN4D4sipuAMcgHXfScuxieSvehxCtRvgOjH9hg==",
       "license": "Apache-2.0"
     },
     "node_modules/@migration-planner-ui/ioc": {
-      "version": "0.0.36",
-      "resolved": "https://registry.npmjs.org/@migration-planner-ui/ioc/-/ioc-0.0.36.tgz",
-      "integrity": "sha512-1RBnFjsR8mbvC9tz/cc4vPV65Su7AmqAhjdj/Nj+dkkUKoD723pd8S6qDBeC3GENkydXrDCqjdb7EACgpepkcQ==",
+      "version": "0.0.38",
+      "resolved": "https://registry.npmjs.org/@migration-planner-ui/ioc/-/ioc-0.0.38.tgz",
+      "integrity": "sha512-rADhtU3uuA7wNnhiwXzYLfhL4l4Uesve4V9p9fUUqTmS4UhGqjgTEmLqqkF+9tmt6izfOBnkbZVOkxhR0bymVw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "dependencies": {
     "@emotion/css": "^11.13.0",
-    "@migration-planner-ui/api-client": "^0.0.37",
-    "@migration-planner-ui/ioc": "^0.0.36",
+    "@migration-planner-ui/api-client": "^0.0.38",
+    "@migration-planner-ui/ioc": "^0.0.38",
     "@patternfly/react-charts": "7.4.9",
     "@patternfly/react-core": "^6.4.0",
     "@patternfly/react-icons": "^6.4.0",

--- a/src/migration-wizard/contexts/discovery-sources/Provider.tsx
+++ b/src/migration-wizard/contexts/discovery-sources/Provider.tsx
@@ -168,7 +168,7 @@ export const Provider: React.FC<PropsWithChildren> = (props) => {
 
   const [listAssessmentsState, listAssessments] = useAsyncFnResetError(
     async (): Promise<Assessment[]> => {
-      const response = await assessmentApi.listAssessments();
+      const response = await assessmentApi.listAssessments({});
       return normalizeAssessmentsResponse(response);
     },
   );

--- a/src/pages/report/Report.test.tsx
+++ b/src/pages/report/Report.test.tsx
@@ -189,7 +189,7 @@ const createAssessment = (
         createdAt: new Date(),
         inventory: {
           vcenterId: "vcenter-1",
-          clusters: clusterData ?? null,
+          clusters: clusterData ?? {},
           vcenter: {
             infra: aggregateInfra,
             vms: aggregateVms,

--- a/src/pages/report/cluster-sizer/SizingInputForm.tsx
+++ b/src/pages/report/cluster-sizer/SizingInputForm.tsx
@@ -12,9 +12,18 @@ import {
 } from "@patternfly/react-core";
 import React from "react";
 
-import { CPU_OPTIONS, MEMORY_OPTIONS, OVERCOMMIT_OPTIONS } from "./constants";
+import {
+  CPU_OPTIONS,
+  CPU_OVERCOMMIT_OPTIONS,
+  MEMORY_OPTIONS,
+  MEMORY_OVERCOMMIT_OPTIONS,
+} from "./constants";
 import PopoverIcon from "./PopoverIcon";
-import type { OvercommitRatio, SizingFormValues } from "./types";
+import type {
+  MemoryOvercommitRatio,
+  OvercommitRatio,
+  SizingFormValues,
+} from "./types";
 
 interface SizingInputFormProps {
   values: SizingFormValues;
@@ -54,13 +63,23 @@ export const SizingInputForm: React.FC<SizingInputFormProps> = ({
     });
   };
 
-  const handleOvercommitChange = (
+  const handleCpuOvercommitChange = (
     _event: React.FormEvent<HTMLSelectElement>,
     ratio: string,
   ): void => {
     onChange({
       ...values,
-      overcommitRatio: parseInt(ratio, 10) as OvercommitRatio,
+      cpuOvercommitRatio: parseInt(ratio, 10) as OvercommitRatio,
+    });
+  };
+
+  const handleMemoryOvercommitChange = (
+    _event: React.FormEvent<HTMLSelectElement>,
+    ratio: string,
+  ): void => {
+    onChange({
+      ...values,
+      memoryOvercommitRatio: parseInt(ratio, 10) as MemoryOvercommitRatio,
     });
   };
 
@@ -145,27 +164,58 @@ export const SizingInputForm: React.FC<SizingInputFormProps> = ({
               </FormGroup>
             </StackItem>
 
-            {/* Overcommitment (CPU & memory) */}
+            {/* CPU overcommitment */}
             <StackItem>
               <FormGroup
-                label="Overcommitment (CPU & memory)"
+                label="CPU overcommitment"
                 isRequired
-                fieldId="overcommit-ratio"
+                fieldId="cpu-overcommit-ratio"
                 labelHelp={
                   <PopoverIcon
                     noVerticalAlign
-                    headerContent="Overcommitment (CPU & memory)"
-                    bodyContent="The ratio of virtual resources to physical resources. Higher ratios allow more VMs but may impact performance if all VMs peak at once. Example: At 1:4, you can run 400 virtual CPUs on 100 physical cores."
+                    headerContent="CPU overcommitment"
+                    bodyContent="The ratio of virtual CPUs to physical cores. Higher ratios allow more VMs but may impact performance if all VMs peak at once. Example: At 1:4, you can run 400 virtual CPUs on 100 physical cores."
                   />
                 }
               >
                 <FormSelect
-                  id="overcommit-ratio"
-                  value={String(values.overcommitRatio)}
-                  onChange={handleOvercommitChange}
-                  aria-label="Overcommitment ratio"
+                  id="cpu-overcommit-ratio"
+                  value={String(values.cpuOvercommitRatio)}
+                  onChange={handleCpuOvercommitChange}
+                  aria-label="CPU overcommitment ratio"
                 >
-                  {OVERCOMMIT_OPTIONS.map((option) => (
+                  {CPU_OVERCOMMIT_OPTIONS.map((option) => (
+                    <FormSelectOption
+                      key={option.value}
+                      value={String(option.value)}
+                      label={option.label}
+                    />
+                  ))}
+                </FormSelect>
+              </FormGroup>
+            </StackItem>
+
+            {/* Memory overcommitment */}
+            <StackItem>
+              <FormGroup
+                label="Memory overcommitment"
+                isRequired
+                fieldId="memory-overcommit-ratio"
+                labelHelp={
+                  <PopoverIcon
+                    noVerticalAlign
+                    headerContent="Memory overcommitment"
+                    bodyContent="The ratio of virtual memory to physical memory. Higher ratios allow more VMs; memory overcommit is typically more conservative than CPU (max 1:4)."
+                  />
+                }
+              >
+                <FormSelect
+                  id="memory-overcommit-ratio"
+                  value={String(values.memoryOvercommitRatio)}
+                  onChange={handleMemoryOvercommitChange}
+                  aria-label="Memory overcommitment ratio"
+                >
+                  {MEMORY_OVERCOMMIT_OPTIONS.map((option) => (
                     <FormSelectOption
                       key={option.value}
                       value={String(option.value)}

--- a/src/pages/report/cluster-sizer/SizingResult.tsx
+++ b/src/pages/report/cluster-sizer/SizingResult.tsx
@@ -16,7 +16,7 @@ import {
 import { CopyIcon } from "@patternfly/react-icons";
 import React, { useCallback, useMemo } from "react";
 
-import { OVERCOMMIT_OPTIONS } from "./constants";
+import { CPU_OVERCOMMIT_OPTIONS, MEMORY_OVERCOMMIT_OPTIONS } from "./constants";
 import type { ClusterRequirementsResponse, SizingFormValues } from "./types";
 
 const DISCLAIMER_TEXT =
@@ -41,10 +41,18 @@ const formatNumber = (value: number): string => value.toLocaleString();
 const formatRatio = (value: number): string => value.toFixed(2);
 
 /**
- * Get the over-commit ratio label
+ * Get the CPU over-commit ratio label
  */
-const getOvercommitLabel = (ratio: number): string => {
-  const option = OVERCOMMIT_OPTIONS.find((opt) => opt.value === ratio);
+const getCpuOvercommitLabel = (ratio: number): string => {
+  const option = CPU_OVERCOMMIT_OPTIONS.find((opt) => opt.value === ratio);
+  return option?.label || `1:${ratio}`;
+};
+
+/**
+ * Get the memory over-commit ratio label
+ */
+const getMemoryOvercommitLabel = (ratio: number): string => {
+  const option = MEMORY_OVERCOMMIT_OPTIONS.find((opt) => opt.value === ratio);
   return option?.label || `1:${ratio}`;
 };
 
@@ -70,7 +78,7 @@ Node Size: ${formValues.customCpu} CPU / ${formValues.customMemoryGb} GB
 
 Additional info
 Target Platform: BareMetal
-Over-Commitment: ${getOvercommitLabel(formValues.overcommitRatio)}
+Over-Commitment: CPU ${getCpuOvercommitLabel(formValues.cpuOvercommitRatio)}, Memory ${getMemoryOvercommitLabel(formValues.memoryOvercommitRatio)}
 VMs to Migrate: ${formatNumber(output.inventoryTotals.totalVMs)} VMs
 - CPU Over-Commit Ratio: ${formatRatio(cpuOverCommitRatio)}
 - Memory Over-Commit Ratio: ${formatRatio(memoryOverCommitRatio)}
@@ -227,8 +235,9 @@ export const SizingResult: React.FC<SizingResultProps> = ({
                 </Content>
                 <Content>Target Platform: BareMetal</Content>
                 <Content>
-                  Over-Commitment:{" "}
-                  {getOvercommitLabel(formValues.overcommitRatio)}
+                  Over-Commitment: CPU{" "}
+                  {getCpuOvercommitLabel(formValues.cpuOvercommitRatio)}, Memory{" "}
+                  {getMemoryOvercommitLabel(formValues.memoryOvercommitRatio)}
                 </Content>
                 <Content>
                   VMs to Migrate:{" "}

--- a/src/pages/report/cluster-sizer/constants.ts
+++ b/src/pages/report/cluster-sizer/constants.ts
@@ -1,5 +1,6 @@
 import type {
   HAReplicaCount,
+  MemoryOvercommitRatio,
   OvercommitRatio,
   SizingFormValues,
   WorkerNodePreset,
@@ -55,9 +56,9 @@ export const MEMORY_OPTIONS: { value: number; label: string }[] = [
 ];
 
 /**
- * Over-commit ratio options for resource sharing
+ * CPU over-commit ratio options for resource sharing
  */
-export const OVERCOMMIT_OPTIONS: {
+export const CPU_OVERCOMMIT_OPTIONS: {
   value: OvercommitRatio;
   label: string;
   description: string;
@@ -87,6 +88,35 @@ export const OVERCOMMIT_OPTIONS: {
     label: "High Density (1:6)",
     description: "Heavy sharing. Maximum savings for test environments.",
     helpText: "Only recommended for non-production workloads.",
+  },
+];
+
+/**
+ * Memory over-commit ratio options (1:6 not supported by API)
+ */
+export const MEMORY_OVERCOMMIT_OPTIONS: {
+  value: MemoryOvercommitRatio;
+  label: string;
+  description: string;
+  helpText: string;
+}[] = [
+  {
+    value: 1,
+    label: "Performance (1:1)",
+    description: "No sharing. Dedicated memory for every VM.",
+    helpText: "Best for latency-sensitive or critical workloads.",
+  },
+  {
+    value: 2,
+    label: "Balanced (1:2)",
+    description: "Light sharing. Safe for critical apps.",
+    helpText: "Good balance between cost and performance.",
+  },
+  {
+    value: 4,
+    label: "Standard (1:4)",
+    description: "Moderate sharing. Best for general use.",
+    helpText: "Typical choice for general purpose workloads.",
   },
 ];
 
@@ -143,7 +173,8 @@ export const DEFAULT_FORM_VALUES: SizingFormValues = {
   customCpu: 32,
   customMemoryGb: 32,
   haReplicas: 3,
-  overcommitRatio: 4, // Standard (1:4)
+  cpuOvercommitRatio: 4, // Standard (1:4)
+  memoryOvercommitRatio: 2, // Balanced (1:2)
   scheduleOnControlPlane: false,
 };
 

--- a/src/pages/report/cluster-sizer/mocks/clusterRequirementsRequest.mock.ts
+++ b/src/pages/report/cluster-sizer/mocks/clusterRequirementsRequest.mock.ts
@@ -3,6 +3,7 @@
  *
  * API Endpoint: POST /api/v1/assessments/{id}/cluster-requirements
  * @see PR #819 - ECOPROJECT-3719 | feat: add post endpoint for sizing calculations
+ * @see ECOPROJECT-3967 - CPU and memory overcommit specified individually
  */
 import type { ClusterRequirementsRequest } from "../types";
 
@@ -11,7 +12,8 @@ import type { ClusterRequirementsRequest } from "../types";
  */
 export const mockClusterRequirementsRequest: ClusterRequirementsRequest = {
   clusterId: "71cfef2c-5c64-4a0a-8238-2f7fbb2f6372",
-  overCommitRatio: "1:4",
+  cpuOverCommitRatio: "1:4",
+  memoryOverCommitRatio: "1:4",
   workerNodeCPU: 16,
   workerNodeMemory: 64,
   controlPlaneSchedulable: false,
@@ -22,7 +24,8 @@ export const mockClusterRequirementsRequest: ClusterRequirementsRequest = {
  */
 export const mockSmallNodeRequest: ClusterRequirementsRequest = {
   clusterId: "123e4567-e89b-12d3-a456-426614174000",
-  overCommitRatio: "1:2",
+  cpuOverCommitRatio: "1:2",
+  memoryOverCommitRatio: "1:2",
   workerNodeCPU: 4,
   workerNodeMemory: 16,
   controlPlaneSchedulable: false,
@@ -33,7 +36,8 @@ export const mockSmallNodeRequest: ClusterRequirementsRequest = {
  */
 export const mockLargeNodeRequest: ClusterRequirementsRequest = {
   clusterId: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
-  overCommitRatio: "1:6",
+  cpuOverCommitRatio: "1:6",
+  memoryOverCommitRatio: "1:4",
   workerNodeCPU: 64,
   workerNodeMemory: 256,
   controlPlaneSchedulable: false,
@@ -45,7 +49,8 @@ export const mockLargeNodeRequest: ClusterRequirementsRequest = {
 export const mockCustomNodeWithControlPlaneRequest: ClusterRequirementsRequest =
   {
     clusterId: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
-    overCommitRatio: "1:1",
+    cpuOverCommitRatio: "1:1",
+    memoryOverCommitRatio: "1:1",
     workerNodeCPU: 32,
     workerNodeMemory: 128,
     controlPlaneSchedulable: true,
@@ -56,7 +61,8 @@ export const mockCustomNodeWithControlPlaneRequest: ClusterRequirementsRequest =
  */
 export const mockMaxValuesRequest: ClusterRequirementsRequest = {
   clusterId: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-  overCommitRatio: "1:6",
+  cpuOverCommitRatio: "1:6",
+  memoryOverCommitRatio: "1:4",
   workerNodeCPU: 200,
   workerNodeMemory: 512,
   controlPlaneSchedulable: true,
@@ -67,7 +73,8 @@ export const mockMaxValuesRequest: ClusterRequirementsRequest = {
  */
 export const mockMinValuesRequest: ClusterRequirementsRequest = {
   clusterId: "b2a7e4b6-91f4-4be7-bfcb-043dee7e50e9",
-  overCommitRatio: "1:1",
+  cpuOverCommitRatio: "1:1",
+  memoryOverCommitRatio: "1:1",
   workerNodeCPU: 2,
   workerNodeMemory: 4,
   controlPlaneSchedulable: false,
@@ -80,8 +87,12 @@ export const createMockClusterRequirementsRequest = (
   overrides: Partial<ClusterRequirementsRequest> = {},
 ): ClusterRequirementsRequest => ({
   clusterId: overrides.clusterId ?? mockClusterRequirementsRequest.clusterId,
-  overCommitRatio:
-    overrides.overCommitRatio ?? mockClusterRequirementsRequest.overCommitRatio,
+  cpuOverCommitRatio:
+    overrides.cpuOverCommitRatio ??
+    mockClusterRequirementsRequest.cpuOverCommitRatio,
+  memoryOverCommitRatio:
+    overrides.memoryOverCommitRatio ??
+    mockClusterRequirementsRequest.memoryOverCommitRatio,
   workerNodeCPU:
     overrides.workerNodeCPU ?? mockClusterRequirementsRequest.workerNodeCPU,
   workerNodeMemory:
@@ -93,14 +104,26 @@ export const createMockClusterRequirementsRequest = (
 });
 
 /**
- * Collection of all over-commit ratio variants for testing
+ * Collection of CPU over-commit ratio variants for testing (memory fixed at 1:4)
  */
-export const mockRequestsByOvercommitRatio: Record<
-  ClusterRequirementsRequest["overCommitRatio"],
+export const mockRequestsByCpuOvercommitRatio: Record<
+  ClusterRequirementsRequest["cpuOverCommitRatio"],
   ClusterRequirementsRequest
 > = {
-  "1:1": createMockClusterRequirementsRequest({ overCommitRatio: "1:1" }),
-  "1:2": createMockClusterRequirementsRequest({ overCommitRatio: "1:2" }),
-  "1:4": createMockClusterRequirementsRequest({ overCommitRatio: "1:4" }),
-  "1:6": createMockClusterRequirementsRequest({ overCommitRatio: "1:6" }),
+  "1:1": createMockClusterRequirementsRequest({
+    cpuOverCommitRatio: "1:1",
+    memoryOverCommitRatio: "1:4",
+  }),
+  "1:2": createMockClusterRequirementsRequest({
+    cpuOverCommitRatio: "1:2",
+    memoryOverCommitRatio: "1:4",
+  }),
+  "1:4": createMockClusterRequirementsRequest({
+    cpuOverCommitRatio: "1:4",
+    memoryOverCommitRatio: "1:4",
+  }),
+  "1:6": createMockClusterRequirementsRequest({
+    cpuOverCommitRatio: "1:6",
+    memoryOverCommitRatio: "1:4",
+  }),
 };

--- a/src/pages/report/cluster-sizer/mocks/data.mock.ts
+++ b/src/pages/report/cluster-sizer/mocks/data.mock.ts
@@ -49,10 +49,10 @@ export const generateMockClusterRequirements = (
     totalMemory: inventoryMemory,
   } = MOCK_INVENTORY;
 
-  // Calculate worker nodes needed based on CPU requirements and overcommit ratio
+  // Calculate worker nodes needed based on CPU requirements and CPU overcommit ratio
   const workerNodes = Math.max(
     3,
-    Math.ceil(inventoryCPU / (workerCpu * values.overcommitRatio)),
+    Math.ceil(inventoryCPU / (workerCpu * values.cpuOvercommitRatio)),
   );
   const controlPlaneNodes = values.haReplicas;
   const totalNodes = workerNodes + controlPlaneNodes;
@@ -82,8 +82,8 @@ export const generateMockClusterRequirements = (
       cpu: cpuUsage,
       memory: memoryUsage,
       limits: {
-        cpu: inventoryCPU * values.overcommitRatio,
-        memory: inventoryMemory * values.overcommitRatio,
+        cpu: inventoryCPU * values.cpuOvercommitRatio,
+        memory: inventoryMemory * values.memoryOvercommitRatio,
       },
       overCommitRatio: {
         cpu: inventoryCPU / totalCPU,

--- a/src/services/report-export/ChartDataTransformer.ts
+++ b/src/services/report-export/ChartDataTransformer.ts
@@ -57,11 +57,11 @@ export class ChartDataTransformer {
   } {
     const snapshotLike = inventory as SnapshotLike;
 
-    const infra = (snapshotLike.infra ||
+    const infra =
+      snapshotLike.infra ||
       snapshotLike.inventory?.infra ||
       snapshotLike.inventory?.vcenter?.infra ||
-      (snapshotLike as { vcenter: { infra: InfraData } }).vcenter
-        ?.infra) as InfraData;
+      (snapshotLike as { vcenter: { infra: InfraData } }).vcenter?.infra;
 
     const vms = (snapshotLike.vms ||
       snapshotLike.inventory?.vms ||


### PR DESCRIPTION
- Updated the cluster sizing form to allow individual specification of CPU and memory overcommit ratios.
- Refactored related components and types to accommodate the new structure.
- Enhanced mock data and tests to reflect the changes in overcommit ratio handling.

Signed-off-by: Jonathan Kilzi <jkilzi@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Split overcommit configuration into separate CPU and Memory controls in the cluster sizing form for more granular resource management configuration.
  * Updated cluster sizing results to display CPU and Memory overcommit ratios independently instead of a combined value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->