### PR TITLE
ECOPROJECT-3745 | fix: Sorting OS card table list

### DIFF
--- a/src/ui/core/components/MigrationChart.tsx
+++ b/src/ui/core/components/MigrationChart.tsx
@@ -142,7 +142,10 @@ const MigrationChart: React.FC<MigrationChartProps> = ({
               <Tbody>
                 {data.map((item, index) => (
                   <Tr key={index}>
-                    <Td width={dataLength} style={{ paddingLeft: "0px" }}>
+                    <Td
+                      width={dataLength}
+                      style={{ paddingLeft: "0px", paddingTop: "4px" }}
+                    >
                       <Flex
                         alignItems={{ default: "alignItemsCenter" }}
                         spaceItems={{ default: "spaceItemsXs" }}
@@ -225,7 +228,11 @@ const MigrationChart: React.FC<MigrationChartProps> = ({
                     </Td>
                     <Td
                       width={10}
-                      style={{ paddingRight: "0px", textAlign: "center" }}
+                      style={{
+                        paddingRight: "0px",
+                        textAlign: "center",
+                        paddingTop: "5px",
+                      }}
                     >
                       <Content
                         component="p"

--- a/src/ui/report/views/assessment-report/OSDistribution.tsx
+++ b/src/ui/report/views/assessment-report/OSDistribution.tsx
@@ -76,13 +76,29 @@ interface OSBarChartProps {
   isExportMode?: boolean;
 }
 
+function osSortGroup(osInfo: {
+  count: number;
+  supported: boolean;
+  upgradeRecommendation?: string;
+}): number {
+  if (!osInfo.supported && (osInfo.upgradeRecommendation?.trim() ?? "") !== "")
+    return 1;
+  if (!osInfo.supported) return 2;
+  return 3;
+}
+
 export const OSBarChart: React.FC<OSBarChartProps> = ({
   osData,
   isExportMode,
 }) => {
   const dataEntries = Object.entries(osData).filter(([os]) => os.trim() !== "");
 
-  const sorted = dataEntries.sort(([, a], [, b]) => b.count - a.count);
+  const sorted = [...dataEntries].sort(([, a], [, b]) => {
+    const groupA = osSortGroup(a);
+    const groupB = osSortGroup(b);
+    if (groupA !== groupB) return groupA - groupB;
+    return b.count - a.count;
+  });
 
   const chartData = sorted.map(([os, osInfo]) => ({
     name: os,


### PR DESCRIPTION
Operating Systems report (UI)
OSDistribution.tsx – Sort order for the OS list:
Unsupported with non-empty upgradeRecommendation (by count desc).
Unsupported without recommendation (by count desc).
Supported (by count desc).
<img width="1266" height="574" alt="Screenshot 2026-03-09 at 15 26 09" src="https://github.com/user-attachments/assets/81c2f17d-e416-4fad-aaa5-3a12a15cc46d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted vertical spacing in the migration chart table for better visual alignment.

* **Bug Fixes**
  * Improved operating system distribution sorting to prioritize systems requiring upgrades first, followed by unsupported systems, then supported ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->