### PR TITLE
ECOPROJECT-4303 | fix: use the parseApiError utility to parse the error from sources endpoint

### DIFF
--- a/src/ui/environment/view-models/useEnvironmentPageViewModel.ts
+++ b/src/ui/environment/view-models/useEnvironmentPageViewModel.ts
@@ -10,6 +10,7 @@ import type {
   SourceCreateInput,
   SourceUpdateInput,
 } from "../../../data/stores/SourcesStore";
+import { parseApiError } from "../../../lib/common/ErrorParser";
 import { DEFAULT_POLLING_DELAY } from "../../../lib/mvvm/PollableStore";
 import type { AssessmentModel } from "../../../models/AssessmentModel";
 import type { SourceModel } from "../../../models/SourceModel";
@@ -194,11 +195,15 @@ export const useEnvironmentPageViewModel = (): EnvironmentPageViewModel => {
   const [createDownloadState, doCreateDownloadSource] = useAsyncFn(
     async (input: SourceCreateInput): Promise<void> => {
       setDismissDownloadError(false);
-      const newSource = await sourcesStore.create(input);
-      await imagesStore.headImage(newSource.id);
-      const url = await imagesStore.getDownloadUrl(newSource.id);
-      setDownloadSourceUrlRaw(url);
-      setSourceCreatedId(newSource.id);
+      try {
+        const newSource = await sourcesStore.create(input);
+        await imagesStore.headImage(newSource.id);
+        const url = await imagesStore.getDownloadUrl(newSource.id);
+        setDownloadSourceUrlRaw(url);
+        setSourceCreatedId(newSource.id);
+      } catch (err) {
+        throw await parseApiError(err, "Failed to create environment");
+      }
     },
     [sourcesStore, imagesStore],
   );
@@ -207,10 +212,14 @@ export const useEnvironmentPageViewModel = (): EnvironmentPageViewModel => {
   const [updateSourceState, doUpdateSource] = useAsyncFn(
     async (input: SourceUpdateInput): Promise<void> => {
       setDismissUpdateError(false);
-      const updated = await sourcesStore.update(input);
-      await imagesStore.headImage(updated.id);
-      const url = await imagesStore.getDownloadUrl(updated.id);
-      setDownloadSourceUrlRaw(url);
+      try {
+        const updated = await sourcesStore.update(input);
+        await imagesStore.headImage(updated.id);
+        const url = await imagesStore.getDownloadUrl(updated.id);
+        setDownloadSourceUrlRaw(url);
+      } catch (err) {
+        throw await parseApiError(err, "Failed to update environment");
+      }
     },
     [sourcesStore, imagesStore],
   );


### PR DESCRIPTION
Now when a user tries to create an environment with a duplicate name, the alert will display:
> Add Environment error
> failed to create source: source with name "env-9october" already exists

Instead of the generic "Response returned an error code".

Before changes:
<img width="535" height="603" alt="Captura desde 2026-03-26 09-53-36" src="https://github.com/user-attachments/assets/d9fe948a-868e-4e0e-9ba8-447c58a8d369" />


After changes:
<img width="535" height="603" alt="Captura desde 2026-03-26 09-56-28" src="https://github.com/user-attachments/assets/c1ddf20f-1b9d-456d-a0e5-7b12ce2e9896" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and messaging when creating or updating environments. Users now receive clearer, action-specific error messages instead of generic exceptions, making it easier to understand and resolve issues when operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->