### PR TITLE
NO-JIRA | fix: update nginx proxy_pass configuration to remove trailing slash

### DIFF
--- a/deploy/dev/nginx.conf.template
+++ b/deploy/dev/nginx.conf.template
@@ -26,7 +26,7 @@ http {
 
         # Proxy API calls to migration-planner-api service
         location ${MIGRATION_PLANNER_API_BASE_URL} {
-            proxy_pass http://migration_planner_api/;
+            proxy_pass http://migration_planner_api;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;

--- a/docs/plans/standalone-nginx-configurable-deployment.md
+++ b/docs/plans/standalone-nginx-configurable-deployment.md
@@ -48,10 +48,10 @@ This allows the same image to be used in dev (e.g. `host.containers.internal:344
 
 ## Environment variables (runtime)
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MIGRATION_PLANNER_API_UPSTREAM` | `host.containers.internal:3443` | Backend host:port nginx proxies to. |
-| `MIGRATION_PLANNER_API_BASE_URL` | `/api/migration-assessment` | Path prefix under which API requests are proxied. Must match the base URL the SPA was built with. |
+| Variable                         | Default                         | Description                                                                                       |
+| -------------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `MIGRATION_PLANNER_API_UPSTREAM` | `host.containers.internal:3443` | Backend host:port nginx proxies to.                                                               |
+| `MIGRATION_PLANNER_API_BASE_URL` | `/api/migration-assessment`     | Path prefix under which API requests are proxied. Must match the base URL the SPA was built with. |
 
 ---
 
@@ -90,12 +90,12 @@ Replace `my-api-host:3443` and the base URL as needed. The base URL must still m
 
 ## Files touched
 
-| Path | Role |
-|------|------|
-| `deploy/dev/nginx.conf.template` | Runtime template with `${MIGRATION_PLANNER_API_UPSTREAM}` and `${MIGRATION_PLANNER_API_BASE_URL}`. |
-| `deploy/dev/docker-entrypoint.sh` | Defaults env, runs `envsubst`, then `exec nginx`. |
-| `deploy/dev/Containerfile` | Copies template and entrypoint; CMD is entrypoint. |
-| `deploy/dev/ui-template.yaml` | Sets env vars and port 8081 for OpenShift deployment. |
+| Path                              | Role                                                                                               |
+| --------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `deploy/dev/nginx.conf.template`  | Runtime template with `${MIGRATION_PLANNER_API_UPSTREAM}` and `${MIGRATION_PLANNER_API_BASE_URL}`. |
+| `deploy/dev/docker-entrypoint.sh` | Defaults env, runs `envsubst`, then `exec nginx`.                                                  |
+| `deploy/dev/Containerfile`        | Copies template and entrypoint; CMD is entrypoint.                                                 |
+| `deploy/dev/ui-template.yaml`     | Sets env vars and port 8081 for OpenShift deployment.                                              |
 
 ---
 


### PR DESCRIPTION
[skip ci]

Updated the proxy_pass directive in the nginx configuration template to eliminate the trailing slash, ensuring proper request forwarding to the migration-planner-api service.

Signed-off-by: Jonathan Kilzi <jkilzi@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Modified API routing configuration in the development deployment (adjusted proxy behavior).
* **Documentation**
  * Reformatted deployment documentation tables and spacing for clearer presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->