### PR TITLE
ECOPROJECT-4008 | feat: replacing 'Migration assessment' strings for 'Migration advisor'

### DIFF
--- a/dev/src/main.tsx
+++ b/dev/src/main.tsx
@@ -9,7 +9,7 @@ import App from "../../src/App"; // Make sure this path is correct relative to s
 // --- Mock/Standalone Shell Components ---
 export const StandaloneHeader: React.FC = () => (
   <header>
-    <h1>Migration Assessment App (Standalone) </h1>
+    <h1>Migration Advisor App (Standalone) </h1>
     <nav>
       <Link to="/"> Home </Link>
       <Link to="/inventory"> Inventory </Link>

--- a/src/ocm/VMwareMigrationCard.tsx
+++ b/src/ocm/VMwareMigrationCard.tsx
@@ -43,7 +43,7 @@ export const VMwareMigrationCard: React.FC = () => {
         <Content>
           <Content component="p">
             Start your migration journey to OpenShift Virtualization. We will
-            create a migration assessment report and help you create a migration
+            create a migration advisor report and help you create a migration
             plan.
           </Content>
         </Content>

--- a/src/pages/MigrationAssessmentPage.tsx
+++ b/src/pages/MigrationAssessmentPage.tsx
@@ -219,7 +219,7 @@ const MigrationAssessmentPage: React.FC = () => (
     breadcrumbs={[
       {
         key: 1,
-        children: "Migration assessment",
+        children: "Migration advisor",
         isActive: true,
       },
     ]}

--- a/src/pages/MigrationPage.tsx
+++ b/src/pages/MigrationPage.tsx
@@ -35,7 +35,7 @@ const MigrationPage: React.FC<Props> = ({ initialTabKey }) => {
   const breadcrumbs = [
     {
       key: 1,
-      children: "Migration assessment",
+      children: "Migration advisor",
     },
     {
       key: 2,

--- a/src/pages/MigrationWizardPage.tsx
+++ b/src/pages/MigrationWizardPage.tsx
@@ -10,7 +10,7 @@ const MigrationWizardPage: React.FC = () => {
         {
           key: 1,
           to: "/openshift/migration-assessment",
-          children: "Migration assessment",
+          children: "Migration advisor",
         },
         { key: 2, children: "Guide", isActive: true },
       ]}

--- a/src/pages/OcmPreviewPage.tsx
+++ b/src/pages/OcmPreviewPage.tsx
@@ -6,7 +6,7 @@ import { VMwareMigrationCard } from "../ocm/VMwareMigrationCard";
 
 const OcmPreviewPage: React.FC = () => {
   return (
-    <AppPage title="VMware Migration Assessment Card for OCM">
+    <AppPage title="VMware Migration Advisor Card for OCM">
       <Bullseye>
         <VMwareMigrationCard />
       </Bullseye>

--- a/src/pages/assessment/Assessment.tsx
+++ b/src/pages/assessment/Assessment.tsx
@@ -412,9 +412,9 @@ const Assessment: React.FC<Props> = ({
                       variant="primary"
                       onClick={onDropdownToggle}
                       isExpanded={isDropdownOpen}
-                      style={{ minWidth: "290px" }}
+                      style={{ minWidth: "90px" }}
                     >
-                      Create new migration assessment
+                      Create
                     </MenuToggle>
                   )}
                   shouldFocusToggleOnSelect

--- a/src/pages/assessment/AssessmentDetails.tsx
+++ b/src/pages/assessment/AssessmentDetails.tsx
@@ -88,7 +88,7 @@ const AssessmentDetails: React.FC = () => {
         breadcrumbs={[
           {
             key: 1,
-            children: "Migration assessment",
+            children: "Migration advisor",
           },
           {
             key: 2,
@@ -136,7 +136,7 @@ const AssessmentDetails: React.FC = () => {
         {
           key: 1,
           to: "/openshift/migration-assessment",
-          children: "Migration assessment",
+          children: "Migration advisor",
         },
         {
           key: 2,

--- a/src/pages/assessment/CreateAssessmentModal.tsx
+++ b/src/pages/assessment/CreateAssessmentModal.tsx
@@ -158,7 +158,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
         };
       case "rvtools":
         return {
-          title: "Create migration assessment from RVTools",
+          title: "Create migration advisor from RVTools",
           fileLabel: "RVTools File (Excel)",
           fileDescription: "Select an Excel file from RVTools (max 50 MiB)",
           accept: ".xlsx,.xls",
@@ -168,7 +168,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
         };
       case "agent":
         return {
-          title: "Create migration assessment from Environment",
+          title: "Create migration advisor from Environment",
           fileLabel: "Environment",
           fileDescription: "Select an environment to create assessment from",
           accept: "",
@@ -308,7 +308,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
       isDisabled={isButtonDisabled}
       isLoading={isLoading || isJobProcessing}
     >
-      Create Migration Assessment
+      Create Migration Advisor
     </Button>,
     <Button key="cancel" variant="link" onClick={handleClose}>
       Cancel

--- a/src/pages/assessment/CreateFromOva.tsx
+++ b/src/pages/assessment/CreateFromOva.tsx
@@ -237,7 +237,7 @@ const CreateFromOva: React.FC = () => {
         {
           key: 1,
           to: "/openshift/migration-assessment/",
-          children: "Migration assessment",
+          children: "Migration advisor",
         },
         {
           key: 2,
@@ -246,7 +246,7 @@ const CreateFromOva: React.FC = () => {
         },
         { key: 3, isActive: true, children: "create new assessment" },
       ]}
-      title="Create new migration assessment"
+      title="Create new assessment"
     >
       <div style={{ maxWidth: "900px" }}>
         <Form isWidthLimited>
@@ -276,7 +276,7 @@ const CreateFromOva: React.FC = () => {
               >
                 {hasDuplicateNameError
                   ? apiError?.message
-                  : "Name your migration assessment"}
+                  : "Name your assessment"}
               </HelperTextItem>
             </HelperText>
           </FormGroup>
@@ -288,7 +288,7 @@ const CreateFromOva: React.FC = () => {
               onClick={() => setIsStepsModalOpen(true)}
               style={{ paddingLeft: 0 }}
             >
-              Migration assessment steps
+              Migration advisor steps
             </Button>
           </div>
 

--- a/src/pages/assessment/EmptyTableBanner.tsx
+++ b/src/pages/assessment/EmptyTableBanner.tsx
@@ -58,7 +58,7 @@ const EmptyTableBanner: React.FC<Props> = ({ onOpenModal }) => {
             <Content style={{ textAlign: "center" }}>
               <Content component="p">
                 Run the discovery process or upload an inventory file to create
-                a full migration assessment report.
+                a full migration advisor report.
               </Content>
               <div
                 style={{
@@ -108,9 +108,9 @@ const EmptyTableBanner: React.FC<Props> = ({ onOpenModal }) => {
               variant="primary"
               onClick={onDropdownToggle}
               isExpanded={isDropdownOpen}
-              style={{ minWidth: "290px" }}
+              style={{ minWidth: "250px" }}
             >
-              Create new migration assessment
+              Create new assessment
             </MenuToggle>
           )}
           shouldFocusToggleOnSelect

--- a/src/pages/assessment/MigrationAssessmentStepsModal.tsx
+++ b/src/pages/assessment/MigrationAssessmentStepsModal.tsx
@@ -20,7 +20,7 @@ export const MigrationAssessmentStepsModal: React.FC<
 
   return (
     <Modal variant={ModalVariant.medium} isOpen={isOpen} onClose={onClose}>
-      <ModalHeader title="Migration assessment steps" />
+      <ModalHeader title="Migration advisor steps" />
       <ModalBody>
         <div className="pf-v6-u-mb-lg" style={{ display: "flex", gap: "16px" }}>
           <button

--- a/src/pages/environment/sources-table/SourcesTable.tsx
+++ b/src/pages/environment/sources-table/SourcesTable.tsx
@@ -518,7 +518,7 @@ export const SourcesTable: React.FC<SourceTableProps> = ({
                                   handleCreateAssessment(source.id)
                                 }
                               >
-                                Create new migration assessment
+                                Create new assessment
                               </DropdownItem>
                               <DropdownItem
                                 isDisabled={

--- a/src/pages/report/ExampleReport.tsx
+++ b/src/pages/report/ExampleReport.tsx
@@ -2012,7 +2012,7 @@ const ExampleReport: React.FC = () => {
       breadcrumbs={[
         {
           key: 1,
-          children: "Migration assessment",
+          children: "Migration advisor",
         },
         {
           key: 2,
@@ -2035,8 +2035,7 @@ const ExampleReport: React.FC = () => {
             </Icon>{" "}
             Ready
             <br />
-            This is an example report showcasing the migration assessment
-            dashboard
+            This is an example report showcasing the migration advisor dashboard
           </StackItem>
           <StackItem>
             {clusterCount > 0 ? (

--- a/src/pages/report/Report.tsx
+++ b/src/pages/report/Report.tsx
@@ -113,7 +113,7 @@ const Inner: React.FC = () => {
         breadcrumbs={[
           {
             key: 1,
-            children: "Migration assessment",
+            children: "Migration advisor",
           },
           {
             key: 2,
@@ -231,7 +231,7 @@ const Inner: React.FC = () => {
       breadcrumbs={[
         {
           key: 1,
-          children: "Migration assessment",
+          children: "Migration advisor",
         },
         {
           key: 2,

--- a/src/pages/starting-page/StartingPage.tsx
+++ b/src/pages/starting-page/StartingPage.tsx
@@ -44,7 +44,7 @@ const createCards = (
       <Content style={{ textAlign: "center" }}>
         <Content style={{ minHeight: "60px" }}>
           Run the discovery process or upload an inventory file to create a full
-          migration assessment report.
+          migration advisor report.
         </Content>
         <Button
           size="sm"

--- a/src/pages/starting-page/StartingPageModal.tsx
+++ b/src/pages/starting-page/StartingPageModal.tsx
@@ -48,11 +48,11 @@ const StartingPageModal: React.FC<Props> = ({
       variant={ModalVariant.large}
       isOpen={isOpen}
       onClose={onClose}
-      aria-label="Getting started with Migration Assessment"
+      aria-label="Getting started with Migration Advisor"
       className="starting-page-modal"
       header={
         <Title headingLevel="h1" size="xl">
-          Getting started with Migration Assessment
+          Getting started with Migration Advisor
         </Title>
       }
       actions={[
@@ -66,9 +66,9 @@ const StartingPageModal: React.FC<Props> = ({
               variant="primary"
               onClick={() => setIsDropdownOpen(!isDropdownOpen)}
               isExpanded={isDropdownOpen}
-              style={{ minWidth: "290px" }}
+              style={{ minWidth: "180px" }}
             >
-              Create new migration assessment
+              Create new assessment
             </MenuToggle>
           )}
         >


### PR DESCRIPTION
feat: replacing 'Migration assessment' strings for 'Migration advisor'

<img width="1448" height="829" alt="Captura desde 2026-02-23 17-55-32" src="https://github.com/user-attachments/assets/2a8a977a-e1a4-4b6a-bd2a-f7a0eaf4339b" />
<img width="1422" height="700" alt="image" src="https://github.com/user-attachments/assets/3fcbddc9-0698-4d59-b0fa-cbf542a3fcd3" />
<img width="1491" height="532" alt="Captura desde 2026-02-23 17-53-27" src="https://github.com/user-attachments/assets/3e9f6b7d-1cfe-4159-89d6-cabbf76ad1b8" />
<img width="1107" height="468" alt="Captura desde 2026-02-23 17-52-36" src="https://github.com/user-attachments/assets/db676833-7736-4805-9961-319fdc37568a" />
<img width="1107" height="468" alt="Captura desde 2026-02-23 17-52-08" src="https://github.com/user-attachments/assets/4209af6f-c202-423c-a19f-a5fb2bcdddb8" />
<img width="1154" height="268" alt="Captura desde 2026-02-23 17-47-27" src="https://github.com/user-attachments/assets/8417fead-0879-4217-86a7-60b31af6da57" />
<img width="1332" height="549" alt="image" src="https://github.com/user-attachments/assets/0137b62e-a3f7-404a-8fbc-9fb3d2b05efb" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Rebranded "Migration Assessment" to "Migration Advisor" across the app (breadcrumbs, titles, modals, cards, and reports).
  * Updated VMware card wording to reference the advisor report and migration plan.
  * Shortened and refined button labels (e.g., "Create") and adjusted dropdown/modal widths for improved UI consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->