### PR TITLE
ECOPROJECT-4307 | fix: align height for each assumption card in Migration time estimation modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6384,9 +6384,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/src/ui/report/views/cluster-sizer/TimeEstimationResult.tsx
+++ b/src/ui/report/views/cluster-sizer/TimeEstimationResult.tsx
@@ -35,6 +35,11 @@ const sectionStyle = css`
   border: 1px solid var(--pf-t--global--border--color--default);
   border-radius: var(--pf-t--global--border--radius--small);
   padding: var(--pf-t--global--spacer--400);
+  height: 100%;
+`;
+
+const equalHeightGridStyle = css`
+  align-items: stretch;
 `;
 
 const totalTimeStyle = css`
@@ -169,7 +174,7 @@ export const TimeEstimationResult: React.FC<TimeEstimationResultProps> = ({
   return (
     <Stack hasGutter>
       <StackItem>
-        <Grid hasGutter>
+        <Grid hasGutter className={equalHeightGridStyle}>
           {schemas.map(([schemaName, result]) => {
             const display = getSchemaDisplay(schemaName);
             const breakdownEntries = result.breakdown
@@ -216,7 +221,7 @@ export const TimeEstimationResult: React.FC<TimeEstimationResultProps> = ({
       </StackItem>
 
       <StackItem>
-        <Grid hasGutter>
+        <Grid hasGutter className={equalHeightGridStyle}>
           {schemas.map(([schemaName, result]) => {
             const display = getSchemaDisplay(schemaName);
             const breakdownEntries = result.breakdown


### PR DESCRIPTION
The fix is to make the cards in each row stretch to the same height by adding align-items: stretch on the grid and height: 100% on the card div.

- Before changes:
<img width="1015" height="385" alt="Captura desde 2026-04-10 12-09-44" src="https://github.com/user-attachments/assets/0b5e12dd-bb8c-4152-95e8-2ebfca00b20e" />

- After changes:
<img width="1015" height="385" alt="Captura desde 2026-04-10 12-12-31" src="https://github.com/user-attachments/assets/e08e5e58-932a-46dd-beb5-ebe63774f2d5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual alignment of time estimation result panels with consistent heights across grid columns for better UI consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->