### PR TITLE
ECOPROJECT-4009 | feat: Change Assisted Migration URL from migration-assessment to migration-advisor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Testing: Vitest + @testing-library/react + jsdom
 - DI: define symbol in `Symbols.ts`, register in `createContainer()`, consume via `useInjection<IXxxStore>(Symbols.X)` using the interface type.
 - Styling: use `@emotion/css` (CSS-in-JS) for all component styles. Do NOT create plain .css files.
 - When deeply nested children share a VM, use a thin React context (see `EnvironmentPageContext.tsx` pattern).
-- Routing: all navigable paths (`navigate()`, `<Link to>`, breadcrumb to, `location.pathname` comparisons) MUST use the `routes` object from `src/routing/Routes.ts`. The routes object automatically includes the correct mount-path prefix via `APP_BASENAME` (empty in dev, `/openshift/migration-assessment` in stage). NEVER hardcode the basename in source files. See the "Routing" section of docs/app-architecture.md.
+- Routing: all navigable paths (`navigate()`, `<Link to>`, breadcrumb to, `location.pathname` comparisons) MUST use the `routes` object from `src/routing/Routes.ts`. The routes object automatically includes the correct mount-path prefix via `APP_BASENAME` (empty in dev, `/openshift/migration-advisor` in stage). NEVER hardcode the basename in source files. See the "Routing" section of docs/app-architecture.md.
 - Naming: files are PascalCase, hooks (use\*) are camelCase, index/constants/types/styles are all-lowercase, directories are kebab-case. See docs/naming-conventions.md.
 
 ## Documentation (`docs/`)

--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ This starts the application in standalone mode with local development settings, 
 
 ## Deployment
 
-- **Development**: https://console.dev.redhat.com/openshift/migration-assessment/
-- **Staging**: https://stage.foo.redhat.com:1337/openshift/migration-assessment
+- **Development**: https://console.dev.redhat.com/openshift/migration-advisor/
+- **Staging**: https://stage.foo.redhat.com:1337/openshift/migration-advisor

--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -2,30 +2,30 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: migration-assessment
+  name: migration-advisor
 objects:
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: Frontend
     metadata:
-      name: migration-assessment
+      name: migration-advisor
     spec:
       API:
         versions:
           - v1
       envName: ${ENV_NAME}
-      title: Assisted Migration
+      title: Openshift Migration Advisor
       deploymentRepo: https://gitlab.cee.redhat.com/assisted-migration/migration-assessment-app
       frontend:
         paths:
-          - /apps/migration-assessment
+          - /apps/migration-advisor
       image: ${IMAGE}:${IMAGE_TAG}
       module:
-        manifestLocation: "/apps/migration-assessment/fed-mods.json"
+        manifestLocation: "/apps/migration-advisor/fed-mods.json"
         modules:
           - id: "migration-assessment"
             module: "./RootApp"
             routes:
-              - pathname: /openshift/migration-assessment
+              - pathname: /openshift/migration-advisor
       feoConfigEnabled: true
 
 parameters:

