### PR TITLE
ECOPROJECT-4302 | fix: change max value in SMT/Hyperthreading field to 2000

### DIFF
--- a/src/ui/report/views/cluster-sizer/constants.ts
+++ b/src/ui/report/views/cluster-sizer/constants.ts
@@ -8,7 +8,7 @@ import type {
 } from "./types";
 
 export const SMT_THREADS_MIN = 2;
-export const SMT_THREADS_MAX = 1000;
+export const SMT_THREADS_MAX = 2000;
 
 /**
  * Worker node size presets with CPU and memory configurations


### PR DESCRIPTION
followup of #522 

Change max value to 2000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Increased the maximum allowed SMT thread count from 1000 to 2000, enabling higher system capacity configurations in cluster sizing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->