### PR TITLE
ECOPROJECT-4330 | fix: "Enable proxy" checkbox remained unchecked when true

### DIFF
--- a/src/ui/environment/helpers/__tests__/proxyConfig.test.ts
+++ b/src/ui/environment/helpers/__tests__/proxyConfig.test.ts
@@ -1,0 +1,93 @@
+import type { Source } from "@openshift-migration-advisor/planner-sdk";
+import { describe, expect, it } from "vitest";
+
+import { getProxyConfig } from "../proxyConfig";
+
+describe("proxyConfig helpers", () => {
+  describe("getProxyConfig", () => {
+    it("should extract all proxy fields correctly", () => {
+      const source: Partial<Source> = {
+        infra: {
+          proxy: {
+            httpUrl: "http://proxy.example.com:8080",
+            httpsUrl: "https://proxy.example.com:8443",
+            noProxy: "test.example.org",
+          },
+        },
+      };
+
+      const config = getProxyConfig(source as Source);
+
+      expect(config).toEqual({
+        httpUrl: "http://proxy.example.com:8080",
+        httpsUrl: "https://proxy.example.com:8443",
+        noProxy: "test.example.org",
+        isProxyEnabled: true,
+      });
+    });
+
+    it("should return empty strings when proxy is null", () => {
+      const source: Partial<Source> = {
+        infra: {
+          proxy: {
+            httpUrl: null,
+            httpsUrl: null,
+            noProxy: null,
+          },
+        },
+      };
+
+      const config = getProxyConfig(source as Source);
+
+      expect(config).toEqual({
+        httpUrl: "",
+        httpsUrl: "",
+        noProxy: "",
+        isProxyEnabled: false,
+      });
+    });
+
+    it("should return empty strings when infra is undefined", () => {
+      const source: Partial<Source> = {
+        infra: undefined,
+      };
+
+      const config = getProxyConfig(source as Source);
+
+      expect(config).toEqual({
+        httpUrl: "",
+        httpsUrl: "",
+        noProxy: "",
+        isProxyEnabled: false,
+      });
+    });
+
+    it("should detect isProxyEnabled when only noProxy is set", () => {
+      const source: Partial<Source> = {
+        infra: {
+          proxy: {
+            httpUrl: null,
+            httpsUrl: null,
+            noProxy: "test.example.org",
+          },
+        },
+      };
+
+      const config = getProxyConfig(source as Source);
+
+      expect(config.isProxyEnabled).toBe(true);
+      expect(config.noProxy).toBe("test.example.org");
+    });
+
+    it("should handle undefined source gracefully", () => {
+      const config = getProxyConfig(undefined);
+
+      expect(config).toEqual({
+        httpUrl: "",
+        httpsUrl: "",
+        noProxy: "",
+        isProxyEnabled: false,
+      });
+    });
+  });
+});

--- a/src/ui/environment/helpers/proxyConfig.ts
+++ b/src/ui/environment/helpers/proxyConfig.ts
@@ -1,0 +1,32 @@
+import type { Source } from "@openshift-migration-advisor/planner-sdk";
+
+/**
+ * Type-safe helper to extract proxy configuration from a Source.
+ * This ensures we always access the proxy via the correct path (src.infra.proxy)
+ * and provides compile-time safety if the SDK structure changes.
+ */
+export interface ProxyConfig {
+  httpUrl: string;
+  httpsUrl: string;
+  noProxy: string;
+  isProxyEnabled: boolean;
+}
+
+/**
+ * Extracts proxy configuration from a Source object.
+ * Returns normalized values (empty strings instead of null/undefined).
+ */
+export const getProxyConfig = (source: Source | undefined): ProxyConfig => {
+  const proxy = source?.infra?.proxy;
+
+  const httpUrl = proxy?.httpUrl ?? "";
+  const httpsUrl = proxy?.httpsUrl ?? "";
+  const noProxy = proxy?.noProxy ?? "";
+
+  return {
+    httpUrl,
+    httpsUrl,
+    noProxy,
+    isProxyEnabled: Boolean(httpUrl || httpsUrl || noProxy),
+  };
+};

--- a/src/ui/environment/views/DiscoverySourceSetupModal.tsx
+++ b/src/ui/environment/views/DiscoverySourceSetupModal.tsx
@@ -25,6 +25,7 @@ import {
 import React, { useCallback, useEffect, useState } from "react";
 
 import { VCenterSetupInstructions } from "../../core/components/VCenterSetupInstructions";
+import { getProxyConfig } from "../helpers/proxyConfig";
 import { normalizeSshKey, validateSshKey } from "../helpers/sshKey";
 import { useEnvironmentPage } from "../view-models/EnvironmentPageContext";
 
@@ -391,30 +392,18 @@ export const DiscoverySourceSetupModal: React.FC<
         const src = vm.getSourceById?.(editSourceId);
         if (src) {
           setEnvironmentName(src.name || "");
-          const proxy =
-            (
-              src as {
-                proxy?: {
-                  httpUrl?: string;
-                  httpsUrl?: string;
-                  noProxy?: string;
-                };
-              }
-            ).proxy || {};
-          const httpUrl = proxy.httpUrl || "";
-          const httpsUrl = proxy.httpsUrl || "";
-          const noProxyVal = proxy.noProxy || "";
-          setHttpProxy(httpUrl);
-          setHttpsProxy(httpsUrl);
-          setNoProxy(noProxyVal);
-          setEnableProxy(Boolean(httpUrl || httpsUrl || noProxyVal));
+          const proxyConfig = getProxyConfig(src);
+          setHttpProxy(proxyConfig.httpUrl);
+          setHttpsProxy(proxyConfig.httpsUrl);
+          setNoProxy(proxyConfig.noProxy);
+          setEnableProxy(proxyConfig.isProxyEnabled);
           setInitialValues({
             sshKey: "",
             environmentName: src.name || "",
-            httpProxy: httpUrl,
-            httpsProxy: httpsUrl,
-            noProxy: noProxyVal,
-            enableProxy: Boolean(httpUrl || httpsUrl || noProxyVal),
+            httpProxy: proxyConfig.httpUrl,
+            httpsProxy: proxyConfig.httpsUrl,
+            noProxy: proxyConfig.noProxy,
+            enableProxy: proxyConfig.isProxyEnabled,
             networkConfigType: "dhcp",
             dns: "",
             subnetMask: "",


### PR DESCRIPTION
Fix bug where "Enable proxy" checkbox remained unchecked when editing an environment with existing proxy configuration (httpUrl, httpsUrl, noProxy).

Root cause:
- Code was accessing `src.proxy` instead of the correct SDK path `src.infra.proxy`
- This bug was introduced because an explicit TypeScript cast bypassed type checking

Changes:
- DiscoverySourceSetupModal.tsx: Use correct path `src.infra.proxy`
- Create type-safe helper `getProxyConfig()` to centralize proxy access
- Add comprehensive tests for proxy configuration loading
- Prevents similar bugs if SDK structure changes in the future

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite validating proxy configuration extraction, URL normalization, and enabled state detection across various scenarios.

* **Refactor**
  * Introduced centralized proxy configuration helper and updated the Discovery Source Setup Modal to use it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->