### PR TITLE
ECOPROJECT-4009 | feat: Change Assisted Migration UI URL to migration-advisor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Testing: Vitest + @testing-library/react + jsdom
 - DI: define symbol in `Symbols.ts`, register in `createContainer()`, consume via `useInjection<IXxxStore>(Symbols.X)` using the interface type.
 - Styling: use `@emotion/css` (CSS-in-JS) for all component styles. Do NOT create plain .css files.
 - When deeply nested children share a VM, use a thin React context (see `EnvironmentPageContext.tsx` pattern).
-- Routing: all navigable paths (`navigate()`, `<Link to>`, breadcrumb to, `location.pathname` comparisons) MUST use the `routes` object from `src/routing/Routes.ts`. The routes object automatically includes the correct mount-path prefix via `APP_BASENAME` (empty in dev, `/openshift/migration-assessment` in stage). NEVER hardcode the basename in source files. See the "Routing" section of docs/app-architecture.md.
+- Routing: all navigable paths (`navigate()`, `<Link to>`, breadcrumb to, `location.pathname` comparisons) MUST use the `routes` object from `src/routing/Routes.ts`. The routes object automatically includes the correct mount-path prefix via `APP_BASENAME` (empty in dev, `/openshift/migration-advisor` in stage). NEVER hardcode the basename in source files. See the "Routing" section of docs/app-architecture.md.
 - Naming: files are PascalCase, hooks (use\*) are camelCase, index/constants/types/styles are all-lowercase, directories are kebab-case. See docs/naming-conventions.md.
 
 ## Documentation (`docs/`)

--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ This starts the application in standalone mode with local development settings, 
 
 ## Deployment
 
-- **Development**: https://console.dev.redhat.com/openshift/migration-assessment/
-- **Staging**: https://stage.foo.redhat.com:1337/openshift/migration-assessment
+- **Development**: https://console.dev.redhat.com/openshift/migration-advisor/
+- **Staging**: https://stage.foo.redhat.com:1337/openshift/migration-advisor

--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: migration-assessment
+  name: migration-advisor
 objects:
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: Frontend
     metadata:
-      name: migration-assessment
+      name: migration-advisor
     spec:
       API:
         versions:
@@ -22,10 +22,10 @@ objects:
       module:
         manifestLocation: "/apps/assisted-migration-app/fed-mods.json"
         modules:
-          - id: "migration-assessment"
+          - id: "migration-advisor"
             module: "./RootApp"
             routes:
-              - pathname: /openshift/migration-assessment
+              - pathname: /openshift/migration-advisor
 
 parameters:
   - name: ENV_NAME

