### PR TITLE
ECOPROJECT-4101 | feat: Add runtime API path detection for multi-deployment support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -167,6 +167,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -622,6 +623,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -662,6 +664,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -681,7 +684,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
       "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -710,7 +712,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
       "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/utilities": "^3.2.2",
         "tslib": "^2.0.0"
@@ -725,7 +726,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
       "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/utilities": "^3.2.2",
         "tslib": "^2.0.0"
@@ -740,7 +740,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
       "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -2559,6 +2558,7 @@
       "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.4.1.tgz",
       "integrity": "sha512-EUSV76Eifkt4R3q2JIaiB6/FHeQqOCttK1DQMXNoOCNa3ODkZ7H+KlMdminufMDfRzhwAgTVihZ62K9PFfc8Vg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@patternfly/react-icons": "^6.4.0",
         "@patternfly/react-styles": "^6.4.0",
@@ -2583,7 +2583,6 @@
       "resolved": "https://registry.npmjs.org/@patternfly/react-drag-drop/-/react-drag-drop-6.4.1.tgz",
       "integrity": "sha512-+zkN+6JO/6qPKb1srsKyC4OpeF/dgQvZ0U4soXeh/n22n2YVcrH9QAUGn1QBB7FmLiAoATHB9vr1awafF5HIYw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
@@ -2602,14 +2601,14 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.4.0.tgz",
       "integrity": "sha512-EXmHA67s5sy+Wy/0uxWoUQ52jr9lsH2wV3QcgtvVc5zxpyBX89gShpqv4jfVqaowznHGDoL6fVBBrSe9BYOliQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@patternfly/react-icons": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.4.0.tgz",
       "integrity": "sha512-SPjzatm73NUYv/BL6A/cjRA5sFQ15NkiyPAcT8gmklI7HY+ptd6/eg49uBDFmxTQcSwbb5ISW/R6wwCQBY2M+Q==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^17 || ^18 || ^19",
         "react-dom": "^17 || ^18 || ^19"
@@ -2626,6 +2625,7 @@
       "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.4.1.tgz",
       "integrity": "sha512-dceS5X1I5gmhRfEf6gsLIdFhrQd5hY+SWRIYzEvI19rrdN9VwCVWg+bhSsNv05pQnGs8uOlzYVBI25p7PJtFeA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@patternfly/react-core": "^6.4.1",
         "@patternfly/react-icons": "^6.4.0",
