### PR TITLE
ECOPROJECT-4073 | fix: Changing titles and color of OSDistribution chart

### DIFF
--- a/src/pages/report/assessment-report/OSDistribution.tsx
+++ b/src/pages/report/assessment-report/OSDistribution.tsx
@@ -90,15 +90,15 @@ export const OSBarChart: React.FC<OSBarChartProps> = ({
     name: os,
     count: osInfo.count,
     legendCategory: osInfo.supported
-      ? "Supported by Red Hat"
-      : "Not supported by Red Hat",
+      ? "Supported by MTV"
+      : "Not supported by MTV",
     infoText: osInfo.upgradeRecommendation,
   }));
 
   // Define custom colors: green for supported, red for not supported
   const customLegend = {
-    "Supported by Red Hat": "#28a745", // Green
-    "Not supported by Red Hat": "#d9534f", // Red
+    "Supported by MTV": "#28a745", // Green
+    "Not supported by MTV": "#f0ad4e", // Yellow
   };
 
   const tableHeight = isExportMode ? "auto !important" : "350px";


### PR DESCRIPTION
Changing titles and color of OSDistribution chart

<img width="850" height="602" alt="Screenshot 2026-02-24 at 18 17 39" src="https://github.com/user-attachments/assets/5915bab6-f413-4183-8e2f-32f1a692ea61" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated OS compatibility terminology and visual color indicators in assessment reports.
  * Modified color scheme for unsupported OS status from red to orange for improved visual distinction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->