### PR TITLE
ECOPROJECT-4294 | fix: sending the correct parameters to cluster-requirements endpoint in case of SNO

### DIFF
--- a/src/ui/report/views/cluster-sizer/SizingInputForm.tsx
+++ b/src/ui/report/views/cluster-sizer/SizingInputForm.tsx
@@ -61,7 +61,13 @@ export const SizingInputForm: React.FC<SizingInputFormProps> = ({
     _event: React.FormEvent<HTMLSelectElement>,
     mode: string,
   ): void => {
-    onChange({ ...values, clusterMode: mode as ClusterMode });
+    const clusterMode = mode as ClusterMode;
+    onChange({
+      ...values,
+      clusterMode,
+      scheduleOnControlPlane:
+        clusterMode === "single-node" ? true : values.scheduleOnControlPlane,
+    });
   };
 
   const handleControlPlaneChange = (

--- a/src/ui/report/views/cluster-sizer/types.ts
+++ b/src/ui/report/views/cluster-sizer/types.ts
@@ -146,14 +146,17 @@ const CLUSTER_MODE_TO_NODE_COUNT: Record<
   "hosted-control-plane": undefined,
 };
 
+const SNO_DEFAULT_WORKER_CPU = 16;
+const SNO_DEFAULT_WORKER_MEMORY = 128;
+
 /**
  * Helper function to convert form values to API request payload.
  *
  * Mode-specific mapping:
  * - Full HA:  all fields sent (worker node, control plane, overcommit, SMT, scheduling)
- * - SNO:      only control plane fields; worker/overcommit/SMT are required by the SDK
- *             but their values are ignored by the backend when controlPlaneNodeCount=1
- * - HCP:      hostedControlPlane=true; control-plane fields omitted (incompatible per API)
+ * - SNO:      minimal payload — controlPlaneSchedulable=true, control plane CPU/memory
+ *             from form, workerNodeCPU/Memory use fixed defaults (required by SDK)
+ * - HCP:      control-plane fields omitted (hosted externally)
  */
 export const formValuesToRequest = (
   clusterId: string,
@@ -165,6 +168,19 @@ export const formValuesToRequest = (
   const isSNO = values.clusterMode === "single-node";
   const isFullHA = values.clusterMode === "full-ha";
 
+  if (isSNO) {
+    return {
+      clusterId,
+      workerNodeCPU: SNO_DEFAULT_WORKER_CPU,
+      workerNodeMemory: SNO_DEFAULT_WORKER_MEMORY,
+      controlPlaneSchedulable: true,
+      controlPlaneNodeCount:
+        ClusterRequirementsRequestControlPlaneNodeCountEnum.NUMBER_1,
+      controlPlaneCPU: values.controlPlaneCpu,
+      controlPlaneMemory: values.controlPlaneMemoryGb,
+    } as ClusterRequirementsRequest;
+  }
+
   return {
     clusterId,
     cpuOverCommitRatio: cpuOvercommitRatioToApiEnum(values.cpuOvercommitRatio),
@@ -175,13 +191,11 @@ export const formValuesToRequest = (
     workerNodeMemory: workerMemory,
     workerNodeThreads:
       isFullHA && values.smtEnabled ? values.smtThreads : undefined,
-    hostedControlPlane: isHCP || undefined,
     controlPlaneSchedulable: isFullHA
       ? values.scheduleOnControlPlane
       : undefined,
-    controlPlaneCPU: isSNO || isFullHA ? values.controlPlaneCpu : undefined,
-    controlPlaneMemory:
-      isSNO || isFullHA ? values.controlPlaneMemoryGb : undefined,
+    controlPlaneCPU: isFullHA ? values.controlPlaneCpu : undefined,
+    controlPlaneMemory: isFullHA ? values.controlPlaneMemoryGb : undefined,
     controlPlaneNodeCount: isHCP
       ? undefined
       : CLUSTER_MODE_TO_NODE_COUNT[values.clusterMode],


### PR DESCRIPTION
<img width="1113" height="1002" alt="image" src="https://github.com/user-attachments/assets/1b58c9f3-df2e-4157-9a91-163b02d18184" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Single-node cluster selection now automatically configures control plane scheduling.
* Enhanced form processing to apply correct settings and defaults for single-node cluster deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->