### PR TITLE
ECOPROJECT-4318 | fix: keep RVTools modal inputs disabled until report opens

### DIFF
--- a/src/ui/assessment/view-models/__tests__/useAssessmentPageViewModel.test.ts
+++ b/src/ui/assessment/view-models/__tests__/useAssessmentPageViewModel.test.ts
@@ -249,6 +249,29 @@ describe("useAssessmentPageViewModel", () => {
 
   // -- Job completion detection ---------------------------------------------
 
+  it("sets isNavigatingToReport immediately when job transitions to Completed", () => {
+    const { result } = renderHook(() => useAssessmentPageViewModel());
+
+    act(() => {
+      setJobsState({
+        currentJob: makeJob({ status: JobStatus.Parsing }),
+      });
+    });
+
+    expect(result.current.isNavigatingToReport).toBe(false);
+
+    act(() => {
+      setJobsState({
+        currentJob: makeJob({
+          status: JobStatus.Completed,
+          assessmentId: "a-42",
+        }),
+      });
+    });
+
+    expect(result.current.isNavigatingToReport).toBe(true);
+  });
+
   it("stops polling, resets, and navigates to report on job completion", async () => {
     renderHook(() => useAssessmentPageViewModel());
 

--- a/src/ui/assessment/view-models/useAssessmentPageViewModel.ts
+++ b/src/ui/assessment/view-models/useAssessmentPageViewModel.ts
@@ -224,9 +224,10 @@ export const useAssessmentPageViewModel = (): AssessmentPageViewModel => {
         navigate(routes.assessmentReport(assessmentId));
       } finally {
         isNavigatingRef.current = false;
+        jobsStore.reset();
       }
     },
-    [assessmentsStore, navigate],
+    [assessmentsStore, navigate, jobsStore],
   );
 
   useEffect(() => {
@@ -243,7 +244,6 @@ export const useAssessmentPageViewModel = (): AssessmentPageViewModel => {
       const assessmentId = currentJob.assessmentId;
       isNavigatingRef.current = true;
       jobsStore.stopPolling();
-      jobsStore.reset();
 
       void navigateToReport(assessmentId);
     }
@@ -312,6 +312,16 @@ export const useAssessmentPageViewModel = (): AssessmentPageViewModel => {
 
   // ---- Return -------------------------------------------------------------
 
+  // Cover the one-render gap between the poll that marks the job Completed
+  // (isJobProcessing becomes false) and the effect that starts navigation
+  // (navigationState.loading becomes true).  Without this, form inputs
+  // briefly re-enable.
+  const isNavigatingToReport =
+    navigationState.loading ||
+    Boolean(
+      currentJob?.status === JobStatus.Completed && currentJob?.assessmentId,
+    );
+
   return {
     currentJob,
     isCreatingJob: jobState.isCreating,
@@ -320,7 +330,7 @@ export const useAssessmentPageViewModel = (): AssessmentPageViewModel => {
     jobProgressValue,
     jobProgressLabel,
     jobError,
-    isNavigatingToReport: navigationState.loading,
+    isNavigatingToReport,
     isDeletingAssessment: deleteState.loading,
     deleteError: deleteState.error,
     isUpdatingAssessment: updateState.loading,

--- a/src/ui/assessment/views/CreateAssessmentModal.tsx
+++ b/src/ui/assessment/views/CreateAssessmentModal.tsx
@@ -93,7 +93,8 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
 
   // Helper to check if file operations should be disabled (RVTools mode during job creation/processing)
   const isFileOperationsDisabled =
-    mode === "rvtools" && (isLoading || isJobProcessing);
+    mode === "rvtools" &&
+    (isLoading || isJobProcessing || isNavigatingToReport);
 
   // Combine with existing error logic - job error takes priority
   const effectiveError = jobError || error;

--- a/src/ui/report/view-models/useReportPageViewModel.ts
+++ b/src/ui/report/view-models/useReportPageViewModel.ts
@@ -498,9 +498,10 @@ export const useReportPageViewModel = (): ReportPageViewModel => {
         navigate(routes.assessmentReport(assessmentId));
       } finally {
         isNavigatingRef.current = false;
+        jobsStore.reset();
       }
     },
-    [assessmentsStore, navigate],
+    [assessmentsStore, navigate, jobsStore],
   );
 
   useEffect(() => {
@@ -517,7 +518,6 @@ export const useReportPageViewModel = (): ReportPageViewModel => {
       const assessmentId = currentJob.assessmentId;
       isNavigatingRef.current = true;
       jobsStore.stopPolling();
-      jobsStore.reset();
       setIsRvtoolsModalOpen(false);
 
       void navigateToReport(assessmentId);
@@ -594,6 +594,13 @@ export const useReportPageViewModel = (): ReportPageViewModel => {
     jobProgressValue,
     jobProgressLabel,
     jobError,
-    isNavigatingToReport: rvtoolsNavigationState.loading,
+    // Cover the one-render gap between the poll that marks the job Completed
+    // (isJobProcessing becomes false) and the effect that starts navigation
+    // (rvtoolsNavigationState.loading becomes true).
+    isNavigatingToReport:
+      rvtoolsNavigationState.loading ||
+      Boolean(
+        currentJob?.status === JobStatus.Completed && currentJob?.assessmentId,
+      ),
   };
 };


### PR DESCRIPTION
Inputs and buttons in the 'Create assessment from RVTools' modal briefly re-enabled between job completion and report navigation.

Fix:
- Derive isNavigatingToReport from Completed job status in addition to navigationState.loading (both assessment and report VMs).
- Move jobsStore.reset() from the effect into the navigateToReport callback so currentJob stays non-null throughout navigation.
- Add isNavigatingToReport to isFileOperationsDisabled in the modal.


https://github.com/user-attachments/assets/df6194b4-a746-4f9a-bc80-7f55af8ace7a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a UI state gap during report navigation by keeping the "opening report" indicator active at the moment a job completes and by deferring state reset until after navigation finishes.

* **Improvements**
  * File upload and related inputs are now disabled while a report is opening to prevent conflicting actions.

* **Tests**
  * Added a unit test ensuring the "navigating to report" flag updates immediately when a job transitions to completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->