### PR TITLE
ECOPROJECT-4148 | fix: surface backend validation errors and prevent stale error display in assessment creation

### DIFF
--- a/src/data/stores/AssessmentsStore.ts
+++ b/src/data/stores/AssessmentsStore.ts
@@ -8,6 +8,7 @@ import {
 import { type Assessment } from "@openshift-migration-advisor/planner-sdk";
 import { type InitOverrideFunction } from "@openshift-migration-advisor/planner-sdk";
 
+import { parseApiError } from "../../lib/common/ErrorParser";
 import { PollableStoreBase } from "../../lib/mvvm/PollableStore";
 import {
   type AssessmentModel,
@@ -97,10 +98,15 @@ export class AssessmentsStore
     assessmentForm: AssessmentCreateForm,
     initOverrides?: RequestInit | InitOverrideFunction,
   ): Promise<AssessmentModel> {
-    const created = await this.api.createAssessment(
-      { assessmentForm },
-      initOverrides,
-    );
+    let created;
+    try {
+      created = await this.api.createAssessment(
+        { assessmentForm },
+        initOverrides,
+      );
+    } catch (err) {
+      throw await parseApiError(err, "Failed to create assessment");
+    }
     const model = createAssessmentModel(created);
     this.assessments = [...this.assessments, model];
     this.notify();
@@ -112,10 +118,15 @@ export class AssessmentsStore
     assessmentUpdate: AssessmentUpdateForm,
     initOverrides?: RequestInit | InitOverrideFunction,
   ): Promise<AssessmentModel> {
-    const updated = await this.api.updateAssessment(
-      { id, assessmentUpdate },
-      initOverrides,
-    );
+    let updated;
+    try {
+      updated = await this.api.updateAssessment(
+        { id, assessmentUpdate },
+        initOverrides,
+      );
+    } catch (err) {
+      throw await parseApiError(err, "Failed to update assessment");
+    }
     const model = createAssessmentModel(updated);
     this.assessments = this.assessments.map((assessment) =>
       assessment.id === model.id ? model : assessment,

--- a/src/data/stores/JobsStore.ts
+++ b/src/data/stores/JobsStore.ts
@@ -56,15 +56,19 @@ export class JobsStore
     }
     this.abortController = new AbortController();
 
+    // Capture in a local variable so this invocation always checks its OWN
+    // controller, even if a subsequent call reassigns `this.abortController`.
+    const controller = this.abortController;
+
     this.setState({ isCreating: true, createError: undefined });
 
     try {
       const job = await this.api.createRVToolsAssessment(
         { name, file },
-        { signal: this.abortController.signal },
+        { signal: controller.signal },
       );
 
-      if (this.abortController.signal.aborted) {
+      if (controller.signal.aborted) {
         if (job?.id && !TERMINAL_JOB_STATUSES.includes(job.status)) {
           this.api.cancelJob({ id: job.id }).catch(() => undefined);
         }
@@ -74,7 +78,7 @@ export class JobsStore
       this.setState({ currentJob: job, isCreating: false });
       return job;
     } catch (err) {
-      if (this.abortController.signal.aborted) {
+      if (controller.signal.aborted) {
         return undefined;
       }
 
@@ -82,6 +86,12 @@ export class JobsStore
         err,
         "Failed to create RVTools job",
       );
+
+      // A newer call may have started while parseApiError was resolving.
+      // If so, this invocation is stale — don't overwrite the newer state.
+      if (this.abortController !== controller) {
+        return undefined;
+      }
 
       this.setState({ createError: errorToStore, isCreating: false });
       return undefined;
@@ -128,6 +138,31 @@ export class JobsStore
     this.reset();
     this.cancelInProgress = false;
     return latestJob;
+  }
+
+  /**
+   * Clear error state so the user can retry with a fresh form.
+   * Clears `createError` and, if the current job reached a terminal state
+   * (Failed / Cancelled / Completed), also clears `currentJob`.
+   * Active (non-terminal) jobs are left untouched.
+   */
+  clearCreateError(): void {
+    const updates: Partial<JobsStoreState> = {};
+
+    if (this.state.createError !== undefined) {
+      updates.createError = undefined;
+    }
+
+    if (
+      this.state.currentJob &&
+      TERMINAL_JOB_STATUSES.includes(this.state.currentJob.status)
+    ) {
+      updates.currentJob = null;
+    }
+
+    if (Object.keys(updates).length > 0) {
+      this.setState(updates);
+    }
   }
 
   /**

--- a/src/data/stores/__tests__/AssessmentsStore.test.ts
+++ b/src/data/stores/__tests__/AssessmentsStore.test.ts
@@ -143,6 +143,66 @@ describe("AssessmentsStore", () => {
     expect(store.getSnapshot()[0].name).toBe("New");
   });
 
+  it("create() extracts error message from ResponseError with JSON body", async () => {
+    const mockResponse = {
+      text: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          message: 'assessment with name "dup" already exists',
+        }),
+      ),
+      status: 409,
+      ok: false,
+      statusText: "Conflict",
+    } as unknown as Response;
+
+    const responseError = new ResponseError(mockResponse, "Response error");
+    vi.mocked(api.createAssessment).mockRejectedValue(responseError);
+
+    const form = { name: "dup" } as Parameters<
+      AssessmentApiInterface["createAssessment"]
+    >[0]["assessmentForm"];
+
+    await expect(store.create(form)).rejects.toThrow(
+      'assessment with name "dup" already exists',
+    );
+  });
+
+  it("create() extracts error message from ResponseError with name validation error", async () => {
+    const mockResponse = {
+      text: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          message: "The provided name: aaa aaa is invalid.",
+        }),
+      ),
+      status: 400,
+      ok: false,
+      statusText: "Bad Request",
+    } as unknown as Response;
+
+    const responseError = new ResponseError(mockResponse, "Response error");
+    vi.mocked(api.createAssessment).mockRejectedValue(responseError);
+
+    const form = { name: "aaa aaa" } as Parameters<
+      AssessmentApiInterface["createAssessment"]
+    >[0]["assessmentForm"];
+
+    await expect(store.create(form)).rejects.toThrow(
+      "The provided name: aaa aaa is invalid.",
+    );
+  });
+
+  it("create() uses fallback message when error is not a ResponseError", async () => {
+    vi.mocked(api.createAssessment).mockRejectedValue(
+      new Error("Network failure"),
+    );
+
+    const form = { name: "test" } as Parameters<
+      AssessmentApiInterface["createAssessment"]
+    >[0]["assessmentForm"];
+
+    await expect(store.create(form)).rejects.toThrow("Network failure");
+  });
+
   it("update() replaces existing item", async () => {
     const initial = makeAssessment({ id: "a-1", name: "Old" });
     vi.mocked(api.listAssessments).mockResolvedValue([initial] as never);
@@ -163,6 +223,34 @@ describe("AssessmentsStore", () => {
     expect(result.name).toBe("Updated");
     expect(store.getSnapshot()).toHaveLength(1);
     expect(store.getSnapshot()[0].name).toBe("Updated");
+  });
+
+  it("update() extracts error message from ResponseError with JSON body", async () => {
+    const initial = makeAssessment({ id: "a-1", name: "Old" });
+    vi.mocked(api.listAssessments).mockResolvedValue([initial] as never);
+    await store.list();
+
+    const mockResponse = {
+      text: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          message: "The provided name: bad name is invalid.",
+        }),
+      ),
+      status: 400,
+      ok: false,
+      statusText: "Bad Request",
+    } as unknown as Response;
+
+    const responseError = new ResponseError(mockResponse, "Response error");
+    vi.mocked(api.updateAssessment).mockRejectedValue(responseError);
+
+    const form = { name: "bad name" } as Parameters<
+      AssessmentApiInterface["updateAssessment"]
+    >[0]["assessmentUpdate"];
+
+    await expect(store.update("a-1", form)).rejects.toThrow(
+      "The provided name: bad name is invalid.",
+    );
   });
 
   it("remove() filters out item and refreshes from server", async () => {

--- a/src/data/stores/__tests__/JobsStore.test.ts
+++ b/src/data/stores/__tests__/JobsStore.test.ts
@@ -142,6 +142,37 @@ describe("JobsStore", () => {
     expect(store.getSnapshot().isCreating).toBe(false);
   });
 
+  it("stale call does not overwrite state when a newer call has started", async () => {
+    let rejectFirst!: (err: Error) => void;
+    vi.mocked(api.createRVToolsAssessment)
+      .mockImplementationOnce(
+        () =>
+          new Promise<Job>((_resolve, reject) => {
+            rejectFirst = reject;
+          }),
+      )
+      .mockRejectedValueOnce(new Error("second error"));
+
+    const firstPromise = store.createRVToolsJob(
+      "first",
+      new File([], "f.xlsx"),
+    );
+
+    const secondPromise = store.createRVToolsJob(
+      "second",
+      new File([], "f.xlsx"),
+    );
+
+    // First call was aborted when second started; resolve it now.
+    // The catch guard should prevent it from overwriting state.
+    rejectFirst(new Error("first error"));
+
+    await firstPromise;
+    await secondPromise;
+
+    expect(store.getSnapshot().createError?.message).toBe("second error");
+  });
+
   // -- Polling --------------------------------------------------------------
 
   it("polls the job and updates state on each tick", async () => {
@@ -227,6 +258,59 @@ describe("JobsStore", () => {
   it("returns null when there is no current job", async () => {
     const result = await store.cancelRVToolsJob();
     expect(result).toBeNull();
+  });
+
+  // -- clearCreateError ------------------------------------------------------
+
+  it("clears createError", async () => {
+    vi.mocked(api.createRVToolsAssessment).mockRejectedValue(
+      new Error("name error"),
+    );
+    await store.createRVToolsJob("bad", new File([], "f.xlsx"));
+    expect(store.getSnapshot().createError).toBeDefined();
+
+    store.clearCreateError();
+
+    expect(store.getSnapshot().createError).toBeUndefined();
+    expect(store.getSnapshot().isCreating).toBe(false);
+  });
+
+  it("also clears currentJob when it is in a terminal state", async () => {
+    const failedJob = makeJob({ status: JobStatus.Failed, error: "boom" });
+    vi.mocked(api.createRVToolsAssessment).mockResolvedValue(
+      makeJob({ status: JobStatus.Pending }),
+    );
+    await store.createRVToolsJob("t", new File([], "f.xlsx"));
+
+    // Simulate polling setting the job to Failed
+    vi.mocked(api.getJob).mockResolvedValue(failedJob);
+    store.startPolling(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+    store.stopPolling();
+    expect(store.getSnapshot().currentJob?.status).toBe(JobStatus.Failed);
+
+    store.clearCreateError();
+
+    expect(store.getSnapshot().currentJob).toBeNull();
+  });
+
+  it("does NOT clear a non-terminal currentJob", async () => {
+    const runningJob = makeJob({ status: JobStatus.Parsing });
+    vi.mocked(api.createRVToolsAssessment).mockResolvedValue(runningJob);
+    await store.createRVToolsJob("t", new File([], "f.xlsx"));
+
+    store.clearCreateError();
+
+    expect(store.getSnapshot().currentJob).toEqual(runningJob);
+  });
+
+  it("clearCreateError is a no-op when there is nothing to clear", () => {
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    store.clearCreateError();
+
+    expect(listener).not.toHaveBeenCalled();
   });
 
   // -- reset ----------------------------------------------------------------

--- a/src/data/stores/interfaces/IJobsStore.ts
+++ b/src/data/stores/interfaces/IJobsStore.ts
@@ -6,6 +6,7 @@ import type { JobsStoreState } from "../JobsStore";
 export interface IJobsStore extends ExternalStore<JobsStoreState> {
   createRVToolsJob(name: string, file: File): Promise<Job | undefined>;
   cancelRVToolsJob(): Promise<Job | null>;
+  clearCreateError(): void;
   reset(): void;
   startPolling(intervalMs: number): void;
   stopPolling(): void;

--- a/src/lib/common/ErrorParser.ts
+++ b/src/lib/common/ErrorParser.ts
@@ -43,3 +43,16 @@ export async function parseApiError(
 
   return new Error(fallbackMessage);
 }
+
+/**
+ * Returns `true` when the error message indicates a name-related validation
+ * failure from the backend (duplicate name or invalid characters).
+ */
+export const isNameError = (error: Error | null): boolean => {
+  if (!error) return false;
+  const msg = error.message || "";
+  return (
+    /assessment with name '.*' already exists/i.test(msg) ||
+    /provided name.+invalid/i.test(msg)
+  );
+};

--- a/src/ui/assessment/view-models/__tests__/useAssessmentPageViewModel.test.ts
+++ b/src/ui/assessment/view-models/__tests__/useAssessmentPageViewModel.test.ts
@@ -28,6 +28,7 @@ let mockAssessmentsStore: {
 let mockJobsStore: {
   createRVToolsJob: ReturnType<typeof vi.fn>;
   cancelRVToolsJob: ReturnType<typeof vi.fn>;
+  clearCreateError: ReturnType<typeof vi.fn>;
   reset: ReturnType<typeof vi.fn>;
   startPolling: ReturnType<typeof vi.fn>;
   stopPolling: ReturnType<typeof vi.fn>;
@@ -94,6 +95,7 @@ describe("useAssessmentPageViewModel", () => {
     mockJobsStore = {
       createRVToolsJob: vi.fn().mockResolvedValue(makeJob()),
       cancelRVToolsJob: vi.fn().mockResolvedValue(null),
+      clearCreateError: vi.fn(),
       reset: vi.fn(),
       startPolling: vi.fn(),
       stopPolling: vi.fn(),
@@ -151,6 +153,18 @@ describe("useAssessmentPageViewModel", () => {
     });
 
     expect(mockJobsStore.startPolling).not.toHaveBeenCalled();
+  });
+
+  // -- clearJobCreateError ---------------------------------------------------
+
+  it("delegates clearJobCreateError to jobsStore.clearCreateError", () => {
+    const { result } = renderHook(() => useAssessmentPageViewModel());
+
+    act(() => {
+      result.current.clearJobCreateError();
+    });
+
+    expect(mockJobsStore.clearCreateError).toHaveBeenCalledOnce();
   });
 
   // -- cancelRVToolsJob -----------------------------------------------------

--- a/src/ui/assessment/view-models/__tests__/useCreateFromOvaViewModel.test.ts
+++ b/src/ui/assessment/view-models/__tests__/useCreateFromOvaViewModel.test.ts
@@ -157,12 +157,10 @@ describe("useCreateFromOvaViewModel", () => {
     expect(result.current.isSubmitDisabled).toBe(true);
   });
 
-  it("hasDuplicateNameError detects duplicate name error message", async () => {
-    // Make create reject with a duplicate-name error
+  it("hasNameError detects duplicate name error message", async () => {
     mockAssessmentsStore.create.mockRejectedValueOnce(
       new Error("An assessment with name 'Foo' already exists"),
     );
-    // Provide a source so the submit path is valid
     const source = makeSource({ id: "s-1", name: "Test" });
     mockEnvVm.sourceCreatedId = "s-1";
     mockEnvVm.getSourceById.mockReturnValue(source);
@@ -177,11 +175,32 @@ describe("useCreateFromOvaViewModel", () => {
       await result.current.handleSubmit();
     });
 
-    expect(result.current.hasDuplicateNameError).toBe(true);
+    expect(result.current.hasNameError).toBe(true);
   });
 
-  it("hasGeneralApiError is true for non-duplicate errors", async () => {
-    // Make create reject with a generic error
+  it("hasNameError detects backend name validation error", async () => {
+    mockAssessmentsStore.create.mockRejectedValueOnce(
+      new Error("The provided name: aaa aaa is invalid."),
+    );
+    const source = makeSource({ id: "s-1", name: "Test" });
+    mockEnvVm.sourceCreatedId = "s-1";
+    mockEnvVm.getSourceById.mockReturnValue(source);
+
+    const { result } = renderHook(() => useCreateFromOvaViewModel());
+
+    act(() => {
+      result.current.setName("aaa aaa");
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(result.current.hasNameError).toBe(true);
+    expect(result.current.hasGeneralApiError).toBe(false);
+  });
+
+  it("hasGeneralApiError is true for non-name-related errors", async () => {
     mockAssessmentsStore.create.mockRejectedValueOnce(
       new Error("Network error"),
     );
@@ -200,7 +219,7 @@ describe("useCreateFromOvaViewModel", () => {
     });
 
     expect(result.current.hasGeneralApiError).toBe(true);
-    expect(result.current.hasDuplicateNameError).toBe(false);
+    expect(result.current.hasNameError).toBe(false);
   });
 
   it("sources comes from envVm.sources", () => {

--- a/src/ui/assessment/view-models/useAssessmentPageViewModel.ts
+++ b/src/ui/assessment/view-models/useAssessmentPageViewModel.ts
@@ -133,6 +133,8 @@ export interface AssessmentPageViewModel {
 
   /** Create a new RVTools assessment (starts an async job). */
   createRVToolsJob: (name: string, file: File) => Promise<void>;
+  /** Clear the create-job error (e.g. when the user edits the form). */
+  clearJobCreateError: () => void;
   /**
    * Cancel the current job.
    * If the job had already completed, the created assessment is cleaned up.
@@ -261,6 +263,10 @@ export const useAssessmentPageViewModel = (): AssessmentPageViewModel => {
     [jobsStore],
   );
 
+  const clearJobCreateError = useCallback((): void => {
+    jobsStore.clearCreateError();
+  }, [jobsStore]);
+
   const cancelRVToolsJob = useCallback(async (): Promise<void> => {
     jobsStore.stopPolling();
     const latestJob = await jobsStore.cancelRVToolsJob();
@@ -342,6 +348,7 @@ export const useAssessmentPageViewModel = (): AssessmentPageViewModel => {
     sortBy,
     setSortBy,
     createRVToolsJob,
+    clearJobCreateError,
     cancelRVToolsJob,
     updateAssessment: doUpdateAssessment,
     deleteAssessment: doDeleteAssessment,

--- a/src/ui/assessment/view-models/useCreateFromOvaViewModel.ts
+++ b/src/ui/assessment/view-models/useCreateFromOvaViewModel.ts
@@ -54,7 +54,7 @@ export interface CreateFromOvaViewModel {
   selectedEnv: SourceModel | undefined;
   isSelectedNotReady: boolean;
   isSubmitDisabled: boolean;
-  hasDuplicateNameError: boolean;
+  hasNameError: boolean;
   hasGeneralApiError: boolean;
 
   // Actions
@@ -131,13 +131,15 @@ export const useCreateFromOvaViewModel = (): CreateFromOvaViewModel => {
     useExisting && selectedEnv && !selectedEnv.isReady,
   );
 
-  const isDuplicateNameError = useCallback(
-    (error: Error | null): boolean =>
-      !!error &&
-      (/assessment with name '.*' already exists/i.test(error.message || "") ||
-        /already exists/i.test(error.message || "")),
-    [],
-  );
+  const isNameError = useCallback((error: Error | null): boolean => {
+    if (!error) return false;
+    const msg = error.message || "";
+    return (
+      /assessment with name '.*' already exists/i.test(msg) ||
+      /already exists/i.test(msg) ||
+      /provided name.+invalid/i.test(msg)
+    );
+  }, []);
 
   const isSubmitDisabled =
     !name || (useExisting ? !selectedEnvironmentId : !envVm.sourceCreatedId);
@@ -300,8 +302,8 @@ export const useCreateFromOvaViewModel = (): CreateFromOvaViewModel => {
       ? null
       : (submitState.error ?? null);
 
-  const hasDuplicateNameError = isDuplicateNameError(apiError);
-  const hasGeneralApiError = !!apiError && !isDuplicateNameError(apiError);
+  const hasNameError = isNameError(apiError);
+  const hasGeneralApiError = !!apiError && !isNameError(apiError);
 
   return {
     sources: envVm.sources,
@@ -333,7 +335,7 @@ export const useCreateFromOvaViewModel = (): CreateFromOvaViewModel => {
     selectedEnv,
     isSelectedNotReady,
     isSubmitDisabled,
-    hasDuplicateNameError,
+    hasNameError,
     hasGeneralApiError,
 
     handleSubmit: doSubmit,

--- a/src/ui/assessment/view-models/useCreateFromOvaViewModel.ts
+++ b/src/ui/assessment/view-models/useCreateFromOvaViewModel.ts
@@ -5,6 +5,7 @@ import { useAsyncFn } from "react-use";
 
 import { Symbols } from "../../../config/Dependencies";
 import type { IAssessmentsStore } from "../../../data/stores/interfaces/IAssessmentsStore";
+import { isNameError } from "../../../lib/common/ErrorParser";
 import type { SourceModel } from "../../../models/SourceModel";
 import { routes } from "../../../routing/Routes";
 import { useEnvironmentPage } from "../../environment/view-models/EnvironmentPageContext";
@@ -130,16 +131,6 @@ export const useCreateFromOvaViewModel = (): CreateFromOvaViewModel => {
   const isSelectedNotReady = Boolean(
     useExisting && selectedEnv && !selectedEnv.isReady,
   );
-
-  const isNameError = useCallback((error: Error | null): boolean => {
-    if (!error) return false;
-    const msg = error.message || "";
-    return (
-      /assessment with name '.*' already exists/i.test(msg) ||
-      /already exists/i.test(msg) ||
-      /provided name.+invalid/i.test(msg)
-    );
-  }, []);
 
   const isSubmitDisabled =
     !name || (useExisting ? !selectedEnvironmentId : !envVm.sourceCreatedId);

--- a/src/ui/assessment/views/Assessment.tsx
+++ b/src/ui/assessment/views/Assessment.tsx
@@ -99,6 +99,7 @@ const Assessment: React.FC<AssessmentProps> = ({
     sortBy,
     setSortBy,
     createRVToolsJob,
+    clearJobCreateError,
     cancelRVToolsJob,
     updateAssessment: vmUpdateAssessment,
     deleteAssessment: vmDeleteAssessment,
@@ -491,6 +492,7 @@ const Assessment: React.FC<AssessmentProps> = ({
         isOpen={isModalOpen}
         onClose={handleCloseModal}
         onSubmit={handleSubmitAssessment}
+        onClearError={clearJobCreateError}
         mode={modalMode}
         isLoading={isCreatingJob}
         error={jobCreateError}

--- a/src/ui/assessment/views/CreateAssessmentModal.tsx
+++ b/src/ui/assessment/views/CreateAssessmentModal.tsx
@@ -25,6 +25,7 @@ interface CreateAssessmentModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSubmit: (name: string, file: File | null, mode: AssessmentMode) => void;
+  onClearError?: () => void;
   mode: AssessmentMode;
   isLoading?: boolean;
   error?: Error | null;
@@ -42,10 +43,15 @@ interface CreateAssessmentModalProps {
   isNavigatingToReport?: boolean;
 }
 
-const isDuplicateNameError = (error: Error | null): boolean =>
-  !!error &&
-  (/assessment with name '.*' already exists/i.test(error.message || "") ||
-    /already exists/i.test(error.message || ""));
+const isNameError = (error: Error | null): boolean => {
+  if (!error) return false;
+  const msg = error.message || "";
+  return (
+    /assessment with name '.*' already exists/i.test(msg) ||
+    /already exists/i.test(msg) ||
+    /provided name.+invalid/i.test(msg)
+  );
+};
 
 const isAbortError = (error: Error | null): boolean => {
   if (!error) return false;
@@ -64,6 +70,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
   isOpen,
   onClose,
   onSubmit,
+  onClearError,
   mode,
   isLoading = false,
   error = null,
@@ -87,10 +94,6 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
   const [nameValidationError, setNameValidationError] = useState("");
   const [fileValidationError, setFileValidationError] = useState("");
 
-  // Track dismissed API errors (reset on new submission)
-  const [nameErrorDismissed, setNameErrorDismissed] = useState(false);
-  const [generalErrorDismissed, setGeneralErrorDismissed] = useState(false);
-
   // Reset all form state when the modal is closed — covers both explicit
   // (Cancel / X) and programmatic closes (e.g. navigation after job completion).
   React.useEffect(() => {
@@ -101,8 +104,6 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
       setNameValidationError("");
       setFileValidationError("");
       setSelectedEnvironmentId("");
-      setNameErrorDismissed(false);
-      setGeneralErrorDismissed(false);
       setRvtoolsConsentChecked(false);
     }
   }, [isOpen]);
@@ -113,25 +114,14 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
   // Combine with existing error logic - job error takes priority
   const effectiveError = jobError || error;
 
-  // Reset dismissed flags when a new error occurs
-  React.useEffect(() => {
-    if (error || jobError) {
-      setNameErrorDismissed(false);
-      setGeneralErrorDismissed(false);
-    }
-  }, [error, jobError]);
-
-  const hasDuplicateNameError =
-    !nameErrorDismissed && isDuplicateNameError(effectiveError);
+  const hasNameError = isNameError(effectiveError);
   const hasGeneralApiError =
-    !generalErrorDismissed &&
     !!effectiveError &&
-    !isDuplicateNameError(effectiveError) &&
+    !isNameError(effectiveError) &&
     !isAbortError(effectiveError);
 
   const nameErrorToDisplay =
-    nameValidationError ||
-    (hasDuplicateNameError ? effectiveError?.message : "");
+    nameValidationError || (hasNameError ? effectiveError?.message : "");
 
   const availableEnvironments = selectedEnvironment
     ? [selectedEnvironment]
@@ -268,8 +258,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
     setNameValidationError("");
     setFileValidationError("");
     setSelectedEnvironmentId("");
-    setNameErrorDismissed(true);
-    setGeneralErrorDismissed(true);
+    onClearError?.();
     setRvtoolsConsentChecked(false);
     onClose();
   };
@@ -338,8 +327,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
                 if (nameValidationError && value.trim()) {
                   setNameValidationError("");
                 }
-                setNameErrorDismissed(true);
-                setGeneralErrorDismissed(true);
+                onClearError?.();
               }}
               validated={nameErrorToDisplay ? "error" : "default"}
               placeholder="Enter assessment name"

--- a/src/ui/assessment/views/CreateAssessmentModal.tsx
+++ b/src/ui/assessment/views/CreateAssessmentModal.tsx
@@ -19,6 +19,8 @@ import {
 } from "@patternfly/react-core";
 import React, { useState } from "react";
 
+import { isNameError } from "../../../lib/common/ErrorParser";
+
 export type AssessmentMode = "inventory" | "rvtools" | "agent";
 
 interface CreateAssessmentModalProps {
@@ -42,16 +44,6 @@ interface CreateAssessmentModalProps {
   /** `true` while loading assessments and navigating to report after job completion. */
   isNavigatingToReport?: boolean;
 }
-
-const isNameError = (error: Error | null): boolean => {
-  if (!error) return false;
-  const msg = error.message || "";
-  return (
-    /assessment with name '.*' already exists/i.test(msg) ||
-    /already exists/i.test(msg) ||
-    /provided name.+invalid/i.test(msg)
-  );
-};
 
 const isAbortError = (error: Error | null): boolean => {
   if (!error) return false;

--- a/src/ui/assessment/views/CreateFromOva.tsx
+++ b/src/ui/assessment/views/CreateFromOva.tsx
@@ -69,15 +69,13 @@ const CreateFromOvaContent: React.FC = () => {
                     vm.setName(v);
                     if (vm.apiError) vm.setApiError(null);
                   }}
-                  validated={vm.hasDuplicateNameError ? "error" : "default"}
+                  validated={vm.hasNameError ? "error" : "default"}
                 />
               </InputGroupItem>
             </InputGroup>
             <HelperText>
-              <HelperTextItem
-                variant={vm.hasDuplicateNameError ? "error" : "default"}
-              >
-                {vm.hasDuplicateNameError
+              <HelperTextItem variant={vm.hasNameError ? "error" : "default"}>
+                {vm.hasNameError
                   ? vm.apiError?.message
                   : "Name your assessment"}
               </HelperTextItem>


### PR DESCRIPTION

- Rename isDuplicateNameError to isNameError and expand the regex to also match "provided name...invalid" messages from the backend, not just "already exists". Applied to both the RVTools (CreateAssessmentModal) and OVA (CreateFromOva / useCreateFro

- Wrap create() and update() in try/catch and call parseApiError so the specific backend validation message (e.g. duplicate name, invalid format) is surfaced to the UI instead of the generic SDK "Response returned an error code" string.

- Capture the AbortController in a local variable at the start of createRVToolsJob so the catch block always checks its own controller. Add a post-parseApiError guard that discards results when a newer call has replaced this.abortController, preventing a slower older request from writing a stale error into the store.

- Replace UI-layer dismissedError tracking with store-level error clearing. When the user edits the name field, onClearError physically removes createError and any terminal-state currentJob from the JobsStore, preventing stale errors from persisting across submissions.


https://github.com/user-attachments/assets/608b14eb-f758-4517-8788-17e73c557abf



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error handling for assessment create/update and job creation to surface parsed messages and prevent stale errors from overwriting newer state.

* **New Features**
  * Added a user-facing action to clear job-creation errors from the assessment page.
  * Unified and expanded name-validation detection for assessment creation; modals now clear errors when name edits occur or dialog closes.

* **Tests**
  * Added tests for error parsing, concurrency guards, and clear-error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->