### PR TITLE
ECOPROJECT-4286 | feat: add a Manage Columns control in the assessments table toolbar

### DIFF
--- a/src/hooks/__tests__/useLocalStorage.test.ts
+++ b/src/hooks/__tests__/useLocalStorage.test.ts
@@ -1,0 +1,107 @@
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+
+import useLocalStorage from "../useLocalStorage";
+
+test("useLocalStorage initial value string", () => {
+  expect(
+    renderHook(() => useLocalStorage("key1", "abc")).result.current[0],
+  ).toBe("abc");
+});
+
+test("useLocalStorage initial value boolean", () => {
+  expect(
+    renderHook(() => useLocalStorage("key2", true)).result.current[0],
+  ).toBe(true);
+});
+
+test("useLocalStorage initial value object", () => {
+  expect(
+    renderHook(() => useLocalStorage("key3", { o: 1 })).result.current[0],
+  ).toEqual({ o: 1 });
+});
+
+test("useLocalStorage initial value null", () => {
+  expect(
+    renderHook(() => useLocalStorage("key4", null)).result.current[0],
+  ).toBe(null);
+});
+
+test("useLocalStorage initial value array", () => {
+  expect(
+    renderHook(() => useLocalStorage("key5", ["a", "b"])).result.current[0],
+  ).toEqual(["a", "b"]);
+});
+
+test("useLocalStorage can change the value with the second element", () => {
+  const { result } = renderHook(() => useLocalStorage("key6", "abc"));
+  expect(result.current[0]).toBe("abc");
+
+  act(() => {
+    result.current[1]("def");
+  });
+  expect(result.current[0]).toBe("def");
+});
+
+test("useLocalStorage return value previously saved", () => {
+  const { result } = renderHook(() => useLocalStorage("key7", "abc"));
+  act(() => {
+    result.current[1]("def");
+  });
+  expect(result.current[0]).toBe("def");
+  expect(
+    renderHook(() => useLocalStorage("key7", "ijk")).result.current[0],
+  ).toBe("def");
+});
+
+test("useLocalStorage doesn't return value previously saved if version is set", () => {
+  const { result } = renderHook(() => useLocalStorage("key8", "abc"));
+  act(() => {
+    result.current[1]("def");
+  });
+  expect(result.current[0]).toBe("def");
+  expect(
+    renderHook(() => useLocalStorage("key8", "ijk", 2)).result.current[0],
+  ).toBe("ijk");
+});
+
+test("useLocalStorage supports updater function", () => {
+  const { result } = renderHook(() => useLocalStorage("key9", 10));
+  expect(result.current[0]).toBe(10);
+
+  act(() => {
+    result.current[1]((prev) => prev + 5);
+  });
+  expect(result.current[0]).toBe(15);
+
+  act(() => {
+    result.current[1]((prev) => prev * 2);
+  });
+  expect(result.current[0]).toBe(30);
+});
+
+test("useLocalStorage supports updater function with arrays", () => {
+  const { result } = renderHook(() => useLocalStorage("key10", ["a", "b"]));
+  expect(result.current[0]).toEqual(["a", "b"]);
+
+  act(() => {
+    result.current[1]((prev) => [...prev, "c"]);
+  });
+  expect(result.current[0]).toEqual(["a", "b", "c"]);
+
+  act(() => {
+    result.current[1]((prev) => prev.filter((item) => item !== "b"));
+  });
+  expect(result.current[0]).toEqual(["a", "c"]);
+});
+
+test("useLocalStorage supports batched updater functions", () => {
+  const { result } = renderHook(() => useLocalStorage("key11", 10));
+  expect(result.current[0]).toBe(10);
+
+  act(() => {
+    result.current[1]((prev) => prev + 5);
+    result.current[1]((prev) => prev * 2);
+  });
+  expect(result.current[0]).toBe(30);
+});

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+
+function readValue<T>(key: string, initialValue: T, version: number = 1): T {
+  try {
+    const item = window.localStorage.getItem(key);
+    if (item) {
+      const parsed = JSON.parse(item) as {
+        value: T;
+        version: number;
+      };
+      return parsed.version === version ? parsed.value : initialValue;
+    }
+    return initialValue;
+  } catch (error) {
+    console.warn(`Error reading localStorage key "${key}":`, error);
+    return initialValue;
+  }
+}
+
+function saveValue<T>(key: string, value: T, version: number = 1): void {
+  try {
+    window.localStorage.setItem(key, JSON.stringify({ version, value }));
+  } catch (error) {
+    console.warn(`Error setting localStorage key "${key}":`, error);
+  }
+}
+
+export default function useLocalStorage<T>(
+  key: string,
+  initialValue: T,
+  version: number = 1,
+): [T, (value: T | ((prev: T) => T)) => void] {
+  const [storedValue, setStoredValue] = useState<T>(
+    readValue(key, initialValue, version),
+  );
+
+  useEffect(() => {
+    saveValue(key, storedValue, version);
+  }, [key, storedValue, version]);
+
+  return [
+    storedValue,
+    (value: T | ((prev: T) => T)) => {
+      setStoredValue((previousValue) =>
+        value instanceof Function ? value(previousValue) : value,
+      );
+    },
+  ];
+}

