### PR TITLE
NO-JIRA | feat: add local backend support for development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,13 @@ start: install
 	@HOT=true npx fec dev --clouddotEnv=stage --uiEnv=stable
 	@echo "✅ Federated dev server started!"
 
+# Start federated dev server with local backend
+.PHONY: start-local
+start-local: install
+	@echo "🚀 Starting federated dev server with local backend..."
+	@HOT=true USE_LOCAL_BACKEND=1 npx fec dev --clouddotEnv=stage --uiEnv=stable
+	@echo "✅ Federated dev server with local backend started!"
+
 # Start dev proxy server
 .PHONY: start-dev-proxy
 start-dev-proxy: install
@@ -375,6 +382,7 @@ help:
 	@echo "  run-standalone      Run the standalone application locally"
 	@echo "  preview-standalone  Preview standalone build"
 	@echo "  start               Start federated dev server (HOT mode)"
+	@echo "  start-local         Start federated dev server with local backend"
 	@echo "  start-dev-proxy     Start dev proxy server"
 	@echo "  start-federated     Start federated static server"
 	@echo "  patch-hosts         Patch /etc/hosts for local development"

--- a/dev/vite.config.ts
+++ b/dev/vite.config.ts
@@ -49,7 +49,7 @@ export default defineConfig(() => {
       port: 3000,
       proxy: {
         "/planner": {
-          target: "http://localhost:3443",
+          target: "http://[::1]:3443",
           secure: false,
           changeOrigin: true,
         },

--- a/fec.config.js
+++ b/fec.config.js
@@ -8,6 +8,16 @@ module.exports = {
   proxyVerbose: true,
   sassPrefix: ".assisted-migration-app, .assistedMigrationApp",
   interceptChromeConfig: false,
+  ...(process.env.USE_LOCAL_BACKEND && {
+    routes: {
+      "/api/migration-assessment": {
+        host: "http://[::1]:3443",
+        pathRewrite: {
+          "^/api/migration-assessment": "",
+        },
+      },
+    },
+  }),
   plugins: [
     new webpack.DefinePlugin({
       "process.env.MIGRATION_PLANNER_API_BASE_URL": JSON.stringify(

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "make test",
     "patch:hosts": "make patch-hosts",
     "start": "make start",
+    "start:local": "make start-local",
     "start:dev-proxy": "make start-dev-proxy",
     "start:federated": "make start-federated",
     "postinstall": "ts-patch install && rimraf .cache",


### PR DESCRIPTION
- Configure proxy to use IPv6 ([::1]:3443) instead of localhost
- Add pathRewrite to strip /api/migration-assessment prefix
- Add 'start-local' make target and npm script

Allows connecting to local migration-planner API in development mode.