--- a/docs/app-architecture.md
+++ b/docs/app-architecture.md
@@ -329,10 +329,10 @@ breadcrumbs) with an `<Outlet />` for child routes (`AssessmentsScreen`,
 
 The app runs in two modes with different routing contexts:
 
-| Mode                      | Who provides `<BrowserRouter>` | Router `basename` | App mount path                      |
-| ------------------------- | ------------------------------ | ----------------- | ----------------------------------- |
-| **Standalone (dev)**      | `dev/src/AppShell.tsx`         | `"/"`             | `/` (root)                          |
-| **Microfrontend (stage)** | Host chrome                    | `"/"`             | `/openshift/migration-assessment/*` |
+| Mode                      | Who provides `<BrowserRouter>` | Router `basename` | App mount path                   |
+| ------------------------- | ------------------------------ | ----------------- | -------------------------------- |
+| **Standalone (dev)**      | `dev/src/AppShell.tsx`         | `"/"`             | `/` (root)                       |
+| **Microfrontend (stage)** | Host chrome                    | `"/"`             | `/openshift/migration-advisor/*` |
 
 In **standalone mode**, the BrowserRouter's `basename` is `"/"` and the app
 occupies the root. Basename-free absolute paths like `/assessments/123` work
@@ -340,25 +340,25 @@ because they resolve from `"/"`.
 
 In **microfrontend (stage) mode**, the Chrome's `BrowserRouter` also has
 `basename="/"`, but the app is mounted inside a nested `<Route>` at
-`/openshift/migration-assessment/*`. An absolute `navigate("/assessments/123")`
+`/openshift/migration-advisor/*`. An absolute `navigate("/assessments/123")`
 resolves from the router root (`"/"`), producing the URL `/assessments/123` —
 which is _outside_ the app's mount point. Navigation paths must therefore
 include the full mount prefix.
 
 `src/routing/Routes.ts` handles this transparently through **runtime
 detection**. At module-load time it checks `window.location.pathname` to
-determine whether the app slug (`/openshift/migration-assessment`) is present
+determine whether the app slug (`/openshift/migration-advisor`) is present
 and stores the result in `APP_BASENAME`:
 
 - Dev mode → `APP_BASENAME = ""`
-- Stage mode → `APP_BASENAME = "/openshift/migration-assessment"`
+- Stage mode → `APP_BASENAME = "/openshift/migration-advisor"`
 
 Every entry in the `routes` object includes `APP_BASENAME` as a prefix, so
 consuming code never needs to think about it:
 
 ```typescript
 // src/routing/Routes.ts (simplified)
-export const APP_BASENAME = resolveAppBasename(); // "" or "/openshift/migration-assessment"
+export const APP_BASENAME = resolveAppBasename(); // "" or "/openshift/migration-advisor"
 
 export const routes = {
   root: APP_BASENAME || "/",
@@ -388,7 +388,7 @@ export const routes = {
 } as const;
 ```
 
-**Do NOT hardcode `/openshift/migration-assessment`** — `APP_BASENAME` handles
+**Do NOT hardcode `/openshift/migration-advisor`** — `APP_BASENAME` handles
 mode detection at runtime.
 
 #### 2. Create the view and view model
@@ -459,7 +459,7 @@ expect(mockNavigate).toHaveBeenCalledWith(routes.migrationPlanById("p-1"));
 #### Common mistakes to avoid
 
 - **Hardcoding the basename** in `navigate()` / `<Link>` — e.g.
-  `navigate("/openshift/migration-assessment/foo")`. This breaks standalone
+  `navigate("/openshift/migration-advisor/foo")`. This breaks standalone
   mode and bypasses the runtime detection.
 - **Using string literals** instead of `routes.*` — this bypasses the
   centralised route map and makes future path changes error-prone.

--- a/fec.config.js
+++ b/fec.config.js
@@ -8,7 +8,7 @@ assert(
 
 /** @type {import('@redhat-cloud-services/frontend-components-config').FecWebpackConfiguration} */
 module.exports = {
-  appUrl: "/openshift/migration-assessment",
+  appUrl: "/openshift/migration-advisor",
   debug: true,
   useProxy: true,
   proxyVerbose: true,

--- a/src/routing/Routes.ts
+++ b/src/routing/Routes.ts
@@ -2,7 +2,7 @@
  * The app slug used by the Insights Chrome to mount this microfrontend.
  * Matches `appUrl` in `fec.config.js`.
  */
-const APP_SLUG = "/openshift/migration-assessment";
+const APP_SLUG = "/openshift/migration-advisor";
 
 /**
  * Resolve the app's base path at runtime.
@@ -33,7 +33,7 @@ function resolveAppBasename(): string {
 /**
  * The app's mount-path prefix.
  * - `""` in standalone (dev) mode
- * - `"/openshift/migration-assessment"` in stage mode
+ * - `"/openshift/migration-advisor"` in stage mode
  */
 export const APP_BASENAME = resolveAppBasename();
 


### PR DESCRIPTION
Change Assisted Migration UI URL to migration-advisor

It depends on https://github.com/RedHatInsights/chrome-service-backend/pull/1035

We're testing for staging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the application's access path from `/openshift/migration-assessment` to `/openshift/migration-advisor`. Users must navigate to the new endpoint to access the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->