@@ -2649,7 +2649,8 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.4.0.tgz",
       "integrity": "sha512-iZthBoXSGQ/+PfGTdPFJVulaJZI3rwE+7A/whOXPGp3Jyq3k6X52pr1+5nlO6WHasbZ9FyeZGqXf4fazUZNjbw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@peculiar/asn1-cms": {
       "version": "2.6.1",
@@ -2945,9 +2946,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config": {
-      "version": "6.7.53",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.7.53.tgz",
-      "integrity": "sha512-v2g41hgEK4jGXngc48RPrPx9j0FkUvjrU4gYIY7qphNt3hQGGfgqxSeAAMAnliQHlzYXycA4xSPluXhQ/wp3HA==",
+      "version": "6.7.54",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.7.54.tgz",
+      "integrity": "sha512-2wjnI9D5L22C8u1RFqoQEYlv23kXwTOpXTvDmSelYYPXtf1fatkrWIaK9TLsGFi8ExF/DLsPvXIdfiPsUMRkRA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2999,9 +3000,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config-utilities": {
-      "version": "4.7.30",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-4.7.30.tgz",
-      "integrity": "sha512-5dIZNoFPXQqC1TVr4dT8tKrEYQ949YJFksfWpwrXzVGuu+ZKW59GVNrvYgIGOJ0/QndS2dEB6kwS6jbY3Dc/SA==",
+      "version": "4.7.31",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-4.7.31.tgz",
+      "integrity": "sha512-1VexGAIZ0CbVsT7NaWHYrwBzk8PwK/dkDhR3M0+d1q6RnB1Y9jWNc0iAk+Ev76vf4sNwG20b2yqVF9toz6xr0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3022,6 +3023,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3809,6 +3811,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -4034,6 +4037,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4254,6 +4258,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -4470,6 +4475,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4481,6 +4487,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4572,8 +4579,7 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -4630,6 +4636,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -5310,6 +5317,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5359,6 +5367,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6123,6 +6132,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8087,6 +8097,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8147,6 +8158,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8952,6 +8964,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -11621,7 +11634,8 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash-es": {
       "version": "4.17.23",
@@ -13609,6 +13623,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13718,6 +13733,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13818,6 +13834,7 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -13913,16 +13930,6 @@
         "performance-now": "^2.1.0"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -13954,6 +13961,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -13966,6 +13974,7 @@
       "resolved": "https://registry.npmjs.org/react-content-loader/-/react-content-loader-6.2.1.tgz",
       "integrity": "sha512-6ONbFX+Hi3SHuP66JB8CPvJn372pj+qwltJV0J8z/8MFrq98I1cbFdZuhDWeQXu3CFxiiDTXJn7DFxx2ZvrO7g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -13984,6 +13993,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -14100,6 +14110,7 @@
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14124,6 +14135,7 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
       "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.23.2",
         "react-router": "6.30.3"
@@ -15029,13 +15041,13 @@
       "license": "MIT"
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
+      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-index": {
@@ -16305,7 +16317,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
@@ -16346,6 +16359,7 @@
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -16451,6 +16465,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16705,7 +16720,6 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -17193,6 +17207,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -17268,6 +17283,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -17418,11 +17434,12 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.105.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
-      "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
+      "version": "5.105.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.3.tgz",
+      "integrity": "sha512-LLBBA4oLmT7sZdHiYE/PeVuifOxYyE2uL/V+9VQP7YSYdJU7bSf7H8bZRRxW8kEPMkmVjnrXmoR3oejIdX0xbg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -17430,7 +17447,7 @@
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-import-phases": "^1.0.3",
         "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
@@ -17448,7 +17465,7 @@
         "tapable": "^2.3.0",
         "terser-webpack-plugin": "^5.3.16",
         "watchpack": "^2.5.1",
-        "webpack-sources": "^3.3.3"
+        "webpack-sources": "^3.3.4"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -17472,6 +17489,7 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -17615,6 +17633,7 @@
       "integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -18148,6 +18167,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     },
     "@redhat-cloud-services/tsc-transform-imports": {
       "glob": ">=10.4.6"
-    }
+    },
+    "serialize-javascript": ">=7.0.3"
   },
   "insights": {
     "appname": "assisted-migration-app"

--- a/src/config/ApiConfig.ts
+++ b/src/config/ApiConfig.ts
@@ -1,0 +1,49 @@
+/**
+ * Maps frontend route paths to their corresponding backend API paths.
+ * This allows a single build to work with multiple deployments.
+ */
+const ROUTE_TO_API_MAP: Record<string, string> = {
+  "/openshift/migration-assessment": "/api/migration-assessment",
+  "/openshift/migration-advisor-dev": "/api/migration-advisor-dev",
+} as const;
+
+/**
+ * Fallback API base URL for local development or when route is not recognized.
+ */
+const DEFAULT_API_BASE_URL = "/api/migration-assessment";
+
+/**
+ * Determines the API base URL at runtime based on the current frontend path.
+ *
+ * This enables a single build to support multiple deployments (e.g., stage and dev)
+ * by detecting the frontend route and mapping it to the appropriate backend API.
+ *
+ * @returns The API base URL for the current deployment
+ */
+export function resolveApiBaseUrl(): string {
+  try {
+    // Strip known Chrome preview/beta prefixes before matching (only full path segments)
+    const pathname = window.location.pathname.replace(
+      /^\/(preview|beta)(?=\/|$)/,
+      "",
+    );
+
+    // Check each known route pattern (match full path segments only)
+    for (const [route, apiPath] of Object.entries(ROUTE_TO_API_MAP)) {
+      if (pathname === route || pathname.startsWith(`${route}/`)) {
+        return apiPath;
+      }
+    }
+
+    // Fallback for local development or unknown routes
+    // If MIGRATION_PLANNER_API_BASE_URL is set at build time, use it
+    if (process.env.MIGRATION_PLANNER_API_BASE_URL) {
+      return process.env.MIGRATION_PLANNER_API_BASE_URL;
+    }
+
+    return DEFAULT_API_BASE_URL;
+  } catch {
+    // SSR / test environment without DOM - use build-time variable or fallback
+    return process.env.MIGRATION_PLANNER_API_BASE_URL || DEFAULT_API_BASE_URL;
+  }
+}

--- a/src/config/Dependencies.ts
+++ b/src/config/Dependencies.ts
@@ -18,6 +18,7 @@ import { VersionsStore } from "../data/stores/VersionsStore";
 import { createAuthMiddleware } from "../lib/middleware/Auth";
 import { HtmlExportService } from "../services/html-export/HtmlExportService";
 import { PdfExportService } from "../services/pdf-export/PdfExportService";
+import { resolveApiBaseUrl } from "./ApiConfig";
 
 /** Symbols used by the DI container */
 export const Symbols = Object.freeze({
@@ -31,8 +32,20 @@ export const Symbols = Object.freeze({
 });
 
 export const createContainer = (auth: ChromeAPI["auth"]): Container => {
+  const apiBaseUrl = resolveApiBaseUrl();
+
+  // Log the detected API path for debugging (safe for SSR/test environments)
+  try {
+    console.log("[Migration Planner] Runtime API Path Detection:", {
+      currentPath: window.location.pathname,
+      detectedApiPath: apiBaseUrl,
+    });
+  } catch {
+    // SSR or test environment without DOM - skip logging
+  }
+
   const plannerApiConfig = new Configuration({
-    basePath: process.env.MIGRATION_PLANNER_API_BASE_URL,
+    basePath: apiBaseUrl,
     middleware: [createAuthMiddleware(auth)],
   });
 

--- a/src/config/__tests__/ApiConfig.test.ts
+++ b/src/config/__tests__/ApiConfig.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resolveApiBaseUrl } from "../ApiConfig";
+
+describe("resolveApiBaseUrl", () => {
+  const originalLocation = window.location;
+
+  afterEach(() => {
+    // Restore environment variables
+    vi.unstubAllEnvs();
+    // Restore window.location
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("should return /api/migration-assessment for production route", () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        pathname: "/openshift/migration-assessment/assessments",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    expect(resolveApiBaseUrl()).toBe("/api/migration-assessment");
+  });
+
+  it("should return /api/migration-advisor-dev for dev route", () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        pathname: "/openshift/migration-advisor-dev/assessments",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    expect(resolveApiBaseUrl()).toBe("/api/migration-advisor-dev");
+  });
+
+  it("should strip /preview prefix before matching", () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        pathname: "/preview/openshift/migration-assessment/assessments",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    expect(resolveApiBaseUrl()).toBe("/api/migration-assessment");
+  });
+
+  it("should strip /beta prefix before matching", () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        pathname: "/beta/openshift/migration-advisor-dev/assessments",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    expect(resolveApiBaseUrl()).toBe("/api/migration-advisor-dev");
+  });
+
+  it("should use build-time env variable for unknown routes", () => {
+    vi.stubEnv("MIGRATION_PLANNER_API_BASE_URL", "/api/custom-path");
+
+    Object.defineProperty(window, "location", {
+      value: {
+        pathname: "/unknown/path",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    expect(resolveApiBaseUrl()).toBe("/api/custom-path");
+  });
+
+  it("should use default fallback when no env variable and unknown route", () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        pathname: "/unknown/path",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    expect(resolveApiBaseUrl()).toBe("/api/migration-assessment");
+  });
+
+  it("should NOT strip /preview when not a full path segment", () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        pathname: "/previewx/openshift/migration-assessment/assessments",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    // Should fall back to default since /previewx/openshift/... is not a known route
+    expect(resolveApiBaseUrl()).toBe("/api/migration-assessment");
+  });
+
+  it("should NOT strip /beta when not a full path segment", () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        pathname: "/beta-test/openshift/migration-assessment/assessments",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    // Should fall back to default since /beta-test/openshift/... is not a known route
+    expect(resolveApiBaseUrl()).toBe("/api/migration-assessment");
+  });
+
+  it("should NOT match partial route segments (suffix)", () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        pathname: "/openshift/migration-assessment-foo/assessments",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    // Should fall back to default since the route continues without a separator
+    expect(resolveApiBaseUrl()).toBe("/api/migration-assessment");
+  });
+
+  it("should NOT match partial route segments for dev route", () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        pathname: "/openshift/migration-advisor-development/assessments",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    // Should fall back to default since migration-advisor-development != migration-advisor-dev
+    expect(resolveApiBaseUrl()).toBe("/api/migration-assessment");
+  });
+
+  it("should match exact route without trailing path", () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        pathname: "/openshift/migration-assessment",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    expect(resolveApiBaseUrl()).toBe("/api/migration-assessment");
+  });
+
+  it("should handle error and fall back to env variable", () => {
+    vi.stubEnv("MIGRATION_PLANNER_API_BASE_URL", "/api/fallback");
+
+    // Mock window.location to throw error
+    Object.defineProperty(window, "location", {
+      get: () => {
+        throw new Error("No window");
+      },
+      configurable: true,
+    });
+
+    expect(resolveApiBaseUrl()).toBe("/api/fallback");
+  });
+
+  it("should handle error and use default when no env variable", () => {
+    // Mock window.location to throw error
+    Object.defineProperty(window, "location", {
+      get: () => {
+        throw new Error("No window");
+      },
+      configurable: true,
+    });
+
+    expect(resolveApiBaseUrl()).toBe("/api/migration-assessment");
+  });
+});

--- a/src/config/__tests__/Dependencies.test.ts
+++ b/src/config/__tests__/Dependencies.test.ts
@@ -55,6 +55,9 @@ vi.mock("../../services/pdf-export/PdfExportService", () => ({
 vi.mock("../../lib/middleware/Auth", () => ({
   createAuthMiddleware: vi.fn().mockReturnValue({ pre: vi.fn() }),
 }));
+vi.mock("../ApiConfig", () => ({
+  resolveApiBaseUrl: vi.fn().mockReturnValue("/api/migration-assessment"),
+}));
 
 // ---------------------------------------------------------------------------
 // Chrome stub


### PR DESCRIPTION
Enable single build to support multiple deployments by detecting API path at runtime based on frontend route

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single-build deployments now auto-detect and route API requests to the correct backend (handles preview/beta URL prefixes) with safe fallbacks.
* **Tests**
  * Added comprehensive unit tests covering URL-based API resolution, preview/beta handling, environment overrides, and error fallbacks.
* **Chores**
  * Updated package dependency override for serialize-javascript to ensure compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->