### PR TITLE
ECOPROJECT-3955 | fix: change 'Delete' button color to red in deletes modals

### DIFF
--- a/src/ui/assessment/views/Assessment.tsx
+++ b/src/ui/assessment/views/Assessment.tsx
@@ -492,10 +492,10 @@ const Assessment: React.FC<Props> = ({
         isDisabled={isDeletingAssessment}
         title="Delete Assessment"
         titleIconVariant="warning"
-        primaryButtonVariant="primary"
+        primaryButtonVariant="danger"
       >
         Are you sure you want to delete{" "}
-        {(selectedAssessment as AssessmentModel)?.name}?
+        <b>{(selectedAssessment as AssessmentModel)?.name}?</b>
       </ConfirmationModal>
     </>
   );

--- a/src/ui/core/components/ConfirmationModal.tsx
+++ b/src/ui/core/components/ConfirmationModal.tsx
@@ -42,7 +42,7 @@ export const ConfirmationModal: React.FC<
     onCancel,
     variant = "small",
     titleIconVariant = "info",
-    primaryButtonVariant = "primary",
+    primaryButtonVariant = "danger",
     title,
     children,
   } = props;


### PR DESCRIPTION
<img width="759" height="219" alt="Captura desde 2026-03-24 16-17-47" src="https://github.com/user-attachments/assets/6bef93c8-a7f2-4faf-a616-9ba4ac2a1266" />

<img width="729" height="242" alt="image" src="https://github.com/user-attachments/assets/d6215c4c-ed54-42db-a1b9-56e920ce0a6e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Delete/confirmation buttons now use danger styling to make destructive actions more noticeable.
  * Confirmation dialogs display the selected assessment name in bold (including the trailing question mark) for clearer emphasis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->