### PR TITLE
ECOPROJECT-4131 | fix: when exporting to PDF, all cards will expand to their full content height

### DIFF
--- a/src/ui/core/components/MigrationChart.tsx
+++ b/src/ui/core/components/MigrationChart.tsx
@@ -132,7 +132,12 @@ const MigrationChart: React.FC<MigrationChartProps> = ({
           direction={{ default: "column" }}
           spaceItems={{ default: "spaceItemsMd" }}
         >
-          <div style={{ maxHeight: maxHeight, overflowY: "auto" }}>
+          <div
+            style={{
+              maxHeight: maxHeight.includes("auto") ? "none" : maxHeight,
+              overflowY: maxHeight.includes("auto") ? "visible" : "auto",
+            }}
+          >
             <Table variant="compact" borders={false}>
               <Tbody>
                 {data.map((item, index) => (

--- a/src/ui/core/components/OffScreenRenderer.tsx
+++ b/src/ui/core/components/OffScreenRenderer.tsx
@@ -29,6 +29,8 @@ const offScreenContainer = css`
     box-shadow: none !important;
     color: black !important;
     border: 1px solid rgba(3, 3, 3, 0.25);
+    max-height: none !important;
+    overflow: visible !important;
   }
 
   .dashboard-card-print,
@@ -41,6 +43,13 @@ const offScreenContainer = css`
     border: none !important;
     box-shadow: none !important;
     padding: 0 !important;
+    max-height: none !important;
+    overflow: visible !important;
+  }
+
+  .pf-v6-c-card__body {
+    overflow: visible !important;
+    max-height: none !important;
   }
 `;
 

--- a/src/ui/report/views/assessment-report/ClustersOverview.tsx
+++ b/src/ui/report/views/assessment-report/ClustersOverview.tsx
@@ -452,7 +452,7 @@ export const ClustersOverview: React.FC<ClustersOverviewProps> = ({
       className={dashboardCard}
       id="clusters-overview"
       data-export-block={isExportMode ? "3.1" : undefined}
-      style={{ overflow: "hidden" }}
+      style={{ overflow: isExportMode ? "visible" : "hidden" }}
     >
       <CardTitle>
         <Flex

--- a/src/ui/report/views/assessment-report/CpuAndMemoryOverview.tsx
+++ b/src/ui/report/views/assessment-report/CpuAndMemoryOverview.tsx
@@ -156,7 +156,7 @@ export const CpuAndMemoryOverview: React.FC<CpuAndMemoryOverviewProps> = ({
     <Card
       className={dashboardCard}
       id="cpu-memory-overview"
-      style={{ overflow: "hidden" }}
+      style={{ overflow: isExportMode ? "visible" : "hidden" }}
     >
       <CardTitle>
         <Flex

--- a/src/ui/report/views/assessment-report/HostsOverview.tsx
+++ b/src/ui/report/views/assessment-report/HostsOverview.tsx
@@ -98,7 +98,7 @@ export const HostsOverview: React.FC<HostsOverviewProps> = ({
     <Card
       className={dashboardCard}
       id="hosts-overview"
-      style={{ overflow: "hidden" }}
+      style={{ overflow: isExportMode ? "visible" : "hidden" }}
     >
       <CardTitle>
         <Flex

--- a/src/ui/report/views/assessment-report/NetworkOverview.tsx
+++ b/src/ui/report/views/assessment-report/NetworkOverview.tsx
@@ -253,7 +253,7 @@ export const NetworkOverview: React.FC<NetworkOverviewProps> = ({
     <Card
       className={dashboardCard}
       id="network-overview"
-      style={{ overflow: "hidden" }}
+      style={{ overflow: isExportMode ? "visible" : "hidden" }}
     >
       <CardTitle>
         <Flex

--- a/src/ui/report/views/assessment-report/StorageOverview.tsx
+++ b/src/ui/report/views/assessment-report/StorageOverview.tsx
@@ -244,7 +244,7 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
     <Card
       className={dashboardCard}
       id="storage-overview"
-      style={{ overflow: "hidden" }}
+      style={{ overflow: isExportMode ? "visible" : "hidden" }}
     >
       <CardTitle>
         <Flex

--- a/src/ui/report/views/assessment-report/VMMigrationStatus.tsx
+++ b/src/ui/report/views/assessment-report/VMMigrationStatus.tsx
@@ -15,7 +15,7 @@ interface VmMigrationStatusProps {
 
 export const VMMigrationStatus: React.FC<VmMigrationStatusProps> = ({
   data,
-  isExportMode: _isExportMode = false,
+  isExportMode = false,
 }) => {
   const donutData = [
     {
@@ -41,7 +41,10 @@ export const VMMigrationStatus: React.FC<VmMigrationStatusProps> = ({
     <Card
       className={dashboardCard}
       id="vm-migration-status"
-      style={{ height: "340px !important", overflow: "hidden" }}
+      style={{
+        height: isExportMode ? "auto" : "340px !important",
+        overflow: isExportMode ? "visible" : "hidden",
+      }}
     >
       <CardTitle>
         <VirtualMachineIcon /> VM Migration Status


### PR DESCRIPTION
When exporting to PDF, all cards will expand to their full content height their full content height without any clipping, ensuring users can see all the data in the exported PDF file.


https://github.com/user-attachments/assets/71124aea-3066-4443-b90d-856a2ed96d9e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering behavior during report export. Content now properly displays without unwanted clipping or height restrictions when generating PDFs or exporting assessment reports.
  * Enhanced overflow handling in assessment report components to ensure all content is visible during export operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->