### PR TITLE
NO-JIRA | fix: use stub data on production

### DIFF
--- a/src/data/stores/IdentityStore.ts
+++ b/src/data/stores/IdentityStore.ts
@@ -9,10 +9,8 @@ export class IdentityStore
 {
   private identity: Identity | null = null;
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   async getIdentity(): Promise<Identity> {
-    if (process.env.NODE_ENV === "production") {
-      return Promise.reject(new Error("GET /api/identity not implemented"));
-    }
     this.identity = getFakeIdentity();
     console.log("[IdentityStore] GET /api/identity:", this.identity);
     this.notify();

--- a/src/data/stores/OrganizationsStore.ts
+++ b/src/data/stores/OrganizationsStore.ts
@@ -12,9 +12,6 @@ export class OrganizationsStore
 
   // eslint-disable-next-line @typescript-eslint/require-await
   async list(): Promise<Organization[]> {
-    if (process.env.NODE_ENV === "production") {
-      return [];
-    }
     this.organizations = getFakeOrganizations();
     console.log(
       "[OrganizationsStore] GET /api/organizations",
@@ -26,9 +23,6 @@ export class OrganizationsStore
 
   // eslint-disable-next-line @typescript-eslint/require-await
   async get(organizationId: string): Promise<Organization | undefined> {
-    if (process.env.NODE_ENV === "production") {
-      return undefined;
-    }
     const organization = getFakeOrganizations().find(
       (organization) => organization.id === organizationId,
     );
@@ -41,9 +35,6 @@ export class OrganizationsStore
 
   // eslint-disable-next-line @typescript-eslint/require-await
   async getUsers(organizationId: string): Promise<User[]> {
-    if (process.env.NODE_ENV === "production") {
-      return [];
-    }
     console.log(
       `[OrganizationsStore] GET /api/organizations/${organizationId}/users`,
       [],

--- a/src/data/stores/PartnerRequestsStore.ts
+++ b/src/data/stores/PartnerRequestsStore.ts
@@ -18,10 +18,6 @@ export class PartnerRequestsStore
 
   // eslint-disable-next-line @typescript-eslint/require-await
   async list(): Promise<PartnerRequest[]> {
-    if (process.env.NODE_ENV === "production") {
-      return [];
-    }
-
     this.partnerRequests = getFakePartnerRequests();
     console.log(
       "[PartnerRequestsStore] GET /api/partners/requests",
@@ -31,12 +27,8 @@ export class PartnerRequestsStore
     return this.partnerRequests;
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   async create(data: PartnerRequestCreate): Promise<PartnerRequest> {
-    if (process.env.NODE_ENV === "production") {
-      return Promise.reject(
-        new Error("POST /api/partners/requests not implemented"),
-      );
-    }
     console.log("[PartnerRequestsStore] POST /api/partners/requests", data);
     const organization = getFakeOrganizations().find(
       (organization) => organization.id === data.request.partnerId,
@@ -50,15 +42,8 @@ export class PartnerRequestsStore
     return newRequest;
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   async delete(request: PartnerRequest): Promise<void> {
-    if (process.env.NODE_ENV === "production") {
-      return Promise.reject(
-        new Error(
-          `DELETE /api/partners/requests/${request.id} not implemented`,
-        ),
-      );
-    }
-
     this.partnerRequests = this.partnerRequests.filter(
       (r) => r.id !== request.id,
     );

--- a/src/data/stores/PartnersStore.ts
+++ b/src/data/stores/PartnersStore.ts
@@ -11,10 +11,6 @@ export class PartnersStore
 
   // eslint-disable-next-line @typescript-eslint/require-await
   async list(): Promise<Partner[]> {
-    if (process.env.NODE_ENV === "production") {
-      return [];
-    }
-
     this.partners = getFakePartners();
     console.log("[PartnersStore] GET /api/partners", this.partners);
     this.notify();


### PR DESCRIPTION
Until API is ready, we can use stub data to fake API calls. Data are displayed behind a feature flag and not displayed to the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed environment-specific control flow conditions from data stores: Identity, Organization, Partner, and Partner Request. Previously, these stores contained conditional logic that altered method behavior based on production environment status. Methods now execute uniformly without environment checks, consistently processing stub data operations across all deployment contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->