### PR TITLE
ECOPROJECT-3654 | fix: responsive icon view 

### DIFF
--- a/src/components/MigrationChart.css
+++ b/src/components/MigrationChart.css
@@ -11,3 +11,15 @@
   .pf-v5-c-button.pf-m-plain:hover {
   color: #000;
 }
+
+.migration-chart-info-trigger {
+  padding: 0;
+  min-width: 0;
+  margin-left: 0.25rem;
+}
+
+.migration-chart-info-trigger.pf-c-button {
+  padding: 0;
+  min-width: 0;
+  margin-left: 0.25rem;
+}

--- a/src/components/MigrationChart.tsx
+++ b/src/components/MigrationChart.tsx
@@ -128,27 +128,27 @@ const MigrationChart: React.FC<MigrationChartProps> = ({
                     <Td width={dataLength} style={{ paddingLeft: "0px" }}>
                       <Flex
                         alignItems={{ default: "alignItemsCenter" }}
-                        spaceItems={{ default: "spaceItemsSm" }}
+                        spaceItems={{ default: "spaceItemsNone" }}
                       >
-                        <FlexItem>
+                        <FlexItem
+                          flex={{ default: "flex_1" }}
+                          style={{ minWidth: 0 }}
+                        >
                           <Content
                             component={ContentVariants.p}
                             style={{
                               fontSize: "clamp(0.4rem, 0.7vw, 1.1rem)",
                               overflow: "hidden",
                               textOverflow: "ellipsis",
-                              wordBreak: "break-word",
-                              display: "-webkit-box",
-                              WebkitLineClamp: 1,
+                              whiteSpace: "nowrap",
                               textTransform: "capitalize",
-                              WebkitBoxOrient: "vertical",
                             }}
                           >
                             {item.name}
                           </Content>
                         </FlexItem>
                         {item.infoText ? (
-                          <FlexItem>
+                          <FlexItem flex={{ default: "flex_0" }}>
                             <Popover
                               className="upgrade-recommendation-popover"
                               position="bottom"
@@ -156,6 +156,7 @@ const MigrationChart: React.FC<MigrationChartProps> = ({
                               bodyContent={<div>{item.infoText}</div>}
                             >
                               <Button
+                                className="migration-chart-info-trigger"
                                 type="button"
                                 aria-label="Open operating system upgrade information"
                                 variant="plain"


### PR DESCRIPTION
When the cell is too narrow for the full name and the icon, the name now truncates with an ellipsis and the icon stays visible on the same line.

Here’s what was changed:
**Text FlexItem** – flex={{ default: "flex_1" }} and style={{ minWidth: 0 }} so it can shrink when space is tight. Without minWidth: 0, the flex item won’t shrink and the ellipsis won’t show.
**Icon FlexItem** – flex={{ default: "flex_0" }} so the icon keeps its size and stays on the same line instead of being pushed or wrapped.
**Text styling** – Replaced the -webkit-box / WebkitLineClamp setup with whiteSpace: "nowrap" so the label is forced to one line and textOverflow: "ellipsis" can apply when the text is clipped.
**Flex spacing** – spaceItems={{ default: "spaceItemsNone" }} so the icon sits right next to the truncated text (your existing .migration-chart-info-trigger margin-left in CSS still adds a small gap).
<img width="1482" height="744" alt="Screenshot 2026-02-23 at 17 00 42" src="https://github.com/user-attachments/assets/7f3f202d-fba7-4df9-b03a-1bc078d83ef3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined migration chart layout with improved spacing and alignment in legend items
  * Optimized text rendering in chart rows to display names on a single line for better readability
  * Enhanced styling of information trigger buttons within the chart

<!-- end of auto-generated comment: release notes by coderabbit.ai -->