### PR TITLE
ECOPROJECT-3906 | fix: aligning content to wrap title

### DIFF
--- a/src/services/report-export/PdfGenerator.ts
+++ b/src/services/report-export/PdfGenerator.ts
@@ -307,7 +307,10 @@ export class PdfGenerator {
         : "VMware Infrastructure Assessment Report";
 
     const titleLineHeight = 8;
-    const titleLines = pdf.splitTextToSize(headerTitle, contentWidth);
+    const titleLines = pdf.splitTextToSize(
+      headerTitle,
+      contentWidth,
+    ) as string[];
     let titleY = margin + 8;
     for (const line of titleLines) {
       pdf.text(line, pageWidth / 2, titleY, { align: "center" });


### PR DESCRIPTION
Long titles will wrap onto multiple centered lines instead of being cut off.
Summary of changes:
**Wrapped title:** The cover title is now split with pdf.splitTextToSize(headerTitle, contentWidth) so it wraps within the content width (page width minus margins). Each line is drawn centered with pdf.text(..., { align: "center" }).
**Vertical spacing:** A fixed line height of 8 mm is used for title lines. The “Generated:” line is placed 4 mm under the last title line (titleY + 4), and “Table of contents” plus TOC entries start at titleY + 16 and titleY + 10 so they stay below the title no matter how many lines it uses.

[Example vCenter assessment long name to test the tooltip - vCenter report - domain-c146658.pdf](https://github.com/user-attachments/files/25494864/Example.vCenter.assessment.long.name.to.test.the.tooltip.-.vCenter.report.-.domain-c146658.pdf)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PDF export layout to properly wrap long document titles across multiple lines, preventing overlap and truncation.
  * Improved positioning of the generated date so it consistently appears after the wrapped title block.
  * Adjusted Table of Contents vertical start and item spacing so TOC headers and entries align correctly with varied title heights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->