### PR TITLE
ECOPROJECT-3435 | fix: Move APP_VERSION build-arg construction to build-container task

### DIFF
--- a/.tekton/migration-planner-ui-pull-request.yaml
+++ b/.tekton/migration-planner-ui-pull-request.yaml
@@ -30,9 +30,6 @@ spec:
       value: build-tools/Dockerfile
     - name: path-context
       value: .
-    - name: build-args
-      value:
-        - APP_VERSION={{target_branch}}-pull-request
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
@@ -228,6 +225,7 @@ spec:
           - name: BUILD_ARGS
             value:
               - $(params.build-args[*])
+              - APP_VERSION={{target_branch}}-pull-request
           - name: BUILD_ARGS_FILE
             value: $(params.build-args-file)
           - name: PRIVILEGED_NESTED

--- a/.tekton/migration-planner-ui-push.yaml
+++ b/.tekton/migration-planner-ui-push.yaml
@@ -27,9 +27,6 @@ spec:
       value: build-tools/Dockerfile
     - name: path-context
       value: .
-    - name: build-args
-      value:
-        - APP_VERSION={{target_branch}}-$(tasks.clone-repository.results.short-commit)
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
@@ -218,6 +215,7 @@ spec:
           - name: BUILD_ARGS
             value:
               - $(params.build-args[*])
+              - APP_VERSION={{target_branch}}-$(tasks.clone-repository.results.short-commit)
           - name: BUILD_ARGS_FILE
             value: $(params.build-args-file)
           - name: PRIVILEGED_NESTED

--- a/.tekton/migration-planner-ui-tag.yaml
+++ b/.tekton/migration-planner-ui-tag.yaml
@@ -27,9 +27,6 @@ spec:
       value: build-tools/Dockerfile
     - name: path-context
       value: .
-    - name: build-args
-      value:
-        - APP_VERSION={{git_tag}}
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
@@ -218,6 +215,7 @@ spec:
           - name: BUILD_ARGS
             value:
               - $(params.build-args[*])
+              - APP_VERSION={{git_tag}}
           - name: BUILD_ARGS_FILE
             value: $(params.build-args-file)
           - name: PRIVILEGED_NESTED


### PR DESCRIPTION
Fixes Konflux pipeline triggers by moving build-arg with task result
  references from PipelineRun params to the build-container task where
  they can be properly resolved at runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration in pipeline workflows to consolidate version argument handling across pull request, push, and tag deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->