### PR TITLE
ECOPROJECT-4132 | fix: pre-select environment when creating assessment from row action

### DIFF
--- a/src/ui/assessment/view-models/__tests__/useCreateFromOvaViewModel.test.ts
+++ b/src/ui/assessment/view-models/__tests__/useCreateFromOvaViewModel.test.ts
@@ -13,11 +13,14 @@ import { useCreateFromOvaViewModel } from "../useCreateFromOvaViewModel";
 // ---------------------------------------------------------------------------
 
 const mockNavigate = vi.fn();
+let mockLocationState:
+  | { reset?: boolean; preselectedSourceId?: string }
+  | undefined = undefined;
 
 vi.mock("react-router-dom", () => ({
   useNavigate: () => mockNavigate,
   useLocation: () => ({
-    state: undefined,
+    state: mockLocationState,
     pathname: "/create",
     search: "",
     hash: "",
@@ -73,6 +76,7 @@ const makeSource = (overrides: Partial<Source> = {}): SourceModel =>
 describe("useCreateFromOvaViewModel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockLocationState = undefined;
     vi.stubGlobal("sessionStorage", {
       getItem: vi.fn().mockReturnValue(null),
       setItem: vi.fn(),
@@ -438,6 +442,41 @@ describe("useCreateFromOvaViewModel", () => {
     expect(result.current.name).toBe("Saved Draft");
     expect(result.current.useExisting).toBe(true);
     expect(result.current.selectedEnvironmentId).toBe("s-saved");
+  });
+
+  it("pre-selects environment when coming from environment page with reset flag", () => {
+    const preselectedSource = makeSource({
+      id: "s-preselected",
+      name: "Preselected",
+    });
+    mockEnvVm.sources = [preselectedSource];
+    mockLocationState = { reset: true, preselectedSourceId: "s-preselected" };
+
+    const { result } = renderHook(() => useCreateFromOvaViewModel());
+
+    expect(result.current.name).toBe("");
+    expect(result.current.useExisting).toBe(true);
+    expect(result.current.selectedEnvironmentId).toBe("s-preselected");
+    expect(sessionStorage.removeItem).toHaveBeenCalled();
+  });
+
+  it("pre-selects manually uploaded environment when coming from environment page", () => {
+    const manuallyUploadedSource = makeSource({
+      id: "s-manual",
+      name: "Manually Uploaded",
+      agent: undefined,
+      onPremises: true,
+      inventory: { vcenter: {} } as Source["inventory"],
+    });
+    mockEnvVm.sources = [manuallyUploadedSource];
+    mockLocationState = { reset: true, preselectedSourceId: "s-manual" };
+
+    const { result } = renderHook(() => useCreateFromOvaViewModel());
+
+    expect(result.current.name).toBe("");
+    expect(result.current.useExisting).toBe(true);
+    expect(result.current.selectedEnvironmentId).toBe("s-manual");
+    expect(sessionStorage.removeItem).toHaveBeenCalled();
   });
 
   // ---- createdSource lookup -------------------------------------------------

--- a/src/ui/assessment/view-models/useCreateFromOvaViewModel.ts
+++ b/src/ui/assessment/view-models/useCreateFromOvaViewModel.ts
@@ -74,7 +74,7 @@ export interface CreateFromOvaViewModel {
 export const useCreateFromOvaViewModel = (): CreateFromOvaViewModel => {
   const navigate = useNavigate();
   const location = useLocation() as {
-    state?: { reset?: boolean };
+    state?: { reset?: boolean; preselectedSourceId?: string };
     pathname: string;
     search: string;
     hash?: string;
@@ -152,8 +152,16 @@ export const useCreateFromOvaViewModel = (): CreateFromOvaViewModel => {
     const shouldReset = Boolean(location.state?.reset);
     if (shouldReset) {
       setName("");
-      setUseExisting(false);
-      setSelectedEnvironmentId("");
+      // Check if we have a pre-selected source ID from navigation state
+      const preselectedSourceId = location.state?.preselectedSourceId;
+      if (preselectedSourceId) {
+        // Pre-select the environment from navigation state
+        setUseExisting(true);
+        setSelectedEnvironmentId(preselectedSourceId);
+      } else {
+        setUseExisting(false);
+        setSelectedEnvironmentId("");
+      }
       try {
         sessionStorage.removeItem(DRAFT_KEY);
       } catch {

--- a/src/ui/environment/views/SourcesTable.tsx
+++ b/src/ui/environment/views/SourcesTable.tsx
@@ -257,7 +257,7 @@ export const SourcesTable: React.FC<SourceTableProps> = ({
     vm.setAssessmentFromAgent?.(true);
     vm.selectSourceById?.(sourceId);
     navigate(routes.assessmentCreate, {
-      state: { reset: true },
+      state: { reset: true, preselectedSourceId: sourceId },
     });
   };
 


### PR DESCRIPTION
When a user creates a new migration assessment from an existing environment row (Environments tab → row Actions → “Create new migration assessment”), the wizard opens and has to pre-select that environment.
Steps to reproduce:

1. Open Migration Assessment and go to the Environments tab.
2. In the Sources table, use the Actions menu on a row for an existing environment with status "Ready" or "Uploaded manually"
3. Click “Create new migration assessment”.
4. Observe the create-assessment wizard.


https://github.com/user-attachments/assets/5a22aa80-38d8-4df2-8a3c-61613dd7b55b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When creating a new assessment from the environment sources page, the source environment you were viewing is now automatically pre-selected in the assessment form, including manually uploaded environments and when using the reset flow.
* **Tests**
  * Added tests covering pre-selection behavior and session cleanup when navigating from the environment page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->