### PR TITLE
NO-JIRA | fix: fixing issues with new URL

### DIFF
--- a/src/config/ApiConfig.ts
+++ b/src/config/ApiConfig.ts
@@ -3,7 +3,7 @@
  * This allows a single build to work with multiple deployments.
  */
 const ROUTE_TO_API_MAP: Record<string, string> = {
-  "/openshift/migration-assessment": "/api/migration-assessment",
+  "/openshift/migration-advisor": "/api/migration-assessment",
   "/openshift/migration-advisor-dev": "/api/migration-advisor-dev",
 } as const;
 

--- a/src/config/__tests__/ApiConfig.test.ts
+++ b/src/config/__tests__/ApiConfig.test.ts
@@ -19,7 +19,7 @@ describe("resolveApiBaseUrl", () => {
   it("should return /api/migration-assessment for production route", () => {
     Object.defineProperty(window, "location", {
       value: {
-        pathname: "/openshift/migration-assessment/assessments",
+        pathname: "/openshift/migration-advisor/assessments",
       },
       writable: true,
       configurable: true,
@@ -43,7 +43,7 @@ describe("resolveApiBaseUrl", () => {
   it("should strip /preview prefix before matching", () => {
     Object.defineProperty(window, "location", {
       value: {
-        pathname: "/preview/openshift/migration-assessment/assessments",
+        pathname: "/preview/openshift/migration-advisor/assessments",
       },
       writable: true,
       configurable: true,
@@ -119,7 +119,7 @@ describe("resolveApiBaseUrl", () => {
   it("should NOT match partial route segments (suffix)", () => {
     Object.defineProperty(window, "location", {
       value: {
-        pathname: "/openshift/migration-assessment-foo/assessments",
+        pathname: "/openshift/migration-advisor-foo/assessments",
       },
       writable: true,
       configurable: true,
@@ -145,7 +145,7 @@ describe("resolveApiBaseUrl", () => {
   it("should match exact route without trailing path", () => {
     Object.defineProperty(window, "location", {
       value: {
-        pathname: "/openshift/migration-assessment",
+        pathname: "/openshift/migration-advisor",
       },
       writable: true,
       configurable: true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application route path from "/openshift/migration-assessment" to "/openshift/migration-advisor" to align with product naming conventions. The corresponding backend API endpoint remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->