### PR TITLE
ECOPROJECT-4304 | fix: change 'Downloading OVA' to 'Download pending' to better understanding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9434,9 +9434,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/src/ui/environment/views/VersionStatus.tsx
+++ b/src/ui/environment/views/VersionStatus.tsx
@@ -45,7 +45,7 @@ const ovaDownloadingStyle = css`
 const OvaDownloading: React.FC = () => (
   <Split hasGutter className={splitGap}>
     <SplitItem>
-      <span className={ovaDownloadingStyle}>Downloading OVA</span>
+      <span className={ovaDownloadingStyle}>Download pending</span>
     </SplitItem>
     <SplitItem>
       <Popover

--- a/src/ui/environment/views/__tests__/SourcesTable.test.tsx
+++ b/src/ui/environment/views/__tests__/SourcesTable.test.tsx
@@ -296,9 +296,9 @@ describe("SourcesTable — all status states", () => {
 
   // --- Agent version column -----------------------------------------------
 
-  it('shows "Downloading OVA" when agent is not connected and not uploaded manually', () => {
+  it('shows "Download pending" when agent is not connected and not uploaded manually', () => {
     render(<SourcesTable onAddEnvironment={vi.fn()} />);
-    expect(screen.getByText("Downloading OVA")).toBeInTheDocument();
+    expect(screen.getByText("Download pending")).toBeInTheDocument();
   });
 
   it('shows "-" for the agent version of an uploaded-manually source', () => {


### PR DESCRIPTION
<img width="1515" height="468" alt="image" src="https://github.com/user-attachments/assets/1a42412a-eae3-4810-8427-57bdc9c849a3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated status text in the environment sources interface from "Downloading OVA" to "Download pending" for clearer user communication when downloads are pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->