### PR TITLE
ECOPROJECT-4302 | fix: disable 'Generate recommendation' button when SMT threads have a validation error

### DIFF
--- a/src/ui/report/view-models/useClusterSizingWizardViewModel.ts
+++ b/src/ui/report/view-models/useClusterSizingWizardViewModel.ts
@@ -8,6 +8,8 @@ import { Symbols } from "../../../config/Dependencies";
 import type { IAssessmentsStore } from "../../../data/stores/interfaces/IAssessmentsStore";
 import {
   DEFAULT_FORM_VALUES,
+  SMT_THREADS_MAX,
+  SMT_THREADS_MIN,
   WORKER_NODE_PRESETS,
 } from "../views/cluster-sizer/constants";
 import type {
@@ -40,6 +42,7 @@ export interface ClusterSizingWizardViewModel {
   isCalculatingComplexity: boolean;
   complexityError: Error | undefined;
   calculateComplexity: () => Promise<void>;
+  isFormValid: boolean;
   ensureEstimationForMenu: (menuItem: string | null) => void;
   reset: () => void;
 }
@@ -80,7 +83,21 @@ export const useClusterSizingWizardViewModel = (
   const [resetCounter, setResetCounter] = useState<number>(0);
   const latestComplexityRequestIdRef = useRef<string>("");
 
+  const smtVisible =
+    formValues.clusterMode === "full-ha" ||
+    formValues.clusterMode === "hosted-control-plane";
+
+  const hasSmtError =
+    smtVisible &&
+    formValues.smtEnabled &&
+    (formValues.smtThreads < SMT_THREADS_MIN ||
+      formValues.smtThreads > SMT_THREADS_MAX);
+
   const [calculateState, doCalculate] = useAsyncFn(async () => {
+    if (hasSmtError) {
+      return;
+    }
+
     setManualCalculateError(undefined);
     // Get worker node CPU and memory based on preset or custom values
     const workerCpu =
@@ -241,9 +258,9 @@ export const useClusterSizingWizardViewModel = (
     formValues.clusterMode === "full-ha" ||
     formValues.clusterMode === "single-node";
   const showControlPlaneScheduling = formValues.clusterMode === "full-ha";
-  const showSmt =
-    formValues.clusterMode === "full-ha" ||
-    formValues.clusterMode === "hosted-control-plane";
+  const showSmt = smtVisible;
+
+  const isFormValid = !hasSmtError;
 
   return {
     formValues,
@@ -270,6 +287,7 @@ export const useClusterSizingWizardViewModel = (
       manualComplexityError ??
       (resetCounter > 0 ? undefined : complexityState.error),
     calculateComplexity: doCalculateComplexity,
+    isFormValid,
     ensureEstimationForMenu,
     reset,
   };

--- a/src/ui/report/views/cluster-sizer/ClusterSizingWizard.tsx
+++ b/src/ui/report/views/cluster-sizer/ClusterSizingWizard.tsx
@@ -165,6 +165,7 @@ export const ClusterSizingWizard: React.FC<ClusterSizingWizardProps> = ({
             }
             onGenerate={handleCalculate}
             isLoading={vm.isCalculating}
+            isGenerateDisabled={!vm.isFormValid}
             hasResults={Boolean(
               vm.sizerOutput || vm.isCalculating || vm.calculateError,
             )}

--- a/src/ui/report/views/cluster-sizer/RecommendationTemplate.tsx
+++ b/src/ui/report/views/cluster-sizer/RecommendationTemplate.tsx
@@ -63,6 +63,8 @@ interface RecommendationTemplateProps {
   isPreferencesInitiallyExpanded?: boolean;
   /** Whether the preferences section is disabled (defaults to false) */
   isPreferencesDisabled?: boolean;
+  /** Whether the generate button is disabled due to validation errors */
+  isGenerateDisabled?: boolean;
   /** Whether to hide the preferences section entirely (defaults to false) */
   hidePreferences?: boolean;
   /** Optional action element rendered inline with the results title */
@@ -83,6 +85,7 @@ export const RecommendationTemplate: React.FC<RecommendationTemplateProps> = ({
   showAlert = true,
   isPreferencesInitiallyExpanded = true,
   isPreferencesDisabled = false,
+  isGenerateDisabled = false,
   hidePreferences = false,
   headerAction,
   hasError = false,
@@ -141,7 +144,9 @@ export const RecommendationTemplate: React.FC<RecommendationTemplateProps> = ({
                     variant="primary"
                     onClick={handleGenerate}
                     isLoading={isLoading}
-                    isDisabled={isLoading || isPreferencesDisabled}
+                    isDisabled={
+                      isLoading || isPreferencesDisabled || isGenerateDisabled
+                    }
                   >
                     {generateButtonText}
                   </Button>

--- a/src/ui/report/views/cluster-sizer/__tests__/ClusterSizingWizard.test.tsx
+++ b/src/ui/report/views/cluster-sizer/__tests__/ClusterSizingWizard.test.tsx
@@ -48,6 +48,7 @@ const mockViewModel = {
   isCalculatingComplexity: false,
   complexityError: null,
   calculateComplexity: mockCalculateComplexity,
+  isFormValid: true,
   ensureEstimationForMenu: mockEnsureEstimationForMenu,
   reset: mockReset,
 };


### PR DESCRIPTION
<img width="1098" height="820" alt="Captura desde 2026-03-25 13-19-09" src="https://github.com/user-attachments/assets/2add2dec-cece-4801-a16c-e32ecfd7f41a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Form validity is now exposed to the cluster sizing UI so the app knows when the sizing form is valid.

* **Bug Fixes**
  * The Generate action in the cluster sizing wizard is disabled when SMT thread settings are out of the allowed range, preventing invalid recommendation runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->