### PR TITLE
ECOPROJECT-4302 | fix: add min/max values to SMT/Hyperthreading field

### DIFF
--- a/src/ui/report/views/cluster-sizer/SizingInputForm.tsx
+++ b/src/ui/report/views/cluster-sizer/SizingInputForm.tsx
@@ -5,10 +5,13 @@ import {
   FlexItem,
   Form,
   FormGroup,
+  FormHelperText,
   FormSelect,
   FormSelectOption,
   Grid,
   GridItem,
+  HelperText,
+  HelperTextItem,
   TextInput,
 } from "@patternfly/react-core";
 import React from "react";
@@ -21,6 +24,8 @@ import {
   CPU_OVERCOMMIT_OPTIONS,
   MEMORY_OPTIONS,
   MEMORY_OVERCOMMIT_OPTIONS,
+  SMT_THREADS_MAX,
+  SMT_THREADS_MIN,
 } from "./constants";
 import PopoverIcon from "./PopoverIcon";
 import type {
@@ -48,7 +53,7 @@ const sectionHeaderStyle = css`
 `;
 
 const smtInputStyle = css`
-  width: 80px;
+  width: 130px;
 `;
 
 const sectionDividerStyle = css`
@@ -158,6 +163,12 @@ export const SizingInputForm: React.FC<SizingInputFormProps> = ({
     onChange({ ...values, controlPlaneMemoryGb: parseInt(memory, 10) });
   };
 
+  const smtThreadsValidated: "success" | "error" | "default" =
+    values.smtEnabled &&
+    (values.smtThreads < SMT_THREADS_MIN || values.smtThreads > SMT_THREADS_MAX)
+      ? "error"
+      : "default";
+
   return (
     <Form>
       <Grid hasGutter>
@@ -218,7 +229,20 @@ export const SizingInputForm: React.FC<SizingInputFormProps> = ({
                   isDisabled={!values.smtEnabled}
                   type="number"
                   className={smtInputStyle}
+                  min={SMT_THREADS_MIN as number}
+                  max={SMT_THREADS_MAX as number}
+                  validated={smtThreadsValidated}
                 />
+                {smtThreadsValidated === "error" && (
+                  <FormHelperText>
+                    <HelperText>
+                      <HelperTextItem variant="error">
+                        Value must be between {SMT_THREADS_MIN} and{" "}
+                        {SMT_THREADS_MAX}
+                      </HelperTextItem>
+                    </HelperText>
+                  </FormHelperText>
+                )}
               </FlexItem>
             </Flex>
           </GridItem>

--- a/src/ui/report/views/cluster-sizer/constants.ts
+++ b/src/ui/report/views/cluster-sizer/constants.ts
@@ -7,6 +7,9 @@ import type {
   WorkerNodePreset,
 } from "./types";
 
+export const SMT_THREADS_MIN = 2;
+export const SMT_THREADS_MAX = 1000;
+
 /**
  * Worker node size presets with CPU and memory configurations
  */


### PR DESCRIPTION
- Add min/max values to SMT/Hyperthreading field (2/1000)
- Show an error if the number is not inside the range

<img width="1006" height="578" alt="Captura desde 2026-03-25 07-30-16" src="https://github.com/user-attachments/assets/4044a381-36b5-4529-b0c4-3f1518d007fa" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Show inline validation error when SMT threads are out of the allowed range while SMT is enabled.

* **Improvements**
  * Enforce numeric min/max limits for SMT threads to prevent invalid entries.

* **Style**
  * Increased SMT threads input width for better visibility and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->