### PR TITLE
ECOPROJECT-4342 | fix: prevent Renovate from upgrading to compromised axios version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12062,15 +12062,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,15 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Renovate configuration for migration-planner-ui-app - runs dependency updates weekly on Saturday mornings",
   "extends": ["config:recommended"],
-  "schedule": ["before 6am on Saturday"]
+  "schedule": ["before 6am on Saturday"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["axios"],
+      "ignoreVersions": ["0.30.4", "1.14.1"]
+    },
+    {
+      "matchPackageNames": ["plain-crypto-js"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
Konflux bot is proposing an unsafe dependency update to axios@1.14.1, which introduces plain-crypto-js as a dependency. Both are part of a recent supply chain attack.

This patch updates the Renovate configuration to:
- ignore axios@1.14.1 and 0.30.4 specifically
- disable plain-crypto-js updates

This prevents the bot from repeatedly proposing compromised versions while allowing future safe releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to add package-specific rules.
  * Ignored updates for two specific versions of a networking library to prevent automatic upgrades to those releases.
  * Disabled automated update checks for a cryptography-related library.
  * Weekly scheduling behavior for dependency checks remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->