--- a/src/ui/assessment/view-models/useAssessmentPageViewModel.ts
+++ b/src/ui/assessment/view-models/useAssessmentPageViewModel.ts
@@ -6,6 +6,7 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useState,
   useSyncExternalStore,
 } from "react";
 import { useNavigate } from "react-router-dom";
@@ -18,7 +19,19 @@ import {
   JOB_POLLING_INTERVAL,
   TERMINAL_JOB_STATUSES,
 } from "../../../data/stores/JobsStore";
+import useLocalStorage from "../../../hooks/useLocalStorage";
 import { routes } from "../../../routing/Routes";
+import type { ColumnKey, SortableColumn } from "../views/AssessmentsTable";
+import {
+  DEFAULT_VISIBLE_COLUMNS,
+  MANDATORY_COLUMNS,
+} from "../views/AssessmentsTable";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const VISIBLE_COLUMNS_KEY = "migration-advisor:visible-columns";
 
 // ---------------------------------------------------------------------------
 // Private helpers — job progress mappers
@@ -99,6 +112,23 @@ export interface AssessmentPageViewModel {
   /** Error from the last update-assessment attempt. */
   updateError?: Error;
 
+  // -- Column visibility & sorting -------------------------------------------
+
+  /** Whether the column selection dropdown is open. */
+  isColumnSelectOpen: boolean;
+  /** Toggle the column selection dropdown. */
+  setIsColumnSelectOpen: (open: boolean) => void;
+  /** Visible columns (includes mandatory columns). */
+  visibleColumns: ColumnKey[];
+  /** Toggle a column's visibility. */
+  toggleColumn: (columnKey: ColumnKey) => void;
+  /** Current sort state. */
+  sortBy: { columnKey: SortableColumn; direction: "asc" | "desc" } | undefined;
+  /** Update the sort state. */
+  setSortBy: (
+    sort: { columnKey: SortableColumn; direction: "asc" | "desc" } | undefined,
+  ) => void;
+
   // -- Actions ---------------------------------------------------------------
 
   /** Create a new RVTools assessment (starts an async job). */
@@ -129,6 +159,57 @@ export const useAssessmentPageViewModel = (): AssessmentPageViewModel => {
   const jobState = useSyncExternalStore(
     jobsStore.subscribe.bind(jobsStore),
     jobsStore.getSnapshot.bind(jobsStore),
+  );
+
+  // ---- Column visibility and sorting --------------------------------------
+
+  const [isColumnSelectOpen, setIsColumnSelectOpen] = useState(false);
+  const [userSelectedColumns, setUserSelectedColumns] = useLocalStorage<
+    ColumnKey[]
+  >(VISIBLE_COLUMNS_KEY, DEFAULT_VISIBLE_COLUMNS);
+
+  const [sortBy, setSortBy] = useState<
+    { columnKey: SortableColumn; direction: "asc" | "desc" } | undefined
+  >({
+    columnKey: "Name",
+    direction: "asc",
+  });
+
+  // Ensure mandatory columns are always included
+  const visibleColumns = useMemo(
+    () =>
+      Array.from(
+        new Set([
+          ...userSelectedColumns.filter((key) =>
+            DEFAULT_VISIBLE_COLUMNS.includes(key),
+          ),
+          ...MANDATORY_COLUMNS,
+        ]),
+      ),
+    [userSelectedColumns],
+  );
+
+  // Reset sort to Name column if the currently sorted column becomes hidden
+  useEffect(() => {
+    if (sortBy) {
+      const sortedColumn = sortBy.columnKey;
+      const sortedColumnNotInVisibleColumns =
+        !visibleColumns.includes(sortedColumn);
+      if (sortedColumn && sortedColumnNotInVisibleColumns) {
+        setSortBy({ columnKey: "Name", direction: "asc" });
+      }
+    }
+  }, [sortBy, visibleColumns]);
+
+  const toggleColumn = useCallback(
+    (columnKey: ColumnKey) => {
+      setUserSelectedColumns((previousColumns) =>
+        previousColumns.includes(columnKey)
+          ? previousColumns.filter((c) => c !== columnKey)
+          : [...previousColumns, columnKey],
+      );
+    },
+    [setUserSelectedColumns],
   );
 
   // ---- Detect job completion and navigate to report -----------------------
@@ -244,6 +325,12 @@ export const useAssessmentPageViewModel = (): AssessmentPageViewModel => {
     deleteError: deleteState.error,
     isUpdatingAssessment: updateState.loading,
     updateError: updateState.error,
+    isColumnSelectOpen,
+    setIsColumnSelectOpen,
+    visibleColumns,
+    toggleColumn,
+    sortBy,
+    setSortBy,
     createRVToolsJob,
     cancelRVToolsJob,
     updateAssessment: doUpdateAssessment,

--- a/src/ui/assessment/views/Assessment.tsx
+++ b/src/ui/assessment/views/Assessment.tsx
@@ -1,3 +1,4 @@
+import { css } from "@emotion/css";
 import {
   Button,
   Dropdown,
@@ -8,11 +9,15 @@ import {
   MenuToggle,
   type MenuToggleElement,
   SearchInput,
+  Select,
+  SelectList,
+  SelectOption,
   Toolbar,
   ToolbarContent,
+  ToolbarGroup,
   ToolbarItem,
 } from "@patternfly/react-core";
-import { FilterIcon, TimesIcon } from "@patternfly/react-icons";
+import { ColumnsIcon, FilterIcon, TimesIcon } from "@patternfly/react-icons";
 import React, { useCallback, useState } from "react";
 
 import type { AssessmentModel } from "../../../models/AssessmentModel";
@@ -21,7 +26,12 @@ import CreateAssessmentDropdown from "../../core/components/CreateAssessmentDrop
 import FilterPill from "../../core/components/FilterPill";
 import StartingPageModal from "../../home/views/StartingPageModal";
 import { useAssessmentPageViewModel } from "../view-models/useAssessmentPageViewModel";
-import AssessmentsTable from "./AssessmentsTable";
+import AssessmentsTable, {
+  type ColumnKey,
+  Columns,
+  MANDATORY_COLUMNS,
+  type SortableColumn,
+} from "./AssessmentsTable";
 import CreateAssessmentModal, {
   type AssessmentMode,
 } from "./CreateAssessmentModal";
@@ -34,6 +44,42 @@ type Props = {
   // When this token changes, the component should open the RVTools modal.
   rvtoolsOpenToken?: string;
 };
+
+const checkboxStyle = css`
+  margin-right: 8px;
+`;
+
+const searchInputStyle = css`
+  min-width: 300px;
+  width: 300px;
+`;
+
+const filterContainerStyle = css`
+  margin-top: 8px;
+`;
+
+const filterInnerStyle = css`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  background: #f5f5f5;
+  padding: 6px 8px;
+  border-radius: 6px;
+`;
+
+const filterLabelStyle = css`
+  background: #e7e7e7;
+  border-radius: 12px;
+  padding: 2px 8px;
+  font-size: 12px;
+`;
+
+const tableContainerStyle = css`
+  margin-top: 10px;
+  max-width: 100%;
+  overflow: auto;
+`;
 
 const Assessment: React.FC<Props> = ({
   assessments,
@@ -49,6 +95,12 @@ const Assessment: React.FC<Props> = ({
     jobError,
     isNavigatingToReport,
     isDeletingAssessment,
+    isColumnSelectOpen,
+    setIsColumnSelectOpen,
+    visibleColumns,
+    toggleColumn,
+    sortBy,
+    setSortBy,
     createRVToolsJob,
     cancelRVToolsJob,
     updateAssessment: vmUpdateAssessment,
@@ -56,12 +108,6 @@ const Assessment: React.FC<Props> = ({
   } = useAssessmentPageViewModel();
 
   const [search, setSearch] = useState("");
-  const [sortBy, setSortBy] = useState<
-    { index: number; direction: "asc" | "desc" } | undefined
-  >({
-    index: 0,
-    direction: "asc",
-  });
   const [isFilterDropdownOpen, setIsFilterDropdownOpen] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalMode, setModalMode] = useState<AssessmentMode>("inventory");
@@ -128,10 +174,10 @@ const Assessment: React.FC<Props> = ({
 
   const onSort = (
     _event: unknown,
-    index: number,
+    columnKey: SortableColumn,
     direction: "asc" | "desc",
   ): void => {
-    setSortBy({ index, direction });
+    setSortBy({ columnKey, direction });
   };
 
   const handleOpenModal = (mode: AssessmentMode): void => {
@@ -227,16 +273,12 @@ const Assessment: React.FC<Props> = ({
         onOpenRVToolsModal={() => handleOpenModal("rvtools")}
       />
 
-      <div
-        style={{
-          background: "white",
-          padding: "0 20px 20px 20px",
-          marginTop: "10px",
-          marginBottom: "10px",
-        }}
-      >
-        <Toolbar inset={{ default: "insetNone" }}>
-          <ToolbarContent>
+      <Toolbar>
+        <ToolbarContent>
+          <ToolbarGroup
+            align={{ default: "alignStart" }}
+            rowWrap={{ default: "wrap", md: "nowrap" }}
+          >
             <ToolbarItem>
               <InputGroup>
                 <InputGroupItem>
@@ -251,8 +293,7 @@ const Assessment: React.FC<Props> = ({
                           setIsFilterDropdownOpen(!isFilterDropdownOpen)
                         }
                         isExpanded={isFilterDropdownOpen}
-                        style={{ minWidth: "220px", width: "220px" }}
-                        icon={<FilterIcon style={{ marginRight: "8px" }} />}
+                        icon={<FilterIcon />}
                       >
                         Filters
                       </MenuToggle>
@@ -288,7 +329,7 @@ const Assessment: React.FC<Props> = ({
                           type="checkbox"
                           readOnly
                           checked={selectedSourceTypes.includes("discovery")}
-                          style={{ marginRight: "8px" }}
+                          className={checkboxStyle}
                         />
                         Discovery OVA
                       </DropdownItem>
@@ -357,99 +398,125 @@ const Assessment: React.FC<Props> = ({
                     value={search}
                     onChange={(_event, value) => setSearch(value)}
                     onClear={() => setSearch("")}
-                    style={{ minWidth: "300px", width: "300px" }}
+                    className={searchInputStyle}
                   />
                 </InputGroupItem>
               </InputGroup>
             </ToolbarItem>
-            {!isTableEmpty() ? (
-              <ToolbarItem align={{ default: "alignStart" }}>
+            <ToolbarItem>
+              <Select
+                isOpen={isColumnSelectOpen}
+                onOpenChange={(isOpen) => setIsColumnSelectOpen(isOpen)}
+                onSelect={(_event, value) => {
+                  if (typeof value === "string") {
+                    toggleColumn(value as ColumnKey);
+                  }
+                }}
+                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                  <MenuToggle
+                    ref={toggleRef}
+                    onClick={() => setIsColumnSelectOpen(!isColumnSelectOpen)}
+                    isExpanded={isColumnSelectOpen}
+                    variant="plain"
+                    icon={<ColumnsIcon />}
+                  >
+                    Manage Columns
+                  </MenuToggle>
+                )}
+              >
+                <SelectList>
+                  {(Object.keys(Columns) as ColumnKey[]).map((columnKey) => {
+                    const isMandatory = MANDATORY_COLUMNS.includes(columnKey);
+                    const isSelected = visibleColumns.includes(columnKey);
+
+                    return (
+                      <SelectOption
+                        key={columnKey}
+                        value={columnKey}
+                        hasCheckbox
+                        isSelected={isSelected}
+                        isDisabled={isMandatory}
+                      >
+                        {Columns[columnKey] || columnKey}
+                      </SelectOption>
+                    );
+                  })}
+                </SelectList>
+              </Select>
+            </ToolbarItem>
+          </ToolbarGroup>
+          {!isTableEmpty() ? (
+            <ToolbarGroup align={{ default: "alignStart", lg: "alignEnd" }}>
+              <ToolbarItem>
                 <CreateAssessmentDropdown
+                  popperProps={{ position: "end" }}
                   onSelectRvtools={() => handleOpenModal("rvtools")}
                 />
               </ToolbarItem>
-            ) : (
-              <></>
-            )}
-          </ToolbarContent>
-        </Toolbar>
+            </ToolbarGroup>
+          ) : (
+            <></>
+          )}
+        </ToolbarContent>
+      </Toolbar>
 
-        {(selectedSourceTypes.length > 0 || selectedOwners.length > 0) && (
-          <div style={{ marginTop: "8px" }}>
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "8px",
-                flexWrap: "wrap",
-                background: "#f5f5f5",
-                padding: "6px 8px",
-                borderRadius: "6px",
+      {(selectedSourceTypes.length > 0 || selectedOwners.length > 0) && (
+        <div className={filterContainerStyle}>
+          <div className={filterInnerStyle}>
+            <span className={filterLabelStyle}>Filters</span>
+
+            {selectedSourceTypes
+              .filter((t) => t === "discovery" || t === "rvtools")
+              .map((t) => (
+                <FilterPill
+                  key={t}
+                  label={`source type=${
+                    t === "discovery" ? "discovery ova" : "rvtools"
+                  }`}
+                  ariaLabel={`Remove source type ${
+                    t === "discovery" ? "discovery ova" : "rvtools"
+                  }`}
+                  onClear={() => toggleSourceType(t)}
+                />
+              ))}
+
+            {selectedOwners
+              .filter((o) => typeof o === "string" && o.trim() !== "")
+              .map((owner) => (
+                <FilterPill
+                  key={owner}
+                  label={`owner=${owner}`}
+                  ariaLabel={`Remove owner ${owner}`}
+                  onClear={() => toggleOwner(owner)}
+                />
+              ))}
+
+            <Button
+              icon={<TimesIcon />}
+              variant="plain"
+              aria-label="Clear all filters"
+              onClick={() => {
+                clearSourceTypes();
+                clearOwners();
               }}
-            >
-              <span
-                style={{
-                  background: "#e7e7e7",
-                  borderRadius: "12px",
-                  padding: "2px 8px",
-                  fontSize: "12px",
-                }}
-              >
-                Filters
-              </span>
-
-              {selectedSourceTypes
-                .filter((t) => t === "discovery" || t === "rvtools")
-                .map((t) => (
-                  <FilterPill
-                    key={t}
-                    label={`source type=${
-                      t === "discovery" ? "discovery ova" : "rvtools"
-                    }`}
-                    ariaLabel={`Remove source type ${
-                      t === "discovery" ? "discovery ova" : "rvtools"
-                    }`}
-                    onClear={() => toggleSourceType(t)}
-                  />
-                ))}
-
-              {selectedOwners
-                .filter((o) => typeof o === "string" && o.trim() !== "")
-                .map((owner) => (
-                  <FilterPill
-                    key={owner}
-                    label={`owner=${owner}`}
-                    ariaLabel={`Remove owner ${owner}`}
-                    onClear={() => toggleOwner(owner)}
-                  />
-                ))}
-
-              <Button
-                icon={<TimesIcon />}
-                variant="plain"
-                aria-label="Clear all filters"
-                onClick={() => {
-                  clearSourceTypes();
-                  clearOwners();
-                }}
-              />
-            </div>
+            />
           </div>
-        )}
-
-        <div style={{ marginTop: "10px" }}>
-          <AssessmentsTable
-            assessments={assessments}
-            isLoading={isLoading}
-            search={search}
-            sortBy={sortBy}
-            onSort={onSort}
-            onDelete={handleDeleteAssessment}
-            onUpdate={handleUpdateAssessment}
-            selectedSourceTypes={selectedSourceTypes}
-            selectedOwners={selectedOwners}
-          />
         </div>
+      )}
+
+      <div className={tableContainerStyle}>
+        <AssessmentsTable
+          assessments={assessments}
+          isLoading={isLoading}
+          search={search}
+          sortBy={sortBy}
+          onSort={onSort}
+          onDelete={handleDeleteAssessment}
+          onUpdate={handleUpdateAssessment}
+          selectedSourceTypes={selectedSourceTypes}
+          selectedOwners={selectedOwners}
+          visibleColumns={visibleColumns}
+        />
       </div>
 
       {isTableEmpty() ? (

--- a/src/ui/assessment/views/AssessmentsTable.tsx
+++ b/src/ui/assessment/views/AssessmentsTable.tsx
@@ -16,7 +16,15 @@ import {
   FileIcon,
   MonitoringIcon,
 } from "@patternfly/react-icons";
-import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+import {
+  Table,
+  TableText,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from "@patternfly/react-table";
 import React, { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -46,13 +54,18 @@ type Props = {
   filterValue?: string;
   selectedSourceTypes?: string[];
   selectedOwners?: string[];
-  sortBy?: { index: number; direction: "asc" | "desc" } | undefined;
-  onSort?: (event: unknown, index: number, direction: "asc" | "desc") => void;
+  sortBy?: { columnKey: SortableColumn; direction: "asc" | "desc" } | undefined;
+  onSort?: (
+    event: unknown,
+    columnKey: SortableColumn,
+    direction: "asc" | "desc",
+  ) => void;
   onDelete?: (assessmentId: string) => void;
   onUpdate?: (assessmentId: string) => void;
+  visibleColumns?: ColumnKey[];
 };
 
-const Columns = {
+export const Columns = {
   Name: "Name",
   SourceType: "Source type",
   LastUpdated: "Last updated",
@@ -65,6 +78,21 @@ const Columns = {
   Actions: "",
 } as const;
 
+export type ColumnKey = keyof typeof Columns;
+export const DEFAULT_VISIBLE_COLUMNS = Object.keys(Columns) as ColumnKey[];
+export const MANDATORY_COLUMNS: ColumnKey[] = ["Name", "Actions"];
+export type SortableColumn = Exclude<ColumnKey, "AssessmentReport" | "Actions">;
+export const SORTABLE_COLUMNS: SortableColumn[] = [
+  "Name",
+  "SourceType",
+  "LastUpdated",
+  "Owner",
+  "Hosts",
+  "VMs",
+  "Networks",
+  "Datastores",
+];
+
 export const AssessmentsTable: React.FC<Props> = ({
   assessments,
   isLoading,
@@ -76,6 +104,7 @@ export const AssessmentsTable: React.FC<Props> = ({
   sortBy,
   onSort,
   onDelete,
+  visibleColumns = Object.keys(Columns) as ColumnKey[],
 }) => {
   const navigate = useNavigate();
   const [openDropdowns, setOpenDropdowns] = useState<Record<string, boolean>>(
@@ -87,6 +116,10 @@ export const AssessmentsTable: React.FC<Props> = ({
       ...prev,
       [assessmentId]: !prev[assessmentId],
     }));
+  };
+
+  const isColumnVisible = (columnKey: ColumnKey): boolean => {
+    return visibleColumns.includes(columnKey);
   };
 
   const handleDelete = (assessmentId: string): void => {
@@ -240,50 +273,50 @@ export const AssessmentsTable: React.FC<Props> = ({
     if (!sortBy) return filtered;
 
     const copy = [...filtered];
-    switch (sortBy.index) {
-      case 0: // Name column
+    switch (sortBy.columnKey) {
+      case "Name":
         copy.sort((a, b) =>
           sortBy.direction === "asc"
             ? a.name.localeCompare(b.name)
             : b.name.localeCompare(a.name),
         );
         break;
-      case 1: // Source type column
+      case "SourceType":
         copy.sort((a, b) =>
           sortBy.direction === "asc"
             ? a.sourceType.localeCompare(b.sourceType)
             : b.sourceType.localeCompare(a.sourceType),
         );
         break;
-      case 2: // Last updated column
+      case "LastUpdated":
         copy.sort((a, b) => {
           const aMs = typeof a.lastUpdatedMs === "number" ? a.lastUpdatedMs : 0;
           const bMs = typeof b.lastUpdatedMs === "number" ? b.lastUpdatedMs : 0;
           return sortBy.direction === "asc" ? aMs - bMs : bMs - aMs;
         });
         break;
-      case 3: // Owner column
+      case "Owner":
         copy.sort((a, b) =>
           sortBy.direction === "asc"
             ? (a.owner || "").localeCompare(b.owner || "")
             : (b.owner || "").localeCompare(a.owner || ""),
         );
         break;
-      case 4: // Hosts column
+      case "Hosts":
         copy.sort((a, b) => {
           const aHosts = typeof a.hosts === "number" ? a.hosts : 0;
           const bHosts = typeof b.hosts === "number" ? b.hosts : 0;
           return sortBy.direction === "asc" ? aHosts - bHosts : bHosts - aHosts;
         });
         break;
-      case 5: // VMs column
+      case "VMs":
         copy.sort((a, b) => {
           const aVms = typeof a.vms === "number" ? a.vms : 0;
           const bVms = typeof b.vms === "number" ? b.vms : 0;
           return sortBy.direction === "asc" ? aVms - bVms : bVms - aVms;
         });
         break;
-      case 6: // Networks column
+      case "Networks":
         copy.sort((a, b) => {
           const aNetworks = typeof a.networks === "number" ? a.networks : 0;
           const bNetworks = typeof b.networks === "number" ? b.networks : 0;
@@ -292,7 +325,7 @@ export const AssessmentsTable: React.FC<Props> = ({
             : bNetworks - aNetworks;
         });
         break;
-      case 7: // Datastores column
+      case "Datastores":
         copy.sort((a, b) => {
           const aDatastores =
             typeof a.datastores === "number" ? a.datastores : 0;
@@ -315,84 +348,28 @@ export const AssessmentsTable: React.FC<Props> = ({
     sortBy,
   ]);
 
-  const nameSortParams =
-    onSort && sortBy
-      ? {
-          sortBy,
-          onSort,
-          columnIndex: 0,
-        }
-      : undefined;
-
-  const sourceTypeSortParams =
-    onSort && sortBy
-      ? {
-          sortBy,
-          onSort,
-          columnIndex: 1,
-        }
-      : undefined;
-
-  const lastUpdatedSortParams =
-    onSort && sortBy
-      ? {
-          sortBy,
-          onSort,
-          columnIndex: 2,
-        }
-      : undefined;
-
-  const ownerSortParams =
-    onSort && sortBy
-      ? {
-          sortBy,
-          onSort,
-          columnIndex: 3,
-        }
-      : undefined;
-
-  const hostsSortParams =
-    onSort && sortBy
-      ? {
-          sortBy,
-          onSort,
-          columnIndex: 4,
-        }
-      : undefined;
-
-  const vmsSortParams =
-    onSort && sortBy
-      ? {
-          sortBy,
-          onSort,
-          columnIndex: 5,
-        }
-      : undefined;
-
-  const networksSortParams =
-    onSort && sortBy
-      ? {
-          sortBy,
-          onSort,
-          columnIndex: 6,
-        }
-      : undefined;
-
-  const datastoresSortParams =
-    onSort && sortBy
-      ? {
-          sortBy,
-          onSort,
-          columnIndex: 7,
-        }
-      : undefined;
+  const getSortParams = (columnKey: SortableColumn) => {
+    if (!onSort || !sortBy) return undefined;
+    const columnIndex = SORTABLE_COLUMNS.indexOf(columnKey);
+    const activeSortColumnIndex = SORTABLE_COLUMNS.indexOf(sortBy.columnKey);
+    return {
+      sortBy: {
+        index: activeSortColumnIndex,
+        direction: sortBy.direction,
+      },
+      onSort: (event: unknown, _index: number, direction: "asc" | "desc") => {
+        onSort(event, columnKey, direction);
+      },
+      columnIndex,
+    };
+  };
 
   if (isLoading && (!assessments || assessments.length === 0)) {
     return (
       <Table aria-label="Loading assessments" variant="compact" borders={false}>
         <Tbody>
           <Tr>
-            <Td colSpan={10}>
+            <Td colSpan={visibleColumns.length}>
               <Spinner size="xl" />
             </Td>
           </Tr>
@@ -401,94 +378,112 @@ export const AssessmentsTable: React.FC<Props> = ({
     );
   }
   return (
-    <div
-      style={{
-        width: "100%",
-        maxHeight: "60vh",
-        overflow: "auto",
-      }}
+    <Table
+      aria-label="Assessments table"
+      variant="compact"
+      borders={false}
+      isStickyHeader
+      gridBreakPoint="grid-md"
     >
-      <Table
-        aria-label="Assessments table"
-        variant="compact"
-        borders={false}
-        isStickyHeader
-        style={{ tableLayout: "auto", width: "100%" }}
-      >
-        <Thead>
-          <Tr>
-            <Th sort={nameSortParams} modifier="wrap">
+      <Thead>
+        <Tr>
+          {isColumnVisible("Name") && (
+            <Th sort={getSortParams("Name")} modifier="nowrap">
               {Columns.Name}
             </Th>
-            <Th sort={sourceTypeSortParams} modifier="nowrap">
+          )}
+          {isColumnVisible("SourceType") && (
+            <Th sort={getSortParams("SourceType")} modifier="nowrap">
               {Columns.SourceType}
             </Th>
-            <Th sort={lastUpdatedSortParams} modifier="nowrap">
+          )}
+          {isColumnVisible("LastUpdated") && (
+            <Th sort={getSortParams("LastUpdated")} modifier="nowrap">
               {Columns.LastUpdated}
             </Th>
-            <Th sort={ownerSortParams} modifier="nowrap">
+          )}
+          {isColumnVisible("Owner") && (
+            <Th sort={getSortParams("Owner")} modifier="nowrap">
               {Columns.Owner}
             </Th>
-            <Th sort={hostsSortParams} modifier="nowrap">
+          )}
+          {isColumnVisible("Hosts") && (
+            <Th sort={getSortParams("Hosts")} modifier="nowrap">
               {Columns.Hosts}
             </Th>
-            <Th sort={vmsSortParams} modifier="nowrap">
+          )}
+          {isColumnVisible("VMs") && (
+            <Th sort={getSortParams("VMs")} modifier="nowrap">
               {Columns.VMs}
             </Th>
-            <Th sort={networksSortParams} modifier="nowrap">
+          )}
+          {isColumnVisible("Networks") && (
+            <Th sort={getSortParams("Networks")} modifier="nowrap">
               {Columns.Networks}
             </Th>
-            <Th sort={datastoresSortParams} modifier="nowrap">
+          )}
+          {isColumnVisible("Datastores") && (
+            <Th sort={getSortParams("Datastores")} modifier="nowrap">
               {Columns.Datastores}
             </Th>
+          )}
+          {isColumnVisible("AssessmentReport") && (
             <Th modifier="nowrap">{Columns.AssessmentReport}</Th>
+          )}
+          {isColumnVisible("Actions") && (
             <Th modifier="fitContent" screenReaderText="Actions">
               {Columns.Actions}
             </Th>
-          </Tr>
-        </Thead>
-        <Tbody>
-          {rows.map((row) => (
-            <Tr key={row.key}>
+          )}
+        </Tr>
+      </Thead>
+      <Tbody>
+        {rows.map((row) => (
+          <Tr key={row.key}>
+            {isColumnVisible("Name") && (
               <Td dataLabel={Columns.Name}>
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "8px",
-                  }}
-                >
-                  <Button
-                    variant={row.hasData ? "link" : "plain"}
-                    style={{ padding: 0, textAlign: "left" }}
-                    isDisabled={!row.hasData}
-                    onClick={
-                      row.hasData
-                        ? (): void => navigate(routes.assessmentById(row.id))
-                        : undefined
-                    }
+                <TableText>
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "8px",
+                    }}
                   >
-                    <Truncate content={row.name} />
-                  </Button>
-                  {!row.hasData && (
-                    <Tooltip
-                      content={
-                        row.sourceType.toLowerCase().includes("rvtools")
-                          ? "No inventory data found. The uploaded file may be corrupted. Please verify and re-upload."
-                          : "No inventory data yet. Data collection may be in progress or the source connection failed."
+                    <Button
+                      variant={row.hasData ? "link" : "plain"}
+                      style={{ padding: 0 }}
+                      isDisabled={!row.hasData}
+                      onClick={
+                        row.hasData
+                          ? (): void => navigate(routes.assessmentById(row.id))
+                          : undefined
                       }
                     >
-                      <ExclamationTriangleIcon
-                        style={{ color: "#f0ab00", cursor: "help" }}
-                      />
-                    </Tooltip>
-                  )}
-                </div>
+                      <Truncate content={row.name} />
+                    </Button>
+                    {!row.hasData && (
+                      <Tooltip
+                        content={
+                          row.sourceType.toLowerCase().includes("rvtools")
+                            ? "No inventory data found. The uploaded file may be corrupted. Please verify and re-upload."
+                            : "No inventory data yet. Data collection may be in progress or the source connection failed."
+                        }
+                      >
+                        <ExclamationTriangleIcon
+                          style={{
+                            color: "#f0ab00",
+                            cursor: "help",
+                          }}
+                        />
+                      </Tooltip>
+                    )}
+                  </div>
+                </TableText>
               </Td>
-              <Td
-                dataLabel={Columns.SourceType}
-                style={{ whiteSpace: "nowrap" }}
-              >
+            )}
+            {isColumnVisible("SourceType") && (
+              <Td dataLabel={Columns.SourceType}>
                 <div
                   style={{
                     display: "flex",
@@ -501,49 +496,63 @@ export const AssessmentsTable: React.FC<Props> = ({
                   ) : (
                     <ConnectedIcon />
                   )}
-                  {row.sourceType.toLowerCase() === "rvtools"
-                    ? "RVTools (XLS/X)"
-                    : "Discovery OVA"}
+                  {row.sourceType.toLowerCase() === "rvtools" ? (
+                    <Truncate content="RVTools (XLS/X)" />
+                  ) : (
+                    <Truncate content="Discovery OVA" />
+                  )}
                 </div>
               </Td>
-              <Td dataLabel={Columns.LastUpdated}>{row.lastUpdated}</Td>
-              <Td dataLabel={Columns.Owner}>{row.owner}</Td>
-              <Td dataLabel={Columns.Hosts} style={{ whiteSpace: "nowrap" }}>
-                {row.hosts}
+            )}
+            {isColumnVisible("LastUpdated") && (
+              <Td dataLabel={Columns.LastUpdated}>
+                <Truncate content={row.lastUpdated} />
               </Td>
-              <Td dataLabel={Columns.VMs} style={{ whiteSpace: "nowrap" }}>
-                {row.vms}
+            )}
+            {isColumnVisible("Owner") && (
+              <Td dataLabel={Columns.Owner}>
+                <Truncate content={row.owner} />
               </Td>
-              <Td dataLabel={Columns.Networks} style={{ whiteSpace: "nowrap" }}>
-                {row.networks}
-              </Td>
-              <Td
-                dataLabel={Columns.Datastores}
-                style={{ whiteSpace: "nowrap" }}
-              >
-                {row.datastores}
-              </Td>
+            )}
+            {isColumnVisible("Hosts") && (
+              <Td dataLabel={Columns.Hosts}>{row.hosts}</Td>
+            )}
+            {isColumnVisible("VMs") && (
+              <Td dataLabel={Columns.VMs}>{row.vms}</Td>
+            )}
+            {isColumnVisible("Networks") && (
+              <Td dataLabel={Columns.Networks}>{row.networks}</Td>
+            )}
+            {isColumnVisible("Datastores") && (
+              <Td dataLabel={Columns.Datastores}>{row.datastores}</Td>
+            )}
+            {isColumnVisible("AssessmentReport") && (
               <Td dataLabel={Columns.AssessmentReport}>
-                <Tooltip
-                  content={
-                    row.hasData
-                      ? "View assessment report"
-                      : row.sourceType.toLowerCase().includes("rvtools")
-                        ? "No inventory data found. The uploaded file may be corrupted. Please verify and re-upload."
-                        : "No inventory data yet. Data collection may be in progress or the source connection failed."
-                  }
-                >
-                  <Button
-                    variant="link"
-                    isAriaDisabled={!row.hasData}
-                    onClick={() => navigate(routes.assessmentReport(row.id))}
-                    icon={<MonitoringIcon />}
-                    style={{ padding: 0, whiteSpace: "nowrap" }}
+                <TableText>
+                  <Tooltip
+                    content={
+                      row.hasData
+                        ? "View assessment report"
+                        : row.sourceType.toLowerCase().includes("rvtools")
+                          ? "No inventory data found. The uploaded file may be corrupted. Please verify and re-upload."
+                          : "No inventory data yet. Data collection may be in progress or the source connection failed."
+                    }
                   >
-                    View report
-                  </Button>
-                </Tooltip>
+                    <Button
+                      variant="link"
+                      isAriaDisabled={!row.hasData}
+                      onClick={() => navigate(routes.assessmentReport(row.id))}
+                      icon={<MonitoringIcon />}
+                      aria-label="View assessment report"
+                      style={{ padding: 0 }}
+                    >
+                      View report
+                    </Button>
+                  </Tooltip>
+                </TableText>
               </Td>
+            )}
+            {isColumnVisible("Actions") && (
               <Td dataLabel={Columns.Actions} modifier="fitContent">
                 <Dropdown
                   isOpen={openDropdowns[row.id] || false}
@@ -564,7 +573,7 @@ export const AssessmentsTable: React.FC<Props> = ({
                       variant="plain"
                       onClick={() => toggleDropdown(row.id)}
                       icon={<EllipsisVIcon />}
-                      style={{ padding: 0 }}
+                      style={{ padding: 0, width: "fit-content" }}
                     ></MenuToggle>
                   )}
                 >
@@ -593,11 +602,11 @@ export const AssessmentsTable: React.FC<Props> = ({
                   </DropdownList>
                 </Dropdown>
               </Td>
-            </Tr>
-          ))}
-        </Tbody>
-      </Table>
-    </div>
+            )}
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
   );
 };
 

--- a/src/ui/core/components/CreateAssessmentDropdown.tsx
+++ b/src/ui/core/components/CreateAssessmentDropdown.tsx
@@ -2,6 +2,7 @@ import {
   Dropdown,
   DropdownItem,
   DropdownList,
+  type DropdownProps,
   MenuToggle,
   type MenuToggleElement,
 } from "@patternfly/react-core";
@@ -13,17 +14,26 @@ import { routes } from "../../../routing/Routes";
 type Props = {
   toggleLabel?: string;
   onSelectRvtools: () => void;
-};
+} & Omit<
+  DropdownProps,
+  | "isOpen"
+  | "onOpenChange"
+  | "toggle"
+  | "shouldFocusToggleOnSelect"
+  | "children"
+>;
 
 const CreateAssessmentDropdown: React.FC<Props> = ({
   toggleLabel = "Create",
   onSelectRvtools,
+  ...props
 }) => {
   const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false);
 
   return (
     <Dropdown
+      {...props}
       isOpen={isOpen}
       onOpenChange={setIsOpen}
       toggle={(toggleRef: React.Ref<MenuToggleElement>) => (


### PR DESCRIPTION
Add "Manage Columns" feature to assessments table

- Introduced a "Manage Columns" button in the assessments table toolbar.
- Button opens a PatternFly Select dropdown listing all available columns with checkboxes.
- Users can toggle columns on/off dynamically, with the table updating immediately.
- Persisted user column selections in localStorage to restore preferences across sessions.
- Add a useLocalStorage hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Manage Columns" control to toggle visible columns; selections persist across sessions and mandatory columns remain shown
  * Table adapts to visible columns, adds horizontal scrolling, and auto-resets sorting if the sorted column is hidden

* **Accessibility & UI**
  * Refreshed toolbar layout, relocated "Create" action, improved table cell rendering and ARIA labeling

* **Tests**
  * Added comprehensive tests for local-storage persistence, versioning, updater and batched updater behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->