### PR TITLE
ECOPROJECT-4133 | fix: Prevent deleted assessments from reappearing during backend processing

### DIFF
--- a/src/data/stores/AssessmentsStore.ts
+++ b/src/data/stores/AssessmentsStore.ts
@@ -47,6 +47,7 @@ export class AssessmentsStore
 {
   private assessments: AssessmentModel[] = [];
   private api: AssessmentApiInterface;
+  private deletedAssessmentIds = new Set<string>();
 
   constructor(api: AssessmentApiInterface) {
     super();
@@ -61,9 +62,28 @@ export class AssessmentsStore
       { sourceId },
       initOverrides,
     )) as AssessmentListResponse;
-    this.assessments = normalizeListResponse(response).map(
+    const rawAssessments = normalizeListResponse(response).map(
       createAssessmentModel,
     );
+
+    // Clean up the deleted IDs cache: if an ID is marked as deleted but no longer
+    // appears in the server response, the backend has confirmed the deletion.
+    // Only do this for unfiltered responses to avoid clearing the cache when
+    // the server returns a source-filtered subset.
+    if (!sourceId) {
+      const serverIds = new Set(rawAssessments.map((a) => a.id));
+      this.deletedAssessmentIds.forEach((deletedId) => {
+        if (!serverIds.has(deletedId)) {
+          this.deletedAssessmentIds.delete(deletedId);
+        }
+      });
+    }
+
+    // Filter out recently deleted assessments that the backend hasn't processed yet
+    this.assessments = rawAssessments.filter(
+      (a) => !this.deletedAssessmentIds.has(a.id),
+    );
+
     this.notify();
     return this.assessments;
   }
@@ -118,24 +138,47 @@ export class AssessmentsStore
       // this parsing error since the deletion itself succeeds (status 200).
       await this.api.deleteAssessment({ id }, initOverrides);
     } catch (error) {
-      // Only suppress parsing errors if the HTTP response was successful.
-      // The SDK throws ResponseError when JSON parsing fails after a successful HTTP call.
-      // We must verify the deletion actually succeeded (status 200) before updating local state.
+      // The backend returns a malformed response that causes parsing errors.
+      // We need to detect if the HTTP call succeeded even though parsing failed.
+
+      // Check for ResponseError with 200 status
       const hasSuccessStatus =
         (error as { response?: { status?: number } })?.response?.status === 200;
-
-      const isSuccessfulDeletion =
+      const isResponseErrorSuccess =
         error instanceof ResponseError && hasSuccessStatus;
 
-      if (!isSuccessfulDeletion) {
+      // Check for TypeError from JSON parsing (e.g., "Cannot read properties of null (reading 'map')")
+      const isTypeErrorFromParsing =
+        error instanceof TypeError &&
+        error.message.includes(
+          "Cannot read properties of null (reading 'map')",
+        );
+
+      // If it's a parsing error, we assume the delete succeeded since these only
+      // happen after a successful HTTP response
+      if (isResponseErrorSuccess || isTypeErrorFromParsing) {
+        // Deletion succeeded despite parsing error, continue execution
+      } else {
         throw error;
       }
     }
 
+    // Track this ID as deleted to prevent it from reappearing if backend is slow
+    this.deletedAssessmentIds.add(id);
+
+    // Optimistic update: remove from local state immediately for instant UI feedback
     this.assessments = this.assessments.filter(
       (assessment) => assessment.id !== id,
     );
     this.notify();
+
+    // Refresh from server in background to ensure consistency. This doesn't block
+    // the UI from closing the modal. The list() method will filter out any items
+    // in deletedAssessmentIds, preventing the deleted item from reappearing.
+    void this.list(undefined, initOverrides).catch((err) => {
+      console.error("Background refresh after delete failed:", err);
+    });
+
     return deletedAssessment;
   }
 

