### PR TITLE
ECOPROJECT-4330 | fix: Keep DiscoverySourceSetupModal open after edition

### DIFF
--- a/src/ui/assessment/view-models/useAssessmentsScreenViewModel.ts
+++ b/src/ui/assessment/view-models/useAssessmentsScreenViewModel.ts
@@ -29,13 +29,17 @@ export const useAssessmentsScreenViewModel = (): AssessmentsScreenViewModel => {
 
   const hasInitialLoadRef = useRef(false);
 
-  const [fetchState, fetchAssessments] = useAsyncFn(async () => {
-    try {
-      return await assessmentsStore.list();
-    } finally {
-      hasInitialLoadRef.current = true;
-    }
-  }, [assessmentsStore]);
+  const [fetchState, fetchAssessments] = useAsyncFn(
+    async () => {
+      try {
+        return await assessmentsStore.list();
+      } finally {
+        hasInitialLoadRef.current = true;
+      }
+    },
+    [assessmentsStore],
+    { loading: true },
+  );
 
   useMount(() => {
     void fetchAssessments();

--- a/src/ui/environment/view-models/useEnvironmentPageViewModel.ts
+++ b/src/ui/environment/view-models/useEnvironmentPageViewModel.ts
@@ -183,13 +183,17 @@ export const useEnvironmentPageViewModel = (): EnvironmentPageViewModel => {
   // ---- Source listing ------------------------------------------------------
   const hasInitialLoadRef = useRef(false);
 
-  const [listSourcesState, doListSources] = useAsyncFn(async () => {
-    try {
-      return await sourcesStore.list();
-    } finally {
-      hasInitialLoadRef.current = true;
-    }
-  }, [sourcesStore]);
+  const [listSourcesState, doListSources] = useAsyncFn(
+    async () => {
+      try {
+        return await sourcesStore.list();
+      } finally {
+        hasInitialLoadRef.current = true;
+      }
+    },
+    [sourcesStore],
+    { loading: true },
+  );
 
   // ---- Source deletion -----------------------------------------------------
   const [deleteSourceState, doDeleteSource] = useAsyncFn(

--- a/src/ui/environment/views/Environment.tsx
+++ b/src/ui/environment/views/Environment.tsx
@@ -177,8 +177,8 @@ const EnvironmentContent: React.FC<EnvironmentContentProps> = ({ vm }) => {
 export const EnvironmentPage: React.FC = () => {
   const vm = useEnvironmentPage();
 
-  // Show spinner if loading or if no initial load
-  if (vm.isLoadingSources || !vm.hasInitialLoad) {
+  // Show spinner only during initial load
+  if (vm.isLoadingSources && !vm.hasInitialLoad) {
     return <LoadingSpinner />;
   }
 


### PR DESCRIPTION
After editing a source, we reload sources. This unmount the modal because of the loading state.
This patch only shows the spinner at startup.

Adding loading: true on the fetches to avoid display the empty state at startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading state management to display UI content more efficiently while fetching data, reducing unnecessary loading overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->