### PR TITLE
ECOPROJECT-4004 | fix: example report crash 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,6 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[typescriptreact]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }


### PR DESCRIPTION
We've fixed the example report crash and add cluster selector and populate example report data.


https://github.com/user-attachments/assets/54de1d67-3b1d-46e4-a452-b9fc571113bc



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cluster selection UI to filter reports by a specific cluster or view aggregated infrastructure across all clusters.
  * Reports now present cluster-derived views, supplying aggregated or per-cluster data to report panels.

* **Data**
  * Sample dataset expanded with datastores, hosts, networks, VM summaries, per-datacenter metrics, and a vCenter ID field for richer reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->