--- a/src/data/stores/__tests__/AssessmentsStore.test.ts
+++ b/src/data/stores/__tests__/AssessmentsStore.test.ts
@@ -165,7 +165,7 @@ describe("AssessmentsStore", () => {
     expect(store.getSnapshot()[0].name).toBe("Updated");
   });
 
-  it("remove() filters out item", async () => {
+  it("remove() filters out item and refreshes from server", async () => {
     const items = [
       makeAssessment({ id: "a-1" }),
       makeAssessment({ id: "a-2" }),
@@ -176,10 +176,15 @@ describe("AssessmentsStore", () => {
     vi.mocked(api.deleteAssessment).mockResolvedValue(
       makeAssessment({ id: "a-1" }) as never,
     );
+    // After deletion, list() is called to refresh from server
+    vi.mocked(api.listAssessments).mockResolvedValue([
+      makeAssessment({ id: "a-2" }),
+    ] as never);
 
     const result = await store.remove("a-1");
 
     expect(api.deleteAssessment).toHaveBeenCalledWith({ id: "a-1" }, undefined);
+    expect(api.listAssessments).toHaveBeenCalledTimes(2); // Initial list + refresh after delete
     expect(result.id).toBe("a-1");
     expect(store.getSnapshot()).toHaveLength(1);
     expect(store.getSnapshot()[0].id).toBe("a-2");
@@ -199,10 +204,15 @@ describe("AssessmentsStore", () => {
       "Failed to parse response",
     );
     vi.mocked(api.deleteAssessment).mockRejectedValue(responseError);
+    // After deletion, list() is called to refresh from server
+    vi.mocked(api.listAssessments).mockResolvedValue([
+      makeAssessment({ id: "a-2" }),
+    ] as never);
 
     const result = await store.remove("a-1");
 
     expect(result.id).toBe("a-1");
+    expect(api.listAssessments).toHaveBeenCalledTimes(2); // Initial list + refresh after delete
     expect(store.getSnapshot()).toHaveLength(1);
     expect(store.getSnapshot()[0].id).toBe("a-2");
   });
@@ -230,6 +240,114 @@ describe("AssessmentsStore", () => {
 
     await expect(store.remove("a-1")).rejects.toThrow("Network failure");
     expect(store.getSnapshot()).toHaveLength(1);
+  });
+
+  it("remove() suppresses TypeError from JSON parsing (malformed backend response)", async () => {
+    const items = [
+      makeAssessment({ id: "a-1" }),
+      makeAssessment({ id: "a-2" }),
+    ];
+    vi.mocked(api.listAssessments).mockResolvedValue(items as never);
+    await store.list();
+
+    // Simulate the exact error from the backend: TypeError during JSON parsing
+    const typeError = new TypeError(
+      "Cannot read properties of null (reading 'map')",
+    );
+    vi.mocked(api.deleteAssessment).mockRejectedValue(typeError);
+    // After deletion, list() is called to refresh from server
+    vi.mocked(api.listAssessments).mockResolvedValue([
+      makeAssessment({ id: "a-2" }),
+    ] as never);
+
+    const result = await store.remove("a-1");
+
+    expect(result.id).toBe("a-1");
+    expect(api.listAssessments).toHaveBeenCalledTimes(2); // Initial list + refresh after delete
+    expect(store.getSnapshot()).toHaveLength(1);
+    expect(store.getSnapshot()[0].id).toBe("a-2");
+  });
+
+  it("remove() rethrows unrelated TypeErrors (not backend parsing errors)", async () => {
+    const items = [makeAssessment({ id: "a-1" })];
+    vi.mocked(api.listAssessments).mockResolvedValue(items as never);
+    await store.list();
+
+    // Simulate an unrelated TypeError (not the specific backend parsing error)
+    const unrelatedError = new TypeError(
+      "Cannot call method 'map' of undefined",
+    );
+    vi.mocked(api.deleteAssessment).mockRejectedValue(unrelatedError);
+
+    await expect(store.remove("a-1")).rejects.toThrow(TypeError);
+    expect(api.listAssessments).toHaveBeenCalledTimes(1); // Only the initial list, no refresh
+    expect(store.getSnapshot()).toHaveLength(1); // Item not removed from local state
+  });
+
+  it("remove() prevents deleted item from reappearing if backend is slow", async () => {
+    const items = [
+      makeAssessment({ id: "a-1" }),
+      makeAssessment({ id: "a-2" }),
+    ];
+    vi.mocked(api.listAssessments).mockResolvedValue(items as never);
+    await store.list();
+
+    vi.mocked(api.deleteAssessment).mockResolvedValue(
+      makeAssessment({ id: "a-1" }) as never,
+    );
+    // Simulate slow backend: first list() call still returns the deleted item
+    vi.mocked(api.listAssessments).mockResolvedValueOnce(items as never);
+    // Second list() call (after backend processes) returns without the deleted item
+    vi.mocked(api.listAssessments).mockResolvedValueOnce([
+      makeAssessment({ id: "a-2" }),
+    ] as never);
+
+    await store.remove("a-1");
+
+    // Even though the backend returned a-1 in the first refresh, it should be filtered out
+    expect(store.getSnapshot()).toHaveLength(1);
+    expect(store.getSnapshot()[0].id).toBe("a-2");
+
+    // Simulate polling call - deleted ID cache should still filter it out
+    await store.list();
+    expect(store.getSnapshot()).toHaveLength(1);
+    expect(store.getSnapshot()[0].id).toBe("a-2");
+  });
+
+  it("list(sourceId) does not clear deleted-ID cache for other sources", async () => {
+    const allItems = [
+      makeAssessment({ id: "a-1", name: "Assessment 1" }),
+      makeAssessment({ id: "a-2", name: "Assessment 2" }),
+    ];
+    vi.mocked(api.listAssessments).mockResolvedValue(allItems as never);
+    await store.list();
+
+    // Delete a-1 (adds it to deletedAssessmentIds cache)
+    vi.mocked(api.deleteAssessment).mockResolvedValue(
+      makeAssessment({ id: "a-1" }) as never,
+    );
+    // Mock the background refresh after delete to still include a-1 (slow backend)
+    vi.mocked(api.listAssessments).mockResolvedValueOnce(allItems as never);
+    await store.remove("a-1");
+
+    // Verify a-1 is filtered out (deleted cache is working)
+    expect(store.getSnapshot()).toHaveLength(1);
+    expect(store.getSnapshot()[0].id).toBe("a-2");
+
+    // Now call list() with a sourceId (filtered response)
+    const filteredItems = [makeAssessment({ id: "a-2" })];
+    vi.mocked(api.listAssessments).mockResolvedValueOnce(
+      filteredItems as never,
+    );
+    await store.list("someOtherSource");
+
+    // Verify that a-1 is still in the deleted cache by calling an unfiltered list()
+    vi.mocked(api.listAssessments).mockResolvedValueOnce(allItems as never);
+    await store.list();
+
+    // a-1 should still be filtered out (deleted cache was not cleared by the filtered call)
+    expect(store.getSnapshot()).toHaveLength(1);
+    expect(store.getSnapshot()[0].id).toBe("a-2");
   });
 
   it("subscribe — listener called on mutation", async () => {


### PR DESCRIPTION
- Detect TypeError from malformed backend delete response
- Add deleted IDs cache to filter stale items from polling
- Execute server refresh in background for instant modal close
- Update local state optimistically for immediate UI feedback


https://github.com/user-attachments/assets/8dc4fc43-e68f-477d-a308-c871af0112be



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Immediate optimistic deletions in the UI with a background refresh to sync state.
  * Deletion operations tolerate malformed server responses (parsing errors) without interrupting the user flow.

* **Bug Fixes**
  * Prevents deleted items from reappearing when the server is slow.
  * Keeps deletions excluded when viewing filtered lists so removed items stay hidden.

* **Tests**
  * Expanded coverage for deletion edge cases, parsing errors, slow-backend behavior, and refresh logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->