### PR TITLE
ECOPROJECT-4101 | ci: Use WORKFLOW_TOKEN to enable cross-workflow tri…

### DIFF
--- a/.github/workflows/sync-release-branch.yml
+++ b/.github/workflows/sync-release-branch.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           # Fetch all history to ensure we have the master branch's commits
           fetch-depth: 0
+          # Use PAT to allow triggering other workflows
+          token: ${{ secrets.WORKFLOW_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Configure Git
         run: |
@@ -81,4 +83,4 @@ jobs:
             fi
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update sync-release-branch workflow to use WORKFLOW_TOKEN (with GITHUB_TOKEN 
fallback) so that pushes to release branches trigger the rebase-dev-on-release workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication handling in CI/CD workflows to use custom credentials when available, with automatic fallback to default credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->