--- a/docs/app-architecture.md
+++ b/docs/app-architecture.md
@@ -329,10 +329,10 @@ breadcrumbs) with an `<Outlet />` for child routes (`AssessmentsScreen`,
 
 The app runs in two modes with different routing contexts:
 
-| Mode                      | Who provides `<BrowserRouter>` | Router `basename` | App mount path                      |
-| ------------------------- | ------------------------------ | ----------------- | ----------------------------------- |
-| **Standalone (dev)**      | `dev/src/AppShell.tsx`         | `"/"`             | `/` (root)                          |
-| **Microfrontend (stage)** | Host chrome                    | `"/"`             | `/openshift/migration-assessment/*` |
+| Mode                      | Who provides `<BrowserRouter>` | Router `basename` | App mount path                   |
+| ------------------------- | ------------------------------ | ----------------- | -------------------------------- |
+| **Standalone (dev)**      | `dev/src/AppShell.tsx`         | `"/"`             | `/` (root)                       |
+| **Microfrontend (stage)** | Host chrome                    | `"/"`             | `/openshift/migration-advisor/*` |
 
 In **standalone mode**, the BrowserRouter's `basename` is `"/"` and the app
 occupies the root. Basename-free absolute paths like `/assessments/123` work
@@ -340,17 +340,17 @@ because they resolve from `"/"`.
 
 In **microfrontend (stage) mode**, the Chrome's `BrowserRouter` also has
 `basename="/"`, but the app is mounted inside a nested `<Route>` at
-`/openshift/migration-assessment/*`. An absolute `navigate("/assessments/123")`
+`/openshift/migration-advisor/*`. An absolute `navigate("/assessments/123")`
 resolves from the router root (`"/"`), producing the URL `/assessments/123` —
 which is _outside_ the app's mount point. Navigation paths must therefore
 include the full mount prefix.
 
 `src/routing/Routes.ts` handles this transparently through **dynamic runtime
 detection**. Each time a route is accessed, it checks `window.location.pathname`
-to determine whether the app slug (`/openshift/migration-assessment`) is present:
+to determine whether the app slug (`/openshift/migration-advisor`) is present:
 
 - Dev mode → basename = `""`
-- Stage mode → basename = `"/openshift/migration-assessment"`
+- Stage mode → basename = `"/openshift/migration-advisor"`
 
 Every entry in the `routes` object uses getters that compute the basename
 dynamically, ensuring correctness even during hot-module reloading or federated
@@ -360,8 +360,8 @@ module initialization timing edge cases:
 // src/routing/Routes.ts (simplified)
 function getAppBasename(): string {
   const pathname = window.location.pathname.replace(/^\/(preview|beta)/, "");
-  return pathname.startsWith("/openshift/migration-assessment")
-    ? "/openshift/migration-assessment"
+  return pathname.startsWith("/openshift/migration-advisor")
+    ? "/openshift/migration-advisor"
     : "";
 }
 
@@ -396,7 +396,7 @@ export const routes = {
 } as const;
 ```
 
-**Do NOT hardcode `/openshift/migration-assessment`** — `APP_BASENAME` handles
+**Do NOT hardcode `/openshift/migration-advisor`** — `APP_BASENAME` handles
 mode detection at runtime.
 
 #### 2. Create the view and view model
@@ -467,7 +467,7 @@ expect(mockNavigate).toHaveBeenCalledWith(routes.migrationPlanById("p-1"));
 #### Common mistakes to avoid
 
 - **Hardcoding the basename** in `navigate()` / `<Link>` — e.g.
-  `navigate("/openshift/migration-assessment/foo")`. This breaks standalone
+  `navigate("/openshift/migration-advisor/foo")`. This breaks standalone
   mode and bypasses the runtime detection.
 - **Using string literals** instead of `routes.*` — this bypasses the
   centralised route map and makes future path changes error-prone.
@@ -480,7 +480,7 @@ expect(mockNavigate).toHaveBeenCalledWith(routes.migrationPlanById("p-1"));
 #### Debugging production routing issues
 
 If you see incorrect URLs in production (e.g. missing the
-`/openshift/migration-assessment` prefix), check the browser console for
+`/openshift/migration-advisor` prefix), check the browser console for
 `[Routes] Basename detected:` log entries. This will show:
 
 - Which mode was detected (`microfrontend` or `standalone`)

--- a/docs/production-routing-fix.md
+++ b/docs/production-routing-fix.md
@@ -2,12 +2,12 @@
 
 ## Issue Summary
 
-**Problem**: URLs in production were intermittently missing the `/openshift/migration-assessment` prefix after certain navigation flows (especially after RVTool uploads).
+**Problem**: URLs in production were intermittently missing the `/openshift/migration-advisor` prefix after certain navigation flows (especially after RVTool uploads).
 
 **Example**:
 
 - ❌ Incorrect: `https://console.redhat.com/assessments/d8d38f15-d3f6-49a6-9a8b-2f7efc21aae9/report`
-- ✅ Correct: `https://console.redhat.com/openshift/migration-assessment/assessments/d8d38f15-d3f6-49a6-9a8b-2f7efc21aae9/report`
+- ✅ Correct: `https://console.redhat.com/openshift/migration-advisor/assessments/d8d38f15-d3f6-49a6-9a8b-2f7efc21aae9/report`
 
 ## Root Cause
 
@@ -34,8 +34,8 @@ export const routes = {
 // After (dynamic, computed on each access)
 function getAppBasename(): string {
   const pathname = window.location.pathname.replace(/^\/(preview|beta)/, "");
-  return pathname.startsWith("/openshift/migration-assessment")
-    ? "/openshift/migration-assessment"
+  return pathname.startsWith("/openshift/migration-advisor")
+    ? "/openshift/migration-advisor"
     : "";
 }
 
@@ -98,8 +98,8 @@ After deployment, monitor the browser console for basename detection logs:
 ```javascript
 [Routes] Basename detected: {
   mode: "microfrontend",
-  basename: "/openshift/migration-assessment",
-  currentPathname: "/openshift/migration-assessment/assessments",
+  basename: "/openshift/migration-advisor",
+  currentPathname: "/openshift/migration-advisor/assessments",
   timestamp: "2026-03-06T12:34:56.789Z"
 }
 ```
@@ -108,7 +108,7 @@ After deployment, monitor the browser console for basename detection logs:
 
 - Log appears once when the app initializes
 - Mode should be `"microfrontend"` in production
-- Basename should be `"/openshift/migration-assessment"`
+- Basename should be `"/openshift/migration-advisor"`
 
 **Red flags**:
 

--- a/docs/troubleshooting-routing.md
+++ b/docs/troubleshooting-routing.md
@@ -4,10 +4,10 @@
 
 ### Symptom
 
-URLs in production are missing the `/openshift/migration-assessment` prefix:
+URLs in production are missing the `/openshift/migration-advisor` prefix:
 
 - ❌ `https://console.redhat.com/assessments/xxx/report`
-- ✅ `https://console.redhat.com/openshift/migration-assessment/assessments/xxx/report`
+- ✅ `https://console.redhat.com/openshift/migration-advisor/assessments/xxx/report`
 
 This typically occurs after specific navigation flows like:
 
@@ -61,8 +61,8 @@ The routes module logs basename detection events to help diagnose issues:
 // Check the console for:
 [Routes] Basename detected: {
   mode: "microfrontend",  // or "standalone"
-  basename: "/openshift/migration-assessment",  // or "(root)"
-  currentPathname: "/openshift/migration-assessment/assessments",
+  basename: "/openshift/migration-advisor",  // or "(root)"
+  currentPathname: "/openshift/migration-advisor/assessments",
   timestamp: "2026-03-06T12:34:56.789Z"
 }
 ```
@@ -83,7 +83,7 @@ To prevent similar issues in the future:
 
    ```typescript
    // ❌ BAD
-   navigate("/openshift/migration-assessment/assessments");
+   navigate("/openshift/migration-advisor/assessments");
 
    // ✅ GOOD
    navigate(routes.assessments);

--- a/fec.config.js
+++ b/fec.config.js
@@ -9,7 +9,7 @@ assert(
 
 /** @type {import('@redhat-cloud-services/frontend-components-config').FecWebpackConfiguration} */
 module.exports = {
-  appUrl: "/openshift/migration-assessment",
+  appUrl: "/openshift/migration-advisor",
   debug: true,
   useProxy: true,
   proxyVerbose: true,

--- a/package.json
+++ b/package.json
@@ -89,6 +89,6 @@
     "serialize-javascript": ">=7.0.3"
   },
   "insights": {
-    "appname": "migration-assessment"
+    "appname": "migration-advisor"
   }
 }

--- a/src/data/stores/VersionsStore.ts
+++ b/src/data/stores/VersionsStore.ts
@@ -4,7 +4,7 @@ import { ExternalStoreBase } from "../../lib/mvvm/ExternalStore";
 import type { VersionInfo } from "../../models/VersionInfo";
 import type { IVersionsStore } from "./interfaces/IVersionsStore";
 
-export const UI_NAME = "migration-assessment";
+export const UI_NAME = "migration-advisor";
 export const API_NAME = "migration-planner";
 
 interface AppInfo {

--- a/src/routing/Routes.ts
+++ b/src/routing/Routes.ts
@@ -2,7 +2,7 @@
  * The app slug used by the Insights Chrome to mount this microfrontend.
  * Matches `appUrl` in `fec.config.js`.
  */
-const APP_SLUG = "/openshift/migration-assessment";
+const APP_SLUG = "/openshift/migration-advisor";
 
 let lastLoggedBasename: string | null = null;
 
@@ -48,7 +48,7 @@ function resolveAppBasename(): string {
 /**
  * Get the app's mount-path prefix dynamically.
  * - `""` in standalone (dev) mode
- * - `"/openshift/migration-assessment"` in stage mode
+ * - `"/openshift/migration-advisor"` in stage mode
  *
  * This is computed on each access to avoid caching stale values during
  * module hot-reloading or federated module initialization.
@@ -60,7 +60,7 @@ function getAppBasename(): string {
 /**
  * The app's mount-path prefix.
  * - `""` in standalone (dev) mode
- * - `"/openshift/migration-assessment"` in stage mode
+ * - `"/openshift/migration-advisor"` in stage mode
  *
  * @deprecated This is a snapshot at module-load time and may be stale.
  * Prefer using the `routes` object which dynamically resolves the basename.

--- a/src/routing/__tests__/Routes.test.ts
+++ b/src/routing/__tests__/Routes.test.ts
@@ -77,7 +77,7 @@ describe("Routes", () => {
   // ---------------------------------------------------------------------------
 
   describe("Microfrontend mode (stage/prod)", () => {
-    const BASE = "/openshift/migration-assessment";
+    const BASE = "/openshift/migration-advisor";
 
     beforeEach(() => {
       Object.defineProperty(window, "location", {
@@ -138,13 +138,13 @@ describe("Routes", () => {
       Object.defineProperty(window, "location", {
         value: {
           ...window.location,
-          pathname: "/openshift/migration-assessment/assessments",
+          pathname: "/openshift/migration-advisor/assessments",
         },
         writable: true,
         configurable: true,
       });
       expect(routes.assessments).toBe(
-        "/openshift/migration-assessment/assessments",
+        "/openshift/migration-advisor/assessments",
       );
     });
 
@@ -153,13 +153,13 @@ describe("Routes", () => {
       Object.defineProperty(window, "location", {
         value: {
           ...window.location,
-          pathname: "/openshift/migration-assessment/assessments",
+          pathname: "/openshift/migration-advisor/assessments",
         },
         writable: true,
         configurable: true,
       });
       expect(routes.assessments).toBe(
-        "/openshift/migration-assessment/assessments",
+        "/openshift/migration-advisor/assessments",
       );
 
       // Simulate navigation to standalone mode
@@ -175,13 +175,13 @@ describe("Routes", () => {
       Object.defineProperty(window, "location", {
         value: {
           ...window.location,
-          pathname: "/preview/openshift/migration-assessment/assessments",
+          pathname: "/preview/openshift/migration-advisor/assessments",
         },
         writable: true,
         configurable: true,
       });
       expect(routes.assessments).toBe(
-        "/openshift/migration-assessment/assessments",
+        "/openshift/migration-advisor/assessments",
       );
     });
 
@@ -189,13 +189,13 @@ describe("Routes", () => {
       Object.defineProperty(window, "location", {
         value: {
           ...window.location,
-          pathname: "/beta/openshift/migration-assessment/assessments",
+          pathname: "/beta/openshift/migration-advisor/assessments",
         },
         writable: true,
         configurable: true,
       });
       expect(routes.assessments).toBe(
-        "/openshift/migration-assessment/assessments",
+        "/openshift/migration-advisor/assessments",
       );
     });
 
@@ -246,7 +246,7 @@ describe("Routes", () => {
       Object.defineProperty(window, "location", {
         value: {
           ...window.location,
-          pathname: "/openshift/migration-assessment/assessments",
+          pathname: "/openshift/migration-advisor/assessments",
         },
         writable: true,
         configurable: true,
@@ -257,11 +257,11 @@ describe("Routes", () => {
 
       // EXPECTED: Should return correct URL with basename
       expect(exampleReportUrl).toBe(
-        "/openshift/migration-assessment/assessments/example-report",
+        "/openshift/migration-advisor/assessments/example-report",
       );
 
       // BEFORE FIX: Would return "/assessments/example-report"
-      // AFTER FIX: Returns "/openshift/migration-assessment/assessments/example-report"
+      // AFTER FIX: Returns "/openshift/migration-advisor/assessments/example-report"
     });
 
     it("reproduces the RVTools upload navigation bug where basename is missing", () => {
@@ -279,7 +279,7 @@ describe("Routes", () => {
       Object.defineProperty(window, "location", {
         value: {
           ...window.location,
-          pathname: "/openshift/migration-assessment/assessments",
+          pathname: "/openshift/migration-advisor/assessments",
         },
         writable: true,
         configurable: true,
@@ -291,11 +291,11 @@ describe("Routes", () => {
 
       // EXPECTED: Should return correct URL with basename
       expect(reportUrl).toBe(
-        `/openshift/migration-assessment/assessments/${assessmentId}/report`,
+        `/openshift/migration-advisor/assessments/${assessmentId}/report`,
       );
 
       // BEFORE FIX: Would return "/assessments/d8d38f15-.../report"
-      // AFTER FIX: Returns "/openshift/migration-assessment/assessments/d8d38f15-.../report"
+      // AFTER FIX: Returns "/openshift/migration-advisor/assessments/d8d38f15-.../report"
     });
 
     it("verifies all route getters adapt to pathname changes during the session", () => {
@@ -314,34 +314,34 @@ describe("Routes", () => {
       Object.defineProperty(window, "location", {
         value: {
           ...window.location,
-          pathname: "/openshift/migration-assessment/assessments",
+          pathname: "/openshift/migration-advisor/assessments",
         },
         writable: true,
         configurable: true,
       });
 
       // ALL routes should now include the basename
-      expect(routes.root).toBe("/openshift/migration-assessment");
+      expect(routes.root).toBe("/openshift/migration-advisor");
       expect(routes.assessments).toBe(
-        "/openshift/migration-assessment/assessments",
+        "/openshift/migration-advisor/assessments",
       );
       expect(routes.assessmentCreate).toBe(
-        "/openshift/migration-assessment/assessments/create",
+        "/openshift/migration-advisor/assessments/create",
       );
       expect(routes.exampleReport).toBe(
-        "/openshift/migration-assessment/assessments/example-report",
+        "/openshift/migration-advisor/assessments/example-report",
       );
       expect(routes.environments).toBe(
-        "/openshift/migration-assessment/environments",
+        "/openshift/migration-advisor/environments",
       );
 
       // And they should work correctly for navigation
       const testId = "test-123";
       expect(routes.assessmentById(testId)).toBe(
-        `/openshift/migration-assessment/assessments/${testId}`,
+        `/openshift/migration-advisor/assessments/${testId}`,
       );
       expect(routes.assessmentReport(testId)).toBe(
-        `/openshift/migration-assessment/assessments/${testId}/report`,
+        `/openshift/migration-advisor/assessments/${testId}/report`,
       );
     });
   });


### PR DESCRIPTION
Change Assisted Migration URL from migration-assessment to migration-advisor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated application branding and routing paths across deployment configuration and package metadata. The application URL has been changed from `/openshift/migration-assessment` to `/openshift/migration-advisor`, and the display title is now "Openshift Migration Advisor".

* **Documentation**
  * Updated routing documentation and troubleshooting guides to reflect new application path and basename references.

* **Tests**
  * Updated routing test expectations to align with new path configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->