### PR TITLE
ECOPROJECT-4244 | feat: implement complexity by Disk&OS tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@emotion/css": "^11.13.0",
-        "@openshift-migration-advisor/planner-sdk": "0.8.0-c0804255c486",
+        "@openshift-migration-advisor/planner-sdk": "0.10.0",
         "@patternfly/react-charts": "7.4.9",
         "@patternfly/react-core": "^6.4.0",
         "@patternfly/react-icons": "^6.4.0",
@@ -2241,9 +2241,9 @@
       }
     },
     "node_modules/@openshift-migration-advisor/planner-sdk": {
-      "version": "0.8.0-c0804255c486",
-      "resolved": "https://registry.npmjs.org/@openshift-migration-advisor/planner-sdk/-/planner-sdk-0.8.0-c0804255c486.tgz",
-      "integrity": "sha512-CVQJ276d7dKQduY2J/nT3GGmSy3QxCdFM7MwA9TFUCgiX0Cv8FDRWcJDO811X2MoKG4H5aceo+pQuPyONTZGvQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@openshift-migration-advisor/planner-sdk/-/planner-sdk-0.10.0.tgz",
+      "integrity": "sha512-XWTDPquuiqzKrjYW8s/lS46qbW+xjO83Mi9TcM1e4luZZA4l9zZSGAH8p3S2NIUNqTLvukUeW6QIRmWgsboc9w==",
       "license": "Apache-2.0"
     },
     "node_modules/@openshift/dynamic-plugin-sdk": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@emotion/css": "^11.13.0",
-    "@openshift-migration-advisor/planner-sdk": "0.8.0-c0804255c486",
+    "@openshift-migration-advisor/planner-sdk": "0.10.0",
     "@patternfly/react-charts": "7.4.9",
     "@patternfly/react-core": "^6.4.0",
     "@patternfly/react-icons": "^6.4.0",

--- a/src/data/stores/AssessmentsStore.ts
+++ b/src/data/stores/AssessmentsStore.ts
@@ -2,6 +2,7 @@ import {
   type AssessmentApiInterface,
   type CalculateAssessmentClusterRequirementsRequest,
   type CalculateMigrationComplexityRequest,
+  type CalculateMigrationEstimationByComplexityRequest,
   type CalculateMigrationEstimationRequest,
   ResponseError,
 } from "@openshift-migration-advisor/planner-sdk";
@@ -219,6 +220,16 @@ export class AssessmentsStore
     initOverrides?: RequestInit | InitOverrideFunction,
   ) {
     return this.api.calculateMigrationComplexity(
+      requestParameters,
+      initOverrides,
+    );
+  }
+
+  calculateEstimationByComplexity(
+    requestParameters: CalculateMigrationEstimationByComplexityRequest,
+    initOverrides?: RequestInit | InitOverrideFunction,
+  ) {
+    return this.api.calculateMigrationEstimationByComplexity(
       requestParameters,
       initOverrides,
     );

--- a/src/data/stores/interfaces/IAssessmentsStore.ts
+++ b/src/data/stores/interfaces/IAssessmentsStore.ts
@@ -1,10 +1,12 @@
 import type {
   CalculateAssessmentClusterRequirementsRequest,
   CalculateMigrationComplexityRequest,
+  CalculateMigrationEstimationByComplexityRequest,
   CalculateMigrationEstimationRequest,
   ClusterRequirementsResponse,
   InitOverrideFunction,
   MigrationComplexityResponse,
+  MigrationEstimationByComplexityResponse,
   SchemaEstimationResult,
 } from "@openshift-migration-advisor/planner-sdk";
 
@@ -51,6 +53,10 @@ export interface IAssessmentsStore extends ExternalStore<AssessmentModel[]> {
     requestParameters: CalculateMigrationComplexityRequest,
     initOverrides?: RequestInit | InitOverrideFunction,
   ): Promise<MigrationComplexityResponse>;
+  calculateEstimationByComplexity(
+    requestParameters: CalculateMigrationEstimationByComplexityRequest,
+    initOverrides?: RequestInit | InitOverrideFunction,
+  ): Promise<MigrationEstimationByComplexityResponse>;
   startPolling(intervalMs?: number): void;
   stopPolling(): void;
 }

--- a/src/ui/report/view-models/useClusterSizingWizardViewModel.ts
+++ b/src/ui/report/view-models/useClusterSizingWizardViewModel.ts
@@ -1,4 +1,7 @@
-import type { MigrationComplexityResponse } from "@openshift-migration-advisor/planner-sdk";
+import type {
+  MigrationComplexityResponse,
+  MigrationEstimationByComplexityResponse,
+} from "@openshift-migration-advisor/planner-sdk";
 import { ResponseError } from "@openshift-migration-advisor/planner-sdk";
 import { useInjection } from "@y0n1/react-ioc";
 import { useCallback, useRef, useState, useSyncExternalStore } from "react";
@@ -42,6 +45,9 @@ export interface ClusterSizingWizardViewModel {
   isCalculatingComplexity: boolean;
   complexityError: Error | undefined;
   calculateComplexity: () => Promise<void>;
+  estimationByComplexity: MigrationEstimationByComplexityResponse | null;
+  isCalculatingEstimationByComplexity: boolean;
+  estimationByComplexityError: Error | undefined;
   isFormValid: boolean;
   ensureEstimationForMenu: (menuItem: string | null) => void;
   reset: () => void;
@@ -71,6 +77,8 @@ export const useClusterSizingWizardViewModel = (
     useState<MigrationEstimationResponse | null>(null);
   const [complexityEstimation, setComplexityEstimation] =
     useState<MigrationComplexityResponse | null>(null);
+  const [estimationByComplexity, setEstimationByComplexity] =
+    useState<MigrationEstimationByComplexityResponse | null>(null);
   const [manualCalculateError, setManualCalculateError] = useState<
     Error | undefined
   >(undefined);
@@ -78,6 +86,9 @@ export const useClusterSizingWizardViewModel = (
     Error | undefined
   >(undefined);
   const [manualComplexityError, setManualComplexityError] = useState<
+    Error | undefined
+  >(undefined);
+  const [manualEstByComplexityError, setManualEstByComplexityError] = useState<
     Error | undefined
   >(undefined);
   const [resetCounter, setResetCounter] = useState<number>(0);
@@ -209,6 +220,42 @@ export const useClusterSizingWizardViewModel = (
     }
   }, [assessmentId, assessmentsStore, clusterId]);
 
+  const [estByComplexityState, doCalculateEstimationByComplexity] =
+    useAsyncFn(async () => {
+      setManualEstByComplexityError(undefined);
+      try {
+        const result = await assessmentsStore.calculateEstimationByComplexity({
+          id: assessmentId,
+          migrationEstimationRequest: {
+            clusterId,
+            estimationSchema: ["network-based", "storage-offload"],
+            params: {
+              work_hours_per_day: 6,
+              post_migration_engineers: 4,
+              transfer_rate_mbps: 600,
+            },
+          },
+        });
+        setEstimationByComplexity(result);
+      } catch (err) {
+        if (err instanceof ResponseError) {
+          const message = await err.response.text();
+          const combinedMessage = message
+            ? `${err.message}: ${message}`
+            : err.message;
+          const error = new Error(combinedMessage, { cause: message });
+          setManualEstByComplexityError(error);
+          throw error;
+        }
+        const error =
+          err instanceof Error
+            ? err
+            : new Error("Failed to calculate estimation by complexity");
+        setManualEstByComplexityError(error);
+        throw error;
+      }
+    }, [assessmentId, assessmentsStore, clusterId]);
+
   const ensureEstimationForMenu = useCallback(
     (menuItem: string | null) => {
       if (
@@ -219,13 +266,21 @@ export const useClusterSizingWizardViewModel = (
       ) {
         void doCalculateEstimation();
       }
-      if (
-        menuItem === "complexity" &&
-        !complexityEstimation &&
-        !complexityState.loading &&
-        !manualComplexityError
-      ) {
-        void doCalculateComplexity();
+      if (menuItem === "complexity") {
+        if (
+          !complexityEstimation &&
+          !complexityState.loading &&
+          !manualComplexityError
+        ) {
+          void doCalculateComplexity();
+        }
+        if (
+          !estimationByComplexity &&
+          !estByComplexityState.loading &&
+          !manualEstByComplexityError
+        ) {
+          void doCalculateEstimationByComplexity();
+        }
       }
     },
     [
@@ -237,6 +292,10 @@ export const useClusterSizingWizardViewModel = (
       complexityState.loading,
       manualComplexityError,
       doCalculateComplexity,
+      estimationByComplexity,
+      estByComplexityState.loading,
+      manualEstByComplexityError,
+      doCalculateEstimationByComplexity,
     ],
   );
 
@@ -245,9 +304,11 @@ export const useClusterSizingWizardViewModel = (
     setSizerOutput(null);
     setMigrationEstimation(null);
     setComplexityEstimation(null);
+    setEstimationByComplexity(null);
     setManualCalculateError(undefined);
     setManualEstimationError(undefined);
     setManualComplexityError(undefined);
+    setManualEstByComplexityError(undefined);
     setResetCounter((prev) => prev + 1);
   }, []);
 
@@ -287,6 +348,11 @@ export const useClusterSizingWizardViewModel = (
       manualComplexityError ??
       (resetCounter > 0 ? undefined : complexityState.error),
     calculateComplexity: doCalculateComplexity,
+    estimationByComplexity,
+    isCalculatingEstimationByComplexity: estByComplexityState.loading,
+    estimationByComplexityError:
+      manualEstByComplexityError ??
+      (resetCounter > 0 ? undefined : estByComplexityState.error),
     isFormValid,
     ensureEstimationForMenu,
     reset,

--- a/src/ui/report/views/cluster-sizer/ClusterSizingWizard.tsx
+++ b/src/ui/report/views/cluster-sizer/ClusterSizingWizard.tsx
@@ -222,6 +222,13 @@ export const ClusterSizingWizard: React.FC<ClusterSizingWizardProps> = ({
                 complexityOutput={vm.complexityEstimation}
                 isLoading={vm.isCalculatingComplexity}
                 error={vm.complexityError ?? null}
+                estimationByComplexity={vm.estimationByComplexity}
+                isLoadingEstimationByComplexity={
+                  vm.isCalculatingEstimationByComplexity
+                }
+                estimationByComplexityError={
+                  vm.estimationByComplexityError ?? null
+                }
               />
             }
             onGenerate={handleCalculateComplexity}

--- a/src/ui/report/views/cluster-sizer/ComplexityResult.tsx
+++ b/src/ui/report/views/cluster-sizer/ComplexityResult.tsx
@@ -3,6 +3,9 @@ import type {
   ComplexityDiskScoreEntry,
   ComplexityOSNameEntry,
   MigrationComplexityResponse,
+  MigrationEstimationByComplexityResponse,
+  OsDiskEstimationEntry,
+  SchemaEstimationResult,
 } from "@openshift-migration-advisor/planner-sdk";
 import {
   Chart,
@@ -16,8 +19,6 @@ import {
 import {
   Alert,
   Badge,
-  Card,
-  CardBody,
   Flex,
   FlexItem,
   Spinner,
@@ -30,11 +31,16 @@ import {
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import React, { useState } from "react";
 
+import { parseDuration } from "./timeUtils";
+
 interface ComplexityResultProps {
   clusterName: string;
   complexityOutput: MigrationComplexityResponse | null;
   isLoading: boolean;
   error: Error | null;
+  estimationByComplexity: MigrationEstimationByComplexityResponse | null;
+  isLoadingEstimationByComplexity: boolean;
+  estimationByComplexityError: Error | null;
 }
 
 interface ChartDatumWithScore {
@@ -50,11 +56,6 @@ interface ChartDatum {
 
 const headerStyle = css`
   margin-bottom: var(--pf-t--global--spacer--200);
-`;
-
-const subtitleStyle = css`
-  color: var(--pf-t--global--text--color--subtle);
-  margin-bottom: var(--pf-t--global--spacer--400);
 `;
 
 const legendContainerStyle = css`
@@ -119,11 +120,37 @@ const DISK_SIZE_LABELS: Record<number, string> = {
   4: "> 50 TB",
 };
 
+const durationToHours = (duration: string): number =>
+  Math.ceil(parseDuration(duration) / 3600);
+
+const formatDiskSize = (tb: number): string => {
+  if (tb === 0) return "0 TB";
+  return `${tb.toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 2 })} TB`;
+};
+
+const timeEstimationCellStyle = css`
+  display: flex;
+  flex-direction: column;
+  gap: var(--pf-t--global--spacer--100);
+`;
+
+const timeEstimationLabelStyle = css`
+  color: var(--pf-t--global--text--color--subtle);
+  font-size: var(--pf-t--global--font--size--xs);
+`;
+
+const timeEstimationValueStyle = css`
+  font-weight: var(--pf-t--global--font--weight--body--bold);
+`;
+
 export const ComplexityResult: React.FC<ComplexityResultProps> = ({
   clusterName,
   complexityOutput,
   isLoading,
   error,
+  estimationByComplexity,
+  isLoadingEstimationByComplexity,
+  estimationByComplexityError,
 }) => {
   const [activeTabKey, setActiveTabKey] = useState<string | number>(0);
 
@@ -401,23 +428,112 @@ export const ComplexityResult: React.FC<ComplexityResultProps> = ({
 
   // Render By Disk & OS tab content
   const renderByDiskAndOSTab = () => {
+    if (isLoadingEstimationByComplexity) {
+      return (
+        <Stack hasGutter>
+          <StackItem>
+            <Spinner
+              size="lg"
+              aria-label="Calculating estimation by complexity"
+            />
+          </StackItem>
+          <StackItem>
+            <p>Calculating estimation by complexity for {clusterName}...</p>
+          </StackItem>
+        </Stack>
+      );
+    }
+
+    if (estimationByComplexityError) {
+      return (
+        <Alert variant="danger" isInline title="Calculation failed">
+          {estimationByComplexityError.message}
+        </Alert>
+      );
+    }
+
+    if (!estimationByComplexity) {
+      return (
+        <Stack hasGutter>
+          <StackItem>
+            <Spinner size="lg" aria-label="Loading estimation by complexity" />
+          </StackItem>
+          <StackItem>
+            <p>Loading estimation data...</p>
+          </StackItem>
+        </Stack>
+      );
+    }
+
+    const entries = estimationByComplexity.complexityByOsDisk;
+    const activeEntries = entries.filter(
+      (e: OsDiskEstimationEntry) => e.vmCount > 0,
+    );
+
     return (
       <Stack hasGutter>
         <StackItem>
-          <div className={headerStyle}>
-            <Title headingLevel="h3">Complexity by Disk & OS</Title>
-            <p className={subtitleStyle}>
-              Combined view of disk size and operating system complexity.
-            </p>
-          </div>
+          <Title headingLevel="h3">Estimation by complexity</Title>
         </StackItem>
-
         <StackItem>
-          <Card>
-            <CardBody>
-              <p>Combined disk and OS complexity analysis coming soon.</p>
-            </CardBody>
-          </Card>
+          <Table aria-label="Estimation by complexity table" variant="compact">
+            <Thead>
+              <Tr>
+                <Th>Complexity</Th>
+                <Th>VM count</Th>
+                <Th>Disk size</Th>
+                <Th>Time estimation</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {activeEntries.map((entry: OsDiskEstimationEntry) => {
+                const networkResult: SchemaEstimationResult | undefined =
+                  entry.estimation?.["network-based"];
+                const storageResult: SchemaEstimationResult | undefined =
+                  entry.estimation?.["storage-offload"];
+                return (
+                  <Tr key={entry.score}>
+                    <Td>
+                      <Badge
+                        style={{
+                          backgroundColor: COMPLEXITY_COLORS[entry.score],
+                          color: "white",
+                        }}
+                      >
+                        {COMPLEXITY_LABELS[entry.score]}
+                      </Badge>
+                    </Td>
+                    <Td>{formatNumber(entry.vmCount)}</Td>
+                    <Td>{formatDiskSize(entry.totalDiskSizeTB)}</Td>
+                    <Td>
+                      <div className={timeEstimationCellStyle}>
+                        <div>
+                          <span className={timeEstimationLabelStyle}>
+                            Network-based:{" "}
+                          </span>
+                          <span className={timeEstimationValueStyle}>
+                            {networkResult
+                              ? `${durationToHours(networkResult.maxTotalDuration)} h`
+                              : "\u2014"}
+                          </span>
+                        </div>
+                        <div>
+                          <span className={timeEstimationLabelStyle}>
+                            Storage-offload:{" "}
+                          </span>
+                          <span className={timeEstimationValueStyle}>
+                            {storageResult
+                              ? `${durationToHours(storageResult.maxTotalDuration)} h`
+                              : "\u2014"}
+                          </span>
+                        </div>
+                      </div>
+                    </Td>
+                  </Tr>
+                );
+              })}
+            </Tbody>
+          </Table>
         </StackItem>
       </Stack>
     );
@@ -433,16 +549,12 @@ export const ComplexityResult: React.FC<ComplexityResultProps> = ({
         >
           <FlexItem>
             <div className={headerStyle}>
-              <Title headingLevel="h2">Complexity</Title>
-              <p className={subtitleStyle}>
-                Estimate migration complexity across operating systems, disk
-                types, and their combination.
-              </p>
+              <Title headingLevel="h2">Migration complexity</Title>
             </div>
           </FlexItem>
           <FlexItem>
             <div className={legendContainerStyle}>
-              {[0, 1, 2, 3, 4].map((score) => (
+              {[1, 2, 3, 4, 0].map((score) => (
                 <Badge
                   key={score}
                   style={{
@@ -462,19 +574,19 @@ export const ComplexityResult: React.FC<ComplexityResultProps> = ({
         <div className={toggleGroupStyle}>
           <ToggleGroup aria-label="Complexity view selector">
             <ToggleGroupItem
-              text="By OS"
+              text="By Operation System"
               buttonId="toggle-by-os"
               isSelected={activeTabKey === 0}
               onChange={() => setActiveTabKey(0)}
             />
             <ToggleGroupItem
-              text="By Disk"
+              text="By Disk size"
               buttonId="toggle-by-disk"
               isSelected={activeTabKey === 1}
               onChange={() => setActiveTabKey(1)}
             />
             <ToggleGroupItem
-              text="By Disk & OS"
+              text="By Disk size & Operating system"
               buttonId="toggle-by-disk-os"
               isSelected={activeTabKey === 2}
               onChange={() => setActiveTabKey(2)}

--- a/src/ui/report/views/cluster-sizer/types.ts
+++ b/src/ui/report/views/cluster-sizer/types.ts
@@ -27,6 +27,8 @@ export type {
   InventoryTotals,
   MigrationComplexityRequest,
   MigrationComplexityResponse,
+  MigrationEstimationByComplexityResponse,
+  OsDiskEstimationEntry,
   SchemaEstimationResult,
   SizingOverCommitRatio,
   SizingResourceConsumption,


### PR DESCRIPTION
- Change useClusterSizingWizardViewModel to add estimationSchema and params to the endpoint migration-estimation/by-complexity
- Change ComplexityResult to add a new method renderByDiskAndOsTab to show a new table with this info: Complexity, VM Count, Disk Size and Time estimation (by network-based or storage-offload schema)


https://github.com/user-attachments/assets/090df373-a043-4fbb-af4c-dff5f9d2ada9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added migration time estimations displayed by complexity level, operating system, and disk size in a tabular format.
  * New estimation view shows VM counts, disk sizes, and duration estimates for different migration approaches.

* **UI/UX**
  * Updated tab and heading labels for improved clarity ("By Disk size & Operating system").
  * Reorganized complexity visualization with adjusted legend display order.
  * Added loading states and error handling for estimation calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->