### PR TITLE
ECOPROJECT-4155 | fix: replacing assisted-migration-docs for openshift-migration-advisor in documentation links

### DIFF
--- a/src/ui/assessment/views/CreateAssessmentModal.tsx
+++ b/src/ui/assessment/views/CreateAssessmentModal.tsx
@@ -147,7 +147,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
           accept: ".xlsx,.xls",
           allowedExtensions: ["xlsx", "xls"],
           fileLink:
-            "https://kubev2v.github.io/assisted-migration-docs/docs/tutorial/#prerequisites-rvtools-file-requirements",
+            "https://kubev2v.github.io/openshift-migration-advisor-docs/docs/tutorial/#prerequisites-rvtools-file-requirements",
         };
       case "agent":
         return {

--- a/src/ui/core/components/VCenterSetupInstructions.tsx
+++ b/src/ui/core/components/VCenterSetupInstructions.tsx
@@ -64,7 +64,7 @@ export const VCenterSetupInstructions: React.FC = () => {
               Select your preference for sharing aggregated data with
               console.redhat.com (read more{" "}
               <a
-                href="https://kubev2v.github.io/assisted-migration-docs/docs/tutorial/#discovery-agent-flow"
+                href="https://kubev2v.github.io/openshift-migration-advisor-docs/docs/tutorial/#discovery-agent-flow"
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
Documentation links are not working.
In this PR we've made these changes:

- Old: https://kubev2v.github.io/assisted-migration-docs/docs/tutorial/#prerequisites-rvtools-file-requirements
  New: https://kubev2v.github.io/openshift-migration-advisor-docs/docs/tutorial/#prerequisites-rvtools-file-requirements

- Old: https://kubev2v.github.io/assisted-migration-docs/docs/tutorial/#discovery-agent-flow
   New: https://kubev2v.github.ioopenshift-migration-advisor-docs/docs/tutorial/#discovery-agent-flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated RVTools documentation link in the assessment configuration modal so users are directed to the current documentation site.
  * Updated vCenter setup instructions to point to OpenShift Migration Advisor documentation instead of the previous Assisted Migration docs, ensuring setup guidance links are accurate and up to date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->