### PR TITLE
ECOPROJECT-4101 | ci: Add new deployment for dev environment

### DIFF
--- a/deploy/frontend-dev.yaml
+++ b/deploy/frontend-dev.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/RedHatInsights/frontend-components/refs/heads/master/packages/config-utils/src/feo/spec/frontend-crd.schema.json
+apiVersion: v1
+kind: Template
+metadata:
+  name: migration-advisor-dev
+objects:
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: Frontend
+    metadata:
+      name: migration-advisor-dev
+    spec:
+      API:
+        versions:
+          - v1
+      envName: ${ENV_NAME}
+      title: Migration Advisor (Dev)
+      deploymentRepo: https://gitlab.cee.redhat.com/assisted-migration/migration-assessment-app
+      frontend:
+        paths:
+          - /apps/migration-advisor-app-dev
+      image: ${IMAGE}:${IMAGE_TAG}
+      module:
+        manifestLocation: "/apps/assisted-migration-app/fed-mods.json"
+        modules:
+          - id: "migration-assessment"
+            module: "./RootApp"
+            routes:
+              - pathname: /openshift/migration-advisor-dev
+
+parameters:
+  - name: ENV_NAME
+    required: true
+  - name: IMAGE_TAG
+  - name: IMAGE
+    required: true


### PR DESCRIPTION
This new environment would be used for the development automatic deploy after push to main branch
The original stage deployment would be used as a stable environment for consulting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a development deployment configuration for the migration-advisor frontend, enabling containerized deployments for the dev environment with environment name, image and tag parameters, repository/path settings, and a dedicated route for the development deployment. This prepares the frontend for straightforward dev deployments and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->