### PR TITLE
NO-JIRA | refactor: Implement configurable nginx deployment for Migration Planner UI

### DIFF
--- a/deploy/dev/Containerfile
+++ b/deploy/dev/Containerfile
@@ -27,11 +27,14 @@ RUN npm run build:standalone
 # Runtime stage
 FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/nginx-126 AS runtime
 # Copy nginx configuration first (changes less often than built app)
-COPY --from=builder ${APP_ROOT}/deploy/dev/nginx.conf /etc/nginx/nginx.conf
+COPY --from=builder ${APP_ROOT}/deploy/dev/nginx.conf.template /etc/nginx/nginx.conf.template
 # Copy built application from builder stage
 COPY --from=builder ${APP_ROOT}/dev/dist /usr/share/nginx/html
 # Expose port 8081 (nginx default for non-root)
 EXPOSE 8081
 
-# Start nginx
-CMD ["nginx", "-g", "daemon off;"]
+# Copy entrypoint that runs envsubst then nginx
+COPY --from=builder ${APP_ROOT}/deploy/dev/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+# Substitute MIGRATION_PLANNER_API_UPSTREAM and start nginx
+CMD ["/docker-entrypoint.sh"]

--- a/deploy/dev/docker-entrypoint.sh
+++ b/deploy/dev/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# Default upstream for migration-planner API (dev: host.containers.internal)
+export MIGRATION_PLANNER_API_UPSTREAM="${MIGRATION_PLANNER_API_UPSTREAM:-host.containers.internal:3443}"
+export MIGRATION_PLANNER_API_BASE_URL="${MIGRATION_PLANNER_API_BASE_URL:-/api/migration-assessment}"
+
+# Substitute MIGRATION_PLANNER_API_UPSTREAM and MIGRATION_PLANNER_API_BASE_URL so nginx $variables are left intact
+envsubst '${MIGRATION_PLANNER_API_UPSTREAM} ${MIGRATION_PLANNER_API_BASE_URL}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+
+exec nginx -g "daemon off;"

--- a/deploy/dev/nginx.conf.template
+++ b/deploy/dev/nginx.conf.template
@@ -1,0 +1,55 @@
+events {
+    worker_connections 1024;
+}
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    sendfile on;
+    keepalive_timeout 65;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+   
+    upstream migration_planner_api {
+        server ${MIGRATION_PLANNER_API_UPSTREAM};
+    }
+    
+    server {
+        listen 8081;
+        server_name localhost;
+        root /usr/share/nginx/html;
+        index index.html;
+        
+         # Proxy API calls to migration-planner-api service
+         location ${MIGRATION_PLANNER_API_BASE_URL} {
+             proxy_pass http://migration_planner_api/;
+             proxy_set_header Host $host;
+             proxy_set_header X-Real-IP $remote_addr;
+             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+             proxy_set_header X-Forwarded-Proto $scheme;
+             proxy_connect_timeout 30s;
+             proxy_send_timeout 30s;
+             proxy_read_timeout 30s;
+         }
+       
+        # Serve static files and SPA
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+       
+        # Enable gzip compression
+        gzip on;
+        gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+       
+        # Security headers
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+
+        # Redirect access logs to stdout using the 'main' format
+        access_log /dev/stdout main;
+        # Redirect error logs to stderr, setting the log level (e.g., info)
+        error_log /dev/stderr info;
+    }
+}

--- a/deploy/dev/ui-template.yaml
+++ b/deploy/dev/ui-template.yaml
@@ -14,6 +14,12 @@ parameters:
   - name: ROUTE_HOST
     description: Host name for the route (optional, if not specified OpenShift will generate one)
     value: ""
+  - name: MIGRATION_PLANNER_API_UPSTREAM
+    description: Backend API host:port for nginx to proxy to (e.g. migration-planner-api:3443 in same namespace)
+    value: "migration-planner-api:3443"
+  - name: MIGRATION_PLANNER_API_BASE_URL
+    description: API base path the SPA was built with; must match build-time value (e.g. /api/migration-assessment)
+    value: "/api/migration-assessment"
 
 objects:
   - kind: Deployment
@@ -39,19 +45,24 @@ objects:
               image: ${MIGRATION_PLANNER_UI_IMAGE}:${IMAGE_TAG}
               imagePullPolicy: Always
               ports:
-                - containerPort: 8080
+                - containerPort: 8081
                   protocol: TCP
+              env:
+                - name: MIGRATION_PLANNER_API_UPSTREAM
+                  value: ${MIGRATION_PLANNER_API_UPSTREAM}
+                - name: MIGRATION_PLANNER_API_BASE_URL
+                  value: ${MIGRATION_PLANNER_API_BASE_URL}
               livenessProbe:
                 httpGet:
                   path: /
-                  port: 8080
+                  port: 8081
                 initialDelaySeconds: 30
                 periodSeconds: 10
                 timeoutSeconds: 5
               readinessProbe:
                 httpGet:
                   path: /
-                  port: 8080
+                  port: 8081
                 initialDelaySeconds: 5
                 periodSeconds: 5
                 timeoutSeconds: 3
@@ -73,8 +84,8 @@ objects:
     spec:
       ports:
         - name: http
-          port: 8080
-          targetPort: 8080
+          port: 8081
+          targetPort: 8081
           protocol: TCP
       selector:
         app: migration-planner-ui

--- a/docs/plans/standalone-nginx-configurable-deployment.md
+++ b/docs/plans/standalone-nginx-configurable-deployment.md
@@ -1,0 +1,108 @@
+# Plan: Configurable standalone nginx deployment
+
+**Status:** Implemented  
+**Scope:** `deploy/dev/` — nginx container used to serve the standalone SPA build
+
+## Goal
+
+Make the nginx container that serves the standalone UI build **configurable at runtime** so a single image can be instantiated with different:
+
+- **API upstream** — host and port of the migration-planner API backend
+- **API base path** — URL path prefix under which API requests are proxied (e.g. `/api/migration-assessment`)
+
+This allows the same image to be used in dev (e.g. `host.containers.internal:3443`), OpenShift (e.g. `migration-planner-api:3443`), or other environments without rebuilding.
+
+---
+
+## Implemented changes
+
+### 1. Nginx config template (`deploy/dev/nginx.conf.template`)
+
+- **Static `nginx.conf`** (`deploy/dev/nginx.conf`) is unchanged and remains the reference for local or non-container use.
+- **Template** `nginx.conf.template` is used at container runtime. It contains two placeholders substituted at startup:
+  - `${MIGRATION_PLANNER_API_UPSTREAM}` — upstream server (host:port), e.g. `host.containers.internal:3443`
+  - `${MIGRATION_PLANNER_API_BASE_URL}` — location path for proxying, e.g. `/api/migration-assessment`
+- A single `location` block proxies requests under the base URL to the upstream; the path prefix is stripped so the backend receives paths relative to its root.
+
+### 2. Entrypoint script (`deploy/dev/docker-entrypoint.sh`)
+
+- Runs before nginx. Exports defaults when env vars are unset:
+  - `MIGRATION_PLANNER_API_UPSTREAM` → `host.containers.internal:3443`
+  - `MIGRATION_PLANNER_API_BASE_URL` → `/api/migration-assessment`
+- Uses `envsubst` to substitute **only** these two variables into the template (so nginx’s own `$host`, `$uri`, etc. are not touched).
+- Writes the result to `/etc/nginx/nginx.conf` and then `exec`s nginx.
+
+### 3. Containerfile (`deploy/dev/Containerfile`)
+
+- **Build stage:** Unchanged; still uses `MIGRATION_PLANNER_API_BASE_URL` (and other build args) so the SPA is built with the correct API base path.
+- **Runtime stage:**
+  - Copies `nginx.conf.template` and `docker-entrypoint.sh` from the build context (via the builder stage copy of the repo).
+  - Sets `docker-entrypoint.sh` as executable.
+  - `CMD` is `/docker-entrypoint.sh` instead of starting nginx directly.
+
+### 4. Build and runtime alignment
+
+- **Build time:** `MIGRATION_PLANNER_API_BASE_URL` is passed as a build arg and baked into the SPA (e.g. in `dev/vite.config.ts`). The frontend sends API requests to that path.
+- **Runtime:** The same logical value should be set in `MIGRATION_PLANNER_API_BASE_URL` (and `MIGRATION_PLANNER_API_UPSTREAM` as needed) when running the container so nginx proxies that path to the intended backend. If build and runtime values differ, the UI may call a path that nginx does not proxy (or vice versa).
+
+---
+
+## Environment variables (runtime)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MIGRATION_PLANNER_API_UPSTREAM` | `host.containers.internal:3443` | Backend host:port nginx proxies to. |
+| `MIGRATION_PLANNER_API_BASE_URL` | `/api/migration-assessment` | Path prefix under which API requests are proxied. Must match the base URL the SPA was built with. |
+
+---
+
+**Runtime image:** `envsubst` is already available in the nginx runtime image (`registry.access.redhat.com/ubi9/nginx-126`); no extra package install is required.
+
+### OpenShift template (addressed)
+
+The OpenShift template (`deploy/dev/ui-template.yaml`) sets `MIGRATION_PLANNER_API_UPSTREAM` and `MIGRATION_PLANNER_API_BASE_URL` on the deployment (via template parameters, defaulting to `migration-planner-api:3443` and `/api/migration-assessment`) and uses port **8081** for the container and service to match the nginx image.
+
+---
+
+## Operational notes (documentation for deployers)
+
+### Build-time vs runtime base URL (must match)
+
+The SPA is built with `MIGRATION_PLANNER_API_BASE_URL` baked in; the frontend always calls that path. Nginx proxies only the path set at runtime via the same variable. **The runtime value must match the build-time value** or the UI will request a path nginx does not proxy (or the opposite). When building the image, pass the same base URL you will use when running the container (e.g. via the OpenShift template parameters or `podman run -e`).
+
+### Location path format convention
+
+Use **no trailing slash** for `MIGRATION_PLANNER_API_BASE_URL` (e.g. `/api/migration-assessment`). Nginx treats it as a prefix location, so both `/api/migration-assessment` and `/api/migration-assessment/` match requests like `/api/migration-assessment/foo`; the default and template use the no-trailing-slash form for consistency and to avoid double slashes when the path is stripped for the upstream.
+
+### Overriding env when running the container locally
+
+The Makefile’s `podman-run` target does not pass `MIGRATION_PLANNER_API_UPSTREAM` or `MIGRATION_PLANNER_API_BASE_URL`; the container uses entrypoint defaults (`host.containers.internal:3443` and `/api/migration-assessment`), which are correct for typical local dev. To use a different API host/port or base path, pass the env vars when running the container, for example:
+
+```bash
+podman run -d --name migration-planner-ui -p 8081:8081 \
+  -e MIGRATION_PLANNER_API_UPSTREAM=my-api-host:3443 \
+  -e MIGRATION_PLANNER_API_BASE_URL=/api/migration-assessment \
+  $(IMAGE):$(IMAGE_TAG)
+```
+
+Replace `my-api-host:3443` and the base URL as needed. The base URL must still match the value the image was built with.
+
+---
+
+## Files touched
+
+| Path | Role |
+|------|------|
+| `deploy/dev/nginx.conf` | Unchanged; reference static config. |
+| `deploy/dev/nginx.conf.template` | Runtime template with `${MIGRATION_PLANNER_API_UPSTREAM}` and `${MIGRATION_PLANNER_API_BASE_URL}`. |
+| `deploy/dev/docker-entrypoint.sh` | Defaults env, runs `envsubst`, then `exec nginx`. |
+| `deploy/dev/Containerfile` | Copies template and entrypoint; CMD is entrypoint. |
+| `deploy/dev/ui-template.yaml` | Sets env vars and port 8081 for OpenShift deployment. |
+
+---
+
+## References
+
+- Standalone deployment: `docs/standalone-deployment.md`
+- Make: `MIGRATION_PLANNER_API_BASE_URL` and build args in `Makefile`; `podman-run` uses entrypoint defaults (see “Overriding env when running the container locally” above for custom values).
+- OpenShift: `deploy/dev/ui-template.yaml` — template parameters `MIGRATION_PLANNER_API_UPSTREAM` and `MIGRATION_PLANNER_API_BASE_URL`, container and service use port 8081.

--- a/docs/standalone-deployment.md
+++ b/docs/standalone-deployment.md
@@ -1,6 +1,10 @@
 # Standalone OpenShift Deployment Guide
 
-This guide provides instructions for building and deploying the Migration Planner UI in a standalone OpenShift environment.
+This guide provides instructions for building and deploying the Migration Planner UI in a standalone OpenShift environment. For the configurable nginx setup (API upstream and base path via environment variables), see [standalone-nginx-configurable-deployment](plans/standalone-nginx-configurable-deployment.md).
+
+**Build and runtime alignment:** The image is built with a specific API base path (`MIGRATION_PLANNER_API_BASE_URL`). When you deploy (OpenShift template or `podman run`), use the same base path at runtime so nginx proxies the path the UI calls. The OpenShift template defaults match the default build; override the template parameters only if you built the image with a different base path.
+
+**Local runs:** `make podman-run` uses default API upstream and base path. To override (e.g. different API host/port), run the container with `-e MIGRATION_PLANNER_API_UPSTREAM=...` and `-e MIGRATION_PLANNER_API_BASE_URL=...`; see the [plan](plans/standalone-nginx-configurable-deployment.md) for the exact variables and examples.
 
 ## Prerequisites
 
@@ -44,6 +48,8 @@ Deploy the application to your OpenShift cluster:
 # Deploy using the OpenShift template
 make deploy-on-openshift IMAGE=quay.io/your-registry/migration-planner-ui
 ```
+
+The template sets `MIGRATION_PLANNER_API_UPSTREAM` (default `migration-planner-api:3443`) and `MIGRATION_PLANNER_API_BASE_URL` (default `/api/migration-assessment`) so nginx proxies API traffic to the backend. Use the same base path as at build time. To override when processing the template, pass e.g. `-p MIGRATION_PLANNER_API_UPSTREAM=your-api-service:3443`.
 
 ### Step 4: Access the Application
 


### PR DESCRIPTION
- Added a runtime template for nginx configuration (`nginx.conf.template`) to allow dynamic substitution of API upstream and base URL.
- Introduced an entrypoint script (`docker-entrypoint.sh`) that sets default environment variables and runs `envsubst` to generate the final nginx configuration.
- Updated the `Containerfile` to copy the new template and entrypoint script, changing the CMD to execute the entrypoint.
- Modified the OpenShift template (`ui-template.yaml`) to include environment variables for API upstream and base URL, and updated the container port to 8081.
- Enhanced documentation to clarify the new configurable deployment process and environment variable usage.

Signed-off-by: Jonathan Kilzi <jkilzi@redha.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime configuration for API upstream and base URL via environment variables.
  * UI now listens on port 8081.
  * Container startup now performs runtime substitution of configuration and launches the web server so settings take effect at start.

* **Documentation**
  * Added guides for configurable standalone web-server deployment, runtime overrides, and updated deployment/run instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->