### PR TITLE
NO-JIRA | fix: adding unknown category in complexity by OS options

### DIFF
--- a/src/ui/report/views/cluster-sizer/ComplexityResult.tsx
+++ b/src/ui/report/views/cluster-sizer/ComplexityResult.tsx
@@ -448,7 +448,7 @@ export const ComplexityResult: React.FC<ComplexityResultProps> = ({
           </FlexItem>
           <FlexItem>
             <div className={legendContainerStyle}>
-              {[1, 2, 3, 4].map((score) => (
+              {[0, 1, 2, 3, 4].map((score) => (
                 <Badge
                   key={score}
                   style={{


### PR DESCRIPTION
<img width="1095" height="728" alt="image" src="https://github.com/user-attachments/assets/df177451-436f-410e-a738-0ec468457fa0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated complexity result display to include "Unknown" score representation in the legend, adding proper visual indicators and color mappings for this previously unhandled state alongside existing score levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->