### PR TITLE
ECOPROJECT-3980 | fix: disable assessment name and consent checkbox after RVTools submission

### DIFF
--- a/src/ui/assessment/views/CreateAssessmentModal.tsx
+++ b/src/ui/assessment/views/CreateAssessmentModal.tsx
@@ -319,6 +319,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
               }}
               validated={nameErrorToDisplay ? "error" : "default"}
               placeholder="Enter assessment name"
+              isDisabled={isFileOperationsDisabled}
             />
             {nameErrorToDisplay && (
               <HelperText>
@@ -439,6 +440,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
                       setRvtoolsConsentChecked(Boolean(checked));
                     }}
                     isRequired
+                    isDisabled={isFileOperationsDisabled}
                   />
                 </div>
               )}


### PR DESCRIPTION
Disable assessment name and consent checkbox after RVTools submission


https://github.com/user-attachments/assets/bf744dde-c083-4608-973d-d291f0907b2d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Assessment name input and RVTools consent checkbox are now properly disabled when file operations are unavailable, preventing unintended user interactions in restricted states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->