### PR TITLE
ECOPROJECT-4045 | fix: propagate backend error messages in source creation

### DIFF
--- a/src/migration-wizard/contexts/discovery-sources/Provider.tsx
+++ b/src/migration-wizard/contexts/discovery-sources/Provider.tsx
@@ -100,10 +100,6 @@ const extractResponseErrorMessage = async (
   }
 };
 
-const isSource = (value: unknown): value is Source => {
-  return typeof value === "object" && value !== null && "id" in value;
-};
-
 export const Provider: React.FC<PropsWithChildren> = (props) => {
   const { children } = props;
   const [sourceSelected, setSourceSelected] = useState<Source | null>(null);
@@ -425,13 +421,16 @@ export const Provider: React.FC<PropsWithChildren> = (props) => {
         dns,
       );
 
-      if (!isSource(newSource)) {
+      // useAsyncFnResetError returns the error object as a value instead of throwing
+      // Check if newSource is actually an Error object
+      if (newSource instanceof Error) {
+        throw newSource;
+      }
+
+      // Validate that we got a valid source before proceeding
+      if (!newSource || !newSource.id) {
         throw new Error(
-          `Failed to create source. Response: ${JSON.stringify(
-            newSource,
-            null,
-            2,
-          )}`,
+          "Failed to create source: invalid response from server",
         );
       }
 


### PR DESCRIPTION
Propagate backend error messages in source creation

<img width="551" height="606" alt="Captura desde 2026-02-17 13-31-39" src="https://github.com/user-attachments/assets/803b6a5a-39e8-4c38-928a-6375204d0aae" />
