### PR TITLE
ECOPROJECT-4327 | fix: solving issues with stale data in rvTools form

### DIFF
--- a/src/ui/assessment/views/CreateAssessmentModal.tsx
+++ b/src/ui/assessment/views/CreateAssessmentModal.tsx
@@ -91,10 +91,24 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
   const [nameErrorDismissed, setNameErrorDismissed] = useState(false);
   const [generalErrorDismissed, setGeneralErrorDismissed] = useState(false);
 
-  // Helper to check if file operations should be disabled (RVTools mode during job creation/processing)
-  const isFileOperationsDisabled =
-    mode === "rvtools" &&
-    (isLoading || isJobProcessing || isNavigatingToReport);
+  // Reset all form state when the modal is closed — covers both explicit
+  // (Cancel / X) and programmatic closes (e.g. navigation after job completion).
+  React.useEffect(() => {
+    if (!isOpen) {
+      setAssessmentName("");
+      setSelectedFile(null);
+      setFilename("");
+      setNameValidationError("");
+      setFileValidationError("");
+      setSelectedEnvironmentId("");
+      setNameErrorDismissed(false);
+      setGeneralErrorDismissed(false);
+      setRvtoolsConsentChecked(false);
+    }
+  }, [isOpen]);
+
+  // Disable all form inputs while the job is being created/processed or the report is loading.
+  const isFormDisabled = isLoading || isJobProcessing || isNavigatingToReport;
 
   // Combine with existing error logic - job error takes priority
   const effectiveError = jobError || error;
@@ -172,8 +186,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
   const config = getFileConfig();
 
   const handleFileChange = (_event: DropEvent, file: File): void => {
-    // Prevent file changes during RVTools job creation/processing
-    if (isFileOperationsDisabled) {
+    if (isFormDisabled) {
       return;
     }
 
@@ -208,8 +221,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
   };
 
   const handleFileClear = (): void => {
-    // Prevent file clearing during RVTools job creation/processing
-    if (isFileOperationsDisabled) {
+    if (isFormDisabled) {
       return;
     }
 
@@ -331,7 +343,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
               }}
               validated={nameErrorToDisplay ? "error" : "default"}
               placeholder="Enter assessment name"
-              isDisabled={isFileOperationsDisabled}
+              isDisabled={isFormDisabled}
             />
             {nameErrorToDisplay && (
               <HelperText>
@@ -366,6 +378,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
                   }
                 }}
                 validated={fileValidationError ? "error" : "default"}
+                isDisabled={isFormDisabled}
               >
                 <FormSelectOption value="" label="Select an environment" />
                 {availableEnvironments.map((env) => (
@@ -428,7 +441,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
                 validated={fileValidationError ? "error" : "default"}
                 accept={config.accept}
                 hideDefaultPreview
-                isDisabled={isFileOperationsDisabled}
+                isDisabled={isFormDisabled}
               />
               {fileValidationError && (
                 <FormHelperText>
@@ -452,7 +465,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
                       setRvtoolsConsentChecked(Boolean(checked));
                     }}
                     isRequired
-                    isDisabled={isFileOperationsDisabled}
+                    isDisabled={isFormDisabled}
                   />
                 </div>
               )}

--- a/src/ui/report/view-models/useReportPageViewModel.ts
+++ b/src/ui/report/view-models/useReportPageViewModel.ts
@@ -495,6 +495,7 @@ export const useReportPageViewModel = (): ReportPageViewModel => {
     async (assessmentId: string) => {
       try {
         await assessmentsStore.list();
+        setIsRvtoolsModalOpen(false);
         navigate(routes.assessmentReport(assessmentId));
       } finally {
         isNavigatingRef.current = false;
@@ -518,7 +519,7 @@ export const useReportPageViewModel = (): ReportPageViewModel => {
       const assessmentId = currentJob.assessmentId;
       isNavigatingRef.current = true;
       jobsStore.stopPolling();
-      setIsRvtoolsModalOpen(false);
+      jobsStore.reset();
 
       void navigateToReport(assessmentId);
     }


### PR DESCRIPTION
- Fix 1: stale form data - Added a useEffect that resets all form state whenever isOpen becames false
- Fix 2: modal closes too early - moved setIsRvtoolsModalOpen(false from the job-completion useEffect into navigateToReport right before the navigate() call


https://github.com/user-attachments/assets/e6683995-4f41-4131-bde4-0448203eecff



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Modal form state now fully clears when the create-assessment dialog closes (name, file selection, validation, environment, error flags, and consent).
  * All form inputs are uniformly disabled while reports are being generated or jobs are processing to prevent unintended interactions.
  * The RVTools modal reliably closes as part of the flow when navigating to a newly generated report.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->