### PR TITLE
ECOPROJECT-4133 | fix: Update assessment list immediately after deletion

### DIFF
--- a/src/data/stores/AssessmentsStore.ts
+++ b/src/data/stores/AssessmentsStore.ts
@@ -1,6 +1,7 @@
 import {
   type AssessmentApiInterface,
   type CalculateAssessmentClusterRequirementsRequest,
+  ResponseError,
 } from "@openshift-migration-advisor/planner-sdk";
 import { type Assessment } from "@openshift-migration-advisor/planner-sdk";
 import { type InitOverrideFunction } from "@openshift-migration-advisor/planner-sdk";
@@ -105,12 +106,36 @@ export class AssessmentsStore
     id: string,
     initOverrides?: RequestInit | InitOverrideFunction,
   ): Promise<AssessmentModel> {
-    const deleted = await this.api.deleteAssessment({ id }, initOverrides);
+    const deletedAssessment = this.assessments.find((a) => a.id === id);
+    if (!deletedAssessment) {
+      throw new Error(`Assessment ${id} not found in local state`);
+    }
+
+    try {
+      // Call the API - the backend's delete endpoint returns a malformed response
+      // with null snapshots that breaks the SDK's JSON parser. We catch and ignore
+      // this parsing error since the deletion itself succeeds (status 200).
+      await this.api.deleteAssessment({ id }, initOverrides);
+    } catch (error) {
+      // Only suppress parsing errors if the HTTP response was successful.
+      // The SDK throws ResponseError when JSON parsing fails after a successful HTTP call.
+      // We must verify the deletion actually succeeded (status 200) before updating local state.
+      const hasSuccessStatus =
+        (error as { response?: { status?: number } })?.response?.status === 200;
+
+      const isSuccessfulDeletion =
+        error instanceof ResponseError && hasSuccessStatus;
+
+      if (!isSuccessfulDeletion) {
+        throw error;
+      }
+    }
+
     this.assessments = this.assessments.filter(
-      (assessment) => assessment.id !== deleted.id,
+      (assessment) => assessment.id !== id,
     );
     this.notify();
-    return createAssessmentModel(deleted);
+    return deletedAssessment;
   }
 
   calculateAssessmentClusterRequirements(

--- a/src/data/stores/__tests__/AssessmentsStore.test.ts
+++ b/src/data/stores/__tests__/AssessmentsStore.test.ts
@@ -1,5 +1,6 @@
 import type { AssessmentApiInterface } from "@openshift-migration-advisor/planner-sdk";
 import type { Assessment } from "@openshift-migration-advisor/planner-sdk";
+import { ResponseError } from "@openshift-migration-advisor/planner-sdk";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AssessmentsStore } from "../AssessmentsStore";
@@ -182,6 +183,53 @@ describe("AssessmentsStore", () => {
     expect(result.id).toBe("a-1");
     expect(store.getSnapshot()).toHaveLength(1);
     expect(store.getSnapshot()[0].id).toBe("a-2");
+  });
+
+  it("remove() suppresses ResponseError with status 200 (parsing error after successful deletion)", async () => {
+    const items = [
+      makeAssessment({ id: "a-1" }),
+      makeAssessment({ id: "a-2" }),
+    ];
+    vi.mocked(api.listAssessments).mockResolvedValue(items as never);
+    await store.list();
+
+    const mockResponse = new Response(null, { status: 200 });
+    const responseError = new ResponseError(
+      mockResponse,
+      "Failed to parse response",
+    );
+    vi.mocked(api.deleteAssessment).mockRejectedValue(responseError);
+
+    const result = await store.remove("a-1");
+
+    expect(result.id).toBe("a-1");
+    expect(store.getSnapshot()).toHaveLength(1);
+    expect(store.getSnapshot()[0].id).toBe("a-2");
+  });
+
+  it("remove() rethrows ResponseError with non-200 status", async () => {
+    const items = [makeAssessment({ id: "a-1" })];
+    vi.mocked(api.listAssessments).mockResolvedValue(items as never);
+    await store.list();
+
+    const mockResponse = new Response(null, { status: 404 });
+    const responseError = new ResponseError(mockResponse, "Not found");
+    vi.mocked(api.deleteAssessment).mockRejectedValue(responseError);
+
+    await expect(store.remove("a-1")).rejects.toThrow(responseError);
+    expect(store.getSnapshot()).toHaveLength(1);
+  });
+
+  it("remove() rethrows non-ResponseError exceptions", async () => {
+    const items = [makeAssessment({ id: "a-1" })];
+    vi.mocked(api.listAssessments).mockResolvedValue(items as never);
+    await store.list();
+
+    const networkError = new Error("Network failure");
+    vi.mocked(api.deleteAssessment).mockRejectedValue(networkError);
+
+    await expect(store.remove("a-1")).rejects.toThrow("Network failure");
+    expect(store.getSnapshot()).toHaveLength(1);
   });
 
   it("subscribe — listener called on mutation", async () => {

--- a/src/ui/assessment/views/Assessment.tsx
+++ b/src/ui/assessment/views/Assessment.tsx
@@ -207,15 +207,15 @@ const Assessment: React.FC<Props> = ({
     setSelectedAssessment(null);
   };
 
-  const handleConfirmUpdate = (name: string): void => {
+  const handleConfirmUpdate = async (name: string): Promise<void> => {
     if (!selectedAssessment) return;
-    void vmUpdateAssessment(selectedAssessment.id, name);
+    await vmUpdateAssessment(selectedAssessment.id, name);
     handleCloseUpdateModal();
   };
 
-  const handleConfirmDelete = (): void => {
+  const handleConfirmDelete = async (): Promise<void> => {
     if (!selectedAssessment) return;
-    void vmDeleteAssessment(selectedAssessment.id);
+    await vmDeleteAssessment(selectedAssessment.id);
     handleCloseDeleteModal();
   };
 
@@ -517,7 +517,7 @@ const Assessment: React.FC<Props> = ({
         isOpen={isUpdateModalOpen}
         onClose={handleCloseUpdateModal}
         onSubmit={(name) => {
-          handleConfirmUpdate(name);
+          void handleConfirmUpdate(name);
         }}
         name={(selectedAssessment as AssessmentModel)?.name || ""}
       />
@@ -526,7 +526,9 @@ const Assessment: React.FC<Props> = ({
         isOpen={isDeleteModalOpen}
         onClose={handleCloseDeleteModal}
         onCancel={handleCloseDeleteModal}
-        onConfirm={handleConfirmDelete}
+        onConfirm={() => {
+          void handleConfirmDelete();
+        }}
         isDisabled={isDeletingAssessment}
         title="Delete Assessment"
         titleIconVariant="warning"


### PR DESCRIPTION
- Handle SDK parsing error from backend's malformed DELETE response. 
- Cache assessment before API call and ignore TypeError since HTTP 200 confirms successful deletion. 
- Update local state immediately.


https://github.com/user-attachments/assets/b713ba62-2f8f-4a26-a314-3e2da2ac8a6a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of assessment deletion: validates existence before deleting, tolerates malformed API responses when appropriate, and ensures local state is cleaned up consistently.
  * Fixed timing of assessment operations so updates and deletions complete before confirmation dialogs close, preventing race conditions and stale UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->