### PR TITLE
ECOPROJECT-4006 | fix: mark as required the share aggregated checkbox in rvTools modal

### DIFF
--- a/src/pages/assessment/CreateAssessmentModal.tsx
+++ b/src/pages/assessment/CreateAssessmentModal.tsx
@@ -464,6 +464,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
                     onChange={(_event, checked) => {
                       setRvtoolsConsentChecked(Boolean(checked));
                     }}
+                    isRequired
                   />
                 </div>
               )}


### PR DESCRIPTION
We've addred a required Field check mark (*) next to the "I agree to share aggregate data about my environment with Red Hat" checkbox, as this is a required field:

<img width="830" height="410" alt="Captura desde 2026-02-12 14-57-37" src="https://github.com/user-attachments/assets/d10b140a-bcc6-49e3-9bee-0aa9c3608b90" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * RVTools data share consent field is now explicitly marked as required in the assessment creation form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->