### PR TITLE
ECOPROJECT-4354 | feat: redesign Migration Time Estimation tab

### DIFF
--- a/src/ui/report/view-models/useClusterSizingWizardViewModel.ts
+++ b/src/ui/report/view-models/useClusterSizingWizardViewModel.ts
@@ -82,10 +82,8 @@ export const useClusterSizingWizardViewModel = (
     useState<EstimationFormValues>(DEFAULT_ESTIMATION_FORM_VALUES);
   const [sizerOutput, setSizerOutput] =
     useState<ClusterRequirementsResponse | null>(null);
-  const [migrationEstimation, setMigrationEstimation] = useState<Record<
-    string,
-    SchemaEstimationResult
-  > | null>(null);
+  const [migrationEstimation, setMigrationEstimation] =
+    useState<MigrationEstimationResponse | null>(null);
   const [complexityEstimation, setComplexityEstimation] =
     useState<MigrationComplexityResponse | null>(null);
   const [estimationByComplexity, setEstimationByComplexity] =
@@ -177,9 +175,9 @@ export const useClusterSizingWizardViewModel = (
         },
       });
 
-      const schemas = result?.estimation;
-      const hasSchemas = schemas && Object.keys(schemas).length > 0;
-      setMigrationEstimation(hasSchemas ? schemas : null);
+      const hasSchemas =
+        result?.estimation && Object.keys(result.estimation).length > 0;
+      setMigrationEstimation(hasSchemas ? result : null);
     } catch (err) {
       if (err instanceof ResponseError) {
         const message = await err.response.text();

--- a/src/ui/report/view-models/useClusterSizingWizardViewModel.ts
+++ b/src/ui/report/view-models/useClusterSizingWizardViewModel.ts
@@ -10,6 +10,7 @@ import { useAsyncFn } from "react-use";
 import { Symbols } from "../../../config/Dependencies";
 import type { IAssessmentsStore } from "../../../data/stores/interfaces/IAssessmentsStore";
 import {
+  DEFAULT_ESTIMATION_FORM_VALUES,
   DEFAULT_FORM_VALUES,
   SMT_THREADS_MAX,
   SMT_THREADS_MIN,
@@ -17,10 +18,14 @@ import {
 } from "../views/cluster-sizer/constants";
 import type {
   ClusterRequirementsResponse,
-  SchemaEstimationResult,
+  EstimationFormValues,
+  MigrationEstimationResponse,
   SizingFormValues,
 } from "../views/cluster-sizer/types";
-import { formValuesToRequest } from "../views/cluster-sizer/types";
+import {
+  estimationFormToParams,
+  formValuesToRequest,
+} from "../views/cluster-sizer/types";
 
 // ---------------------------------------------------------------------------
 // Public interface
@@ -37,7 +42,9 @@ export interface ClusterSizingWizardViewModel {
   isCalculating: boolean;
   calculateError: Error | undefined;
   calculate: () => Promise<void>;
-  migrationEstimation: Record<string, SchemaEstimationResult> | null;
+  estimationFormValues: EstimationFormValues;
+  setEstimationFormValues: (v: EstimationFormValues) => void;
+  migrationEstimation: MigrationEstimationResponse | null;
   isCalculatingEstimation: boolean;
   estimationError: Error | undefined;
   calculateEstimation: () => Promise<void>;
@@ -71,6 +78,8 @@ export const useClusterSizingWizardViewModel = (
 
   const [formValues, setFormValues] =
     useState<SizingFormValues>(DEFAULT_FORM_VALUES);
+  const [estimationFormValues, setEstimationFormValues] =
+    useState<EstimationFormValues>(DEFAULT_ESTIMATION_FORM_VALUES);
   const [sizerOutput, setSizerOutput] =
     useState<ClusterRequirementsResponse | null>(null);
   const [migrationEstimation, setMigrationEstimation] = useState<Record<
@@ -161,7 +170,11 @@ export const useClusterSizingWizardViewModel = (
     try {
       const result = await assessmentsStore.calculateMigrationEstimation({
         id: assessmentId,
-        migrationEstimationRequest: { clusterId },
+        migrationEstimationRequest: {
+          clusterId,
+          estimationSchema: ["network-based", "storage-offload"],
+          params: estimationFormToParams(estimationFormValues),
+        },
       });
 
       const schemas = result?.estimation;
@@ -184,7 +197,7 @@ export const useClusterSizingWizardViewModel = (
       setManualEstimationError(error);
       throw error;
     }
-  }, [assessmentId, assessmentsStore, clusterId]);
+  }, [assessmentId, assessmentsStore, clusterId, estimationFormValues]);
 
   const [complexityState, doCalculateComplexity] = useAsyncFn(async () => {
     setManualComplexityError(undefined);
@@ -261,14 +274,6 @@ export const useClusterSizingWizardViewModel = (
 
   const ensureEstimationForMenu = useCallback(
     (menuItem: string | null) => {
-      if (
-        menuItem === "time-estimation" &&
-        !migrationEstimation &&
-        !estimationState.loading &&
-        !manualEstimationError
-      ) {
-        void doCalculateEstimation();
-      }
       if (menuItem === "complexity") {
         if (
           !complexityEstimation &&
@@ -287,10 +292,6 @@ export const useClusterSizingWizardViewModel = (
       }
     },
     [
-      migrationEstimation,
-      estimationState.loading,
-      manualEstimationError,
-      doCalculateEstimation,
       complexityEstimation,
       complexityState.loading,
       manualComplexityError,
@@ -304,6 +305,7 @@ export const useClusterSizingWizardViewModel = (
 
   const reset = useCallback(() => {
     setFormValues(DEFAULT_FORM_VALUES);
+    setEstimationFormValues(DEFAULT_ESTIMATION_FORM_VALUES);
     setSizerOutput(null);
     setMigrationEstimation(null);
     setComplexityEstimation(null);
@@ -339,6 +341,8 @@ export const useClusterSizingWizardViewModel = (
       manualCalculateError ??
       (resetCounter > 0 ? undefined : calculateState.error),
     calculate: doCalculate,
+    estimationFormValues,
+    setEstimationFormValues,
     migrationEstimation,
     isCalculatingEstimation: estimationState.loading,
     estimationError:

--- a/src/ui/report/views/cluster-sizer/ClusterSizingWizard.tsx
+++ b/src/ui/report/views/cluster-sizer/ClusterSizingWizard.tsx
@@ -188,8 +188,13 @@ export const ClusterSizingWizard: React.FC<ClusterSizingWizardProps> = ({
       case "time-estimation":
         return (
           <RecommendationTemplate
-            preferencesTitle="Migration estimation parameters"
-            preferencesContent={<TimeEstimationForm values={vm.formValues} />}
+            preferencesTitle="Migration preferences"
+            preferencesContent={
+              <TimeEstimationForm
+                values={vm.estimationFormValues}
+                onChange={vm.setEstimationFormValues}
+              />
+            }
             resultsContent={
               <TimeEstimationResult
                 clusterName={clusterName}
@@ -205,10 +210,10 @@ export const ClusterSizingWizard: React.FC<ClusterSizingWizardProps> = ({
               vm.isCalculatingEstimation ||
               vm.estimationError,
             )}
-            generateButtonText="Calculate time estimation"
+            generateButtonText="Calculate"
             resultsTitle=""
             showAlert={false}
-            hidePreferences={true}
+            hasError={Boolean(vm.estimationError)}
           />
         );
       case "complexity":

--- a/src/ui/report/views/cluster-sizer/ComplexityResult.tsx
+++ b/src/ui/report/views/cluster-sizer/ComplexityResult.tsx
@@ -31,7 +31,7 @@ import {
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import React, { useState } from "react";
 
-import { parseDuration } from "./timeUtils";
+import { durationToHours } from "./timeUtils";
 
 interface ComplexityResultProps {
   clusterName: string;
@@ -119,9 +119,6 @@ const DISK_SIZE_LABELS: Record<number, string> = {
   3: "21-50 TB",
   4: "> 50 TB",
 };
-
-const durationToHours = (duration: string): number =>
-  Math.ceil(parseDuration(duration) / 3600);
 
 const formatDiskSize = (tb: number): string => {
   if (tb === 0) return "0 TB";

--- a/src/ui/report/views/cluster-sizer/TimeEstimationForm.tsx
+++ b/src/ui/report/views/cluster-sizer/TimeEstimationForm.tsx
@@ -1,119 +1,201 @@
+import { css } from "@emotion/css";
 import {
-  Form,
+  Flex,
+  FlexItem,
   FormGroup,
-  Grid,
-  GridItem,
+  Slider,
+  type SliderOnChangeEvent,
+  Stack,
+  StackItem,
   TextInput,
-  Title,
 } from "@patternfly/react-core";
-import React from "react";
+import React, { useCallback } from "react";
 
-import PopoverIcon from "./PopoverIcon";
-import type { SizingFormValues } from "./types";
+import { ESTIMATION_SLIDER_LIMITS } from "./constants";
+import type { EstimationFormValues } from "./types";
 
 interface TimeEstimationFormProps {
-  values: SizingFormValues;
+  values: EstimationFormValues;
+  onChange: (values: EstimationFormValues) => void;
 }
+
+const sliderRowStyle = css`
+  align-items: center;
+  gap: var(--pf-t--global--spacer--300);
+`;
+
+const inputStyle = css`
+  max-width: 80px;
+`;
+
+const inputWideStyle = css`
+  max-width: 110px;
+`;
+
+const rangeLabelsStyle = css`
+  display: flex;
+  justify-content: space-between;
+  color: var(--pf-t--global--text--color--subtle);
+  font-size: var(--pf-t--global--font--size--sm);
+  margin-top: calc(-1 * var(--pf-t--global--spacer--100));
+`;
+
+const sliderWrapperStyle = css`
+  flex: 1;
+`;
+
+interface SliderFieldProps {
+  label: string;
+  fieldId: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  minLabel: string;
+  maxLabel: string;
+  wideInput?: boolean;
+  onChange: (value: number) => void;
+}
+
+const SliderField: React.FC<SliderFieldProps> = ({
+  label,
+  fieldId,
+  value,
+  min,
+  max,
+  step,
+  minLabel,
+  maxLabel,
+  wideInput = false,
+  onChange,
+}) => {
+  const handleSliderChange = useCallback(
+    (_event: SliderOnChangeEvent, sliderValue: number) => {
+      onChange(sliderValue);
+    },
+    [onChange],
+  );
+
+  const handleInputChange = useCallback(
+    (_event: React.FormEvent<HTMLInputElement>, inputValue: string) => {
+      const parsed = parseFloat(inputValue);
+      if (!isNaN(parsed)) {
+        const clamped = Math.min(max, Math.max(min, parsed));
+        const rounded = Math.round(clamped / step) * step;
+        onChange(parseFloat(rounded.toFixed(10)));
+      }
+    },
+    [onChange, min, max, step],
+  );
+
+  return (
+    <FormGroup label={label} fieldId={fieldId}>
+      <Flex className={sliderRowStyle}>
+        <FlexItem>
+          <TextInput
+            id={fieldId}
+            type="number"
+            value={value}
+            onChange={handleInputChange}
+            aria-label={label}
+            className={wideInput ? inputWideStyle : inputStyle}
+          />
+        </FlexItem>
+        <FlexItem grow={{ default: "grow" }}>
+          <div className={sliderWrapperStyle}>
+            <Slider
+              value={value}
+              min={min}
+              max={max}
+              step={step}
+              onChange={handleSliderChange}
+              aria-label={label}
+              showBoundaries={false}
+              showTicks={false}
+            />
+            <div className={rangeLabelsStyle}>
+              <span>{minLabel}</span>
+              <span>{maxLabel}</span>
+            </div>
+          </div>
+        </FlexItem>
+      </Flex>
+    </FormGroup>
+  );
+};
 
 export const TimeEstimationForm: React.FC<TimeEstimationFormProps> = ({
   values,
+  onChange,
 }) => {
+  const limits = ESTIMATION_SLIDER_LIMITS;
+
+  const handleFieldChange = useCallback(
+    (field: keyof EstimationFormValues) => (raw: number) => {
+      onChange({ ...values, [field]: raw });
+    },
+    [values, onChange],
+  );
+
   return (
-    <Form>
-      <Grid hasGutter>
-        <GridItem span={12}>
-          <Title headingLevel="h2">Migration parameters</Title>
-        </GridItem>
+    <Stack hasGutter>
+      <StackItem>
+        <SliderField
+          label="Network transfer rate"
+          fieldId="estimation-transfer-rate"
+          value={values.transferRateMbps}
+          min={limits.transferRateMbps.min}
+          max={limits.transferRateMbps.max}
+          step={limits.transferRateMbps.step}
+          minLabel="0 Mbps"
+          maxLabel="10,000 Mbps"
+          wideInput
+          onChange={handleFieldChange("transferRateMbps")}
+        />
+      </StackItem>
 
-        <GridItem span={6}>
-          <FormGroup
-            label="Worker node CPU cores"
-            isRequired
-            fieldId="time-worker-cpu"
-            labelHelp={
-              <PopoverIcon
-                noVerticalAlign
-                headerContent="Worker node CPU cores"
-                bodyContent="The number of CPU cores allocated to each worker node."
-              />
-            }
-          >
-            <TextInput
-              id="time-worker-cpu"
-              value={String(values.customCpu)}
-              isDisabled
-              aria-label="Worker node CPU cores"
-            />
-          </FormGroup>
-        </GridItem>
+      <StackItem>
+        <SliderField
+          label="Work hours per day"
+          fieldId="estimation-work-hours"
+          value={values.workHoursPerDay}
+          min={limits.workHoursPerDay.min}
+          max={limits.workHoursPerDay.max}
+          step={limits.workHoursPerDay.step}
+          minLabel="0 hours"
+          maxLabel="24 hours"
+          onChange={handleFieldChange("workHoursPerDay")}
+        />
+      </StackItem>
 
-        <GridItem span={6}>
-          <FormGroup
-            label="Worker node memory size (GB)"
-            isRequired
-            fieldId="time-worker-memory"
-            labelHelp={
-              <PopoverIcon
-                noVerticalAlign
-                headerContent="Worker node memory size"
-                bodyContent="The amount of memory in GB allocated to each worker node."
-              />
-            }
-          >
-            <TextInput
-              id="time-worker-memory"
-              value={String(values.customMemoryGb)}
-              isDisabled
-              aria-label="Worker node memory size"
-            />
-          </FormGroup>
-        </GridItem>
+      <StackItem>
+        <SliderField
+          label="Troubleshooting time per VM"
+          fieldId="estimation-troubleshoot"
+          value={values.troubleshootMinsPerVm}
+          min={limits.troubleshootMinsPerVm.min}
+          max={limits.troubleshootMinsPerVm.max}
+          step={limits.troubleshootMinsPerVm.step}
+          minLabel="0 minutes"
+          maxLabel="180 minutes"
+          onChange={handleFieldChange("troubleshootMinsPerVm")}
+        />
+      </StackItem>
 
-        <GridItem span={6}>
-          <FormGroup
-            label="CPU overcommitment"
-            isRequired
-            fieldId="time-cpu-overcommit"
-            labelHelp={
-              <PopoverIcon
-                noVerticalAlign
-                headerContent="CPU overcommitment"
-                bodyContent="The ratio of virtual CPUs to physical cores."
-              />
-            }
-          >
-            <TextInput
-              id="time-cpu-overcommit"
-              value={`1:${values.cpuOvercommitRatio}`}
-              isDisabled
-              aria-label="CPU overcommitment ratio"
-            />
-          </FormGroup>
-        </GridItem>
-
-        <GridItem span={6}>
-          <FormGroup
-            label="Memory overcommitment"
-            isRequired
-            fieldId="time-memory-overcommit"
-            labelHelp={
-              <PopoverIcon
-                noVerticalAlign
-                headerContent="Memory overcommitment"
-                bodyContent="The ratio of virtual memory to physical memory."
-              />
-            }
-          >
-            <TextInput
-              id="time-memory-overcommit"
-              value={`1:${values.memoryOvercommitRatio}`}
-              isDisabled
-              aria-label="Memory overcommitment ratio"
-            />
-          </FormGroup>
-        </GridItem>
-      </Grid>
-    </Form>
+      <StackItem>
+        <SliderField
+          label="Post-migration engineers"
+          fieldId="estimation-engineers"
+          value={values.postMigrationEngineers}
+          min={limits.postMigrationEngineers.min}
+          max={limits.postMigrationEngineers.max}
+          step={limits.postMigrationEngineers.step}
+          minLabel="0 engineers"
+          maxLabel="50 engineers"
+          onChange={handleFieldChange("postMigrationEngineers")}
+        />
+      </StackItem>
+    </Stack>
   );
 };
 

--- a/src/ui/report/views/cluster-sizer/TimeEstimationResult.tsx
+++ b/src/ui/report/views/cluster-sizer/TimeEstimationResult.tsx
@@ -111,19 +111,23 @@ const formatHoursSubtitle = (result: SchemaEstimationResult): string => {
   const minH = durationToHours(result.minTotalDuration);
   const maxH = durationToHours(result.maxTotalDuration);
   const fmt = (h: number) => h.toLocaleString("en-US");
-  if (minH === maxH) return `${fmt(minH)} hours`;
+  if (minH === maxH) {
+    return `${fmt(minH)} ${minH === 1 ? "hour" : "hours"}`;
+  }
   return `${fmt(minH)}\u2013${fmt(maxH)} hours`;
 };
 
 const formatDetailDuration = (detail: EstimationDetail): string => {
   if (detail.duration) {
     const h = durationToHours(detail.duration);
-    return `${h.toLocaleString("en-US")} hours`;
+    return `${h.toLocaleString("en-US")} ${h === 1 ? "hour" : "hours"}`;
   }
   if (detail.minDuration && detail.maxDuration) {
     const minH = durationToHours(detail.minDuration);
     const maxH = durationToHours(detail.maxDuration);
-    if (minH === maxH) return `${minH.toLocaleString("en-US")} hours`;
+    if (minH === maxH) {
+      return `${minH.toLocaleString("en-US")} ${minH === 1 ? "hour" : "hours"}`;
+    }
     return `${minH.toLocaleString("en-US")}\u2013${maxH.toLocaleString("en-US")} hours`;
   }
   return "N/A";

--- a/src/ui/report/views/cluster-sizer/TimeEstimationResult.tsx
+++ b/src/ui/report/views/cluster-sizer/TimeEstimationResult.tsx
@@ -1,6 +1,7 @@
 import { css } from "@emotion/css";
 import type {
   EstimationDetail,
+  MigrationEstimationResponse,
   SchemaEstimationResult,
 } from "@openshift-migration-advisor/planner-sdk";
 import {
@@ -19,7 +20,7 @@ import {
 } from "@patternfly/react-core";
 import { CopyIcon } from "@patternfly/react-icons";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 
 import PopoverIcon from "./PopoverIcon";
 import {
@@ -28,11 +29,11 @@ import {
   parseStorageOffload,
   parseStorageTransfer,
 } from "./timeParsingUtils";
-import { parseDuration } from "./timeUtils";
+import { durationToHours, formatHumanDuration } from "./timeUtils";
 
 interface TimeEstimationResultProps {
   clusterName: string;
-  estimationOutput: Record<string, SchemaEstimationResult> | null;
+  estimationOutput: MigrationEstimationResponse | null;
   isLoading: boolean;
   error: Error | null;
 }
@@ -98,23 +99,6 @@ const SCHEMA_LABELS: Record<string, string> = {
 
 const getSchemaLabel = (schemaName: string): string =>
   SCHEMA_LABELS[schemaName] ?? schemaName;
-
-const durationToHours = (duration: string): number =>
-  Math.ceil(parseDuration(duration) / 3600);
-
-const formatHumanDuration = (hours: number): string => {
-  if (hours >= 730) {
-    const months = hours / 730;
-    return months % 1 === 0
-      ? `${months} months`
-      : `${months.toFixed(1)} months`;
-  }
-  if (hours >= 24) {
-    const days = Math.ceil(hours / 24);
-    return `${days} days`;
-  }
-  return `${hours} hours`;
-};
 
 const formatTotalDisplay = (result: SchemaEstimationResult): string => {
   const minH = durationToHours(result.minTotalDuration);
@@ -211,12 +195,10 @@ const buildPopoverBody = (
   </div>
 );
 
-const generatePlainText = (
-  output: Record<string, SchemaEstimationResult>,
-): string => {
+const generatePlainText = (output: MigrationEstimationResponse): string => {
   const lines: string[] = ["Migration time estimation", ""];
 
-  for (const [schemaName, result] of Object.entries(output)) {
+  for (const [schemaName, result] of Object.entries(output.estimation)) {
     lines.push(getSchemaLabel(schemaName));
     lines.push(
       `  Total: ${formatTotalDisplay(result)} (${formatHoursSubtitle(result)})`,
@@ -241,16 +223,25 @@ export const TimeEstimationResult: React.FC<TimeEstimationResultProps> = ({
   isLoading,
   error,
 }) => {
+  const canCopy = useMemo(
+    () =>
+      !!estimationOutput &&
+      typeof navigator.clipboard?.writeText === "function" &&
+      (typeof window === "undefined" || window.isSecureContext),
+    [estimationOutput],
+  );
+
   const handleCopy = useCallback(() => {
-    if (
-      !estimationOutput ||
-      !navigator.clipboard?.writeText ||
-      (typeof window !== "undefined" && !window.isSecureContext)
-    ) {
+    if (!canCopy || !estimationOutput) {
       return;
     }
-    void navigator.clipboard.writeText(generatePlainText(estimationOutput));
-  }, [estimationOutput]);
+    navigator.clipboard
+      .writeText(generatePlainText(estimationOutput))
+      .catch((err: unknown) => {
+        console.error("Failed to copy estimation to clipboard", err);
+      });
+  }, [canCopy, estimationOutput]);
+
   if (isLoading) {
     return (
       <Stack hasGutter>
@@ -275,11 +266,14 @@ export const TimeEstimationResult: React.FC<TimeEstimationResultProps> = ({
     );
   }
 
-  if (!estimationOutput || Object.keys(estimationOutput).length === 0) {
+  if (
+    !estimationOutput ||
+    Object.keys(estimationOutput.estimation).length === 0
+  ) {
     return null;
   }
 
-  const schemas = Object.entries(estimationOutput);
+  const schemas = Object.entries(estimationOutput.estimation);
   const gridSpan = schemas.length > 1 ? 6 : 12;
 
   return (
@@ -298,6 +292,7 @@ export const TimeEstimationResult: React.FC<TimeEstimationResultProps> = ({
             icon={<CopyIcon />}
             iconPosition="end"
             onClick={handleCopy}
+            isDisabled={!canCopy}
           >
             Copy as plain text
           </Button>

--- a/src/ui/report/views/cluster-sizer/TimeEstimationResult.tsx
+++ b/src/ui/report/views/cluster-sizer/TimeEstimationResult.tsx
@@ -5,6 +5,9 @@ import type {
 } from "@openshift-migration-advisor/planner-sdk";
 import {
   Alert,
+  Button,
+  Flex,
+  FlexItem,
   Grid,
   GridItem,
   List,
@@ -14,10 +17,13 @@ import {
   StackItem,
   Title,
 } from "@patternfly/react-core";
+import { CopyIcon } from "@patternfly/react-icons";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
-import React from "react";
+import React, { useCallback } from "react";
 
+import PopoverIcon from "./PopoverIcon";
 import {
+  type ParsedAssumption,
   parsePostMigrationChecks,
   parseStorageOffload,
   parseStorageTransfer,
@@ -31,81 +37,110 @@ interface TimeEstimationResultProps {
   error: Error | null;
 }
 
-const sectionStyle = css`
-  border: 1px solid var(--pf-t--global--border--color--default);
-  border-radius: var(--pf-t--global--border--radius--small);
+const cardStyle = css`
+  background-color: var(--pf-t--global--background--color--secondary--default);
+  border-radius: var(--pf-t--global--border--radius--medium);
   padding: var(--pf-t--global--spacer--400);
   height: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
+const outerCardStyle = css`
+  border: 1px solid var(--pf-t--global--border--color--default);
+  border-radius: var(--pf-t--global--border--radius--medium);
+  padding: var(--pf-t--global--spacer--400);
+`;
+
+const cardHeaderStyle = css`
+  margin-bottom: var(--pf-t--global--spacer--400);
 `;
 
 const equalHeightGridStyle = css`
   align-items: stretch;
 `;
 
-const totalTimeStyle = css`
-  font-size: var(--pf-t--global--font--size--xl);
-  font-weight: var(--pf-t--global--font--weight--body--bold);
-  margin-bottom: var(--pf-t--global--spacer--300);
-`;
-
 const schemaTitleStyle = css`
+  display: flex;
+  align-items: center;
+  gap: var(--pf-t--global--spacer--100);
   color: var(--pf-t--global--text--color--subtle);
-  margin-bottom: var(--pf-t--global--spacer--200);
-`;
-
-const assumptionsSubtitleStyle = css`
-  color: var(--pf-t--global--text--color--subtle);
-  margin-bottom: var(--pf-t--global--spacer--300);
-`;
-
-const phaseHeaderStyle = css`
+  font-size: var(--pf-t--global--font--size--sm);
   font-weight: var(--pf-t--global--font--weight--body--bold);
-  margin-top: var(--pf-t--global--spacer--300);
   margin-bottom: var(--pf-t--global--spacer--200);
+  justify-content: center;
 `;
 
-const SCHEMA_DISPLAY: Record<
-  string,
-  { summaryTitle: string; summarySubtitle: string; assumptionsTitle: string }
-> = {
-  "network-based": {
-    summaryTitle: "Migration Time Summary",
-    summarySubtitle: "Network-based Estimation",
-    assumptionsTitle: "Migration Assumptions",
-  },
-  "storage-offload": {
-    summaryTitle: "Storage-offload Estimation",
-    summarySubtitle: "Storage-offload Estimation",
-    assumptionsTitle: "Storage-offload Assumptions",
-  },
+const totalTimeStyle = css`
+  font-size: var(--pf-t--global--font--size--2xl);
+  font-weight: var(--pf-t--global--font--weight--body--bold);
+  text-align: center;
+  margin-bottom: var(--pf-t--global--spacer--100);
+`;
+
+const hoursSubtitleStyle = css`
+  font-size: var(--pf-t--global--font--size--sm);
+  color: var(--pf-t--global--text--color--subtle);
+  text-align: center;
+  margin-bottom: var(--pf-t--global--spacer--400);
+`;
+
+const popoverPhaseTitle = css`
+  font-weight: var(--pf-t--global--font--weight--body--bold);
+  margin-top: var(--pf-t--global--spacer--200);
+  margin-bottom: var(--pf-t--global--spacer--100);
+`;
+
+const SCHEMA_LABELS: Record<string, string> = {
+  "network-based": "Network-based estimation",
+  "storage-offload": "Storage-offload estimation",
 };
 
-const getSchemaDisplay = (schemaName: string) =>
-  SCHEMA_DISPLAY[schemaName] ?? {
-    summaryTitle: schemaName,
-    summarySubtitle: schemaName,
-    assumptionsTitle: `${schemaName} Assumptions`,
-  };
+const getSchemaLabel = (schemaName: string): string =>
+  SCHEMA_LABELS[schemaName] ?? schemaName;
 
 const durationToHours = (duration: string): number =>
   Math.ceil(parseDuration(duration) / 3600);
 
-const formatTotalTime = (result: SchemaEstimationResult): string => {
+const formatHumanDuration = (hours: number): string => {
+  if (hours >= 730) {
+    const months = hours / 730;
+    return months % 1 === 0
+      ? `${months} months`
+      : `${months.toFixed(1)} months`;
+  }
+  if (hours >= 24) {
+    const days = Math.ceil(hours / 24);
+    return `${days} days`;
+  }
+  return `${hours} hours`;
+};
+
+const formatTotalDisplay = (result: SchemaEstimationResult): string => {
   const minH = durationToHours(result.minTotalDuration);
   const maxH = durationToHours(result.maxTotalDuration);
-  if (minH === maxH) return `${minH} Hours`;
-  return `${minH} \u2013 ${maxH} Hours`;
+  if (minH === maxH) return formatHumanDuration(minH);
+  return `${formatHumanDuration(minH)}\u2013${formatHumanDuration(maxH)}`;
+};
+
+const formatHoursSubtitle = (result: SchemaEstimationResult): string => {
+  const minH = durationToHours(result.minTotalDuration);
+  const maxH = durationToHours(result.maxTotalDuration);
+  const fmt = (h: number) => h.toLocaleString("en-US");
+  if (minH === maxH) return `${fmt(minH)} hours`;
+  return `${fmt(minH)}\u2013${fmt(maxH)} hours`;
 };
 
 const formatDetailDuration = (detail: EstimationDetail): string => {
   if (detail.duration) {
-    return `${durationToHours(detail.duration)} Hours`;
+    const h = durationToHours(detail.duration);
+    return `${h.toLocaleString("en-US")} hours`;
   }
   if (detail.minDuration && detail.maxDuration) {
     const minH = durationToHours(detail.minDuration);
     const maxH = durationToHours(detail.maxDuration);
-    if (minH === maxH) return `${minH} Hours`;
-    return `${minH} \u2013 ${maxH} Hours`;
+    if (minH === maxH) return `${minH.toLocaleString("en-US")} hours`;
+    return `${minH.toLocaleString("en-US")}\u2013${maxH.toLocaleString("en-US")} hours`;
   }
   return "N/A";
 };
@@ -115,15 +150,19 @@ const extractDetailText = (reason: string): string => {
   const vmsMatch = reason.match(/(\d+)\s+VMs?/i);
   if (volumeMatch) {
     const gb = parseFloat(volumeMatch[1].replace(/,/g, ""));
-    return `${(gb / 1000).toFixed(1)} TB Total Volume`;
+    return `${(gb / 1000).toFixed(1)} TB total volume`;
   }
   if (vmsMatch) {
-    return `${vmsMatch[1]} Virtual Machines`;
+    return `${Number(vmsMatch[1]).toLocaleString("en-US")} VMs`;
   }
   return "";
 };
 
-const getAssumptions = (schemaName: string, phase: string, reason: string) => {
+const getAssumptions = (
+  schemaName: string,
+  phase: string,
+  reason: string,
+): ParsedAssumption => {
   if (phase.toLowerCase().includes("post-migration")) {
     return parsePostMigrationChecks(reason);
   }
@@ -133,12 +172,85 @@ const getAssumptions = (schemaName: string, phase: string, reason: string) => {
   return parseStorageTransfer(reason);
 };
 
+const renderAssumptionItems = (assumptions: ParsedAssumption) => {
+  const entries: [string, string | undefined][] = [
+    ["Workload", assumptions.workload],
+    ["Resources", assumptions.resources],
+    ["Schedule", assumptions.schedule],
+    ["Volume", assumptions.volume],
+    ["Transfer Speed", assumptions.transferSpeed],
+    ["Transfer Rate", assumptions.transferRate],
+    ["Assumption", assumptions.assumption],
+  ];
+
+  return entries
+    .filter(([, value]) => value)
+    .map(([label, value]) => (
+      <ListItem key={label}>
+        {label}: {value}
+      </ListItem>
+    ));
+};
+
+const buildPopoverBody = (
+  schemaName: string,
+  breakdownEntries: [string, EstimationDetail][],
+): React.ReactNode => (
+  <div>
+    {breakdownEntries.map(([phase, detail]) => {
+      const assumptions = getAssumptions(schemaName, phase, detail.reason);
+      const items = renderAssumptionItems(assumptions);
+      if (items.length === 0) return null;
+      return (
+        <div key={phase}>
+          <div className={popoverPhaseTitle}>{phase}</div>
+          <List>{items}</List>
+        </div>
+      );
+    })}
+  </div>
+);
+
+const generatePlainText = (
+  output: Record<string, SchemaEstimationResult>,
+): string => {
+  const lines: string[] = ["Migration time estimation", ""];
+
+  for (const [schemaName, result] of Object.entries(output)) {
+    lines.push(getSchemaLabel(schemaName));
+    lines.push(
+      `  Total: ${formatTotalDisplay(result)} (${formatHoursSubtitle(result)})`,
+    );
+
+    if (result.breakdown) {
+      for (const [phase, detail] of Object.entries(result.breakdown)) {
+        const dur = formatDetailDuration(detail);
+        const text = extractDetailText(detail.reason);
+        lines.push(`  ${phase}: ${dur}${text ? ` - ${text}` : ""}`);
+      }
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+};
+
 export const TimeEstimationResult: React.FC<TimeEstimationResultProps> = ({
   clusterName,
   estimationOutput,
   isLoading,
   error,
 }) => {
+  const handleCopy = useCallback(() => {
+    if (
+      !estimationOutput ||
+      !navigator.clipboard?.writeText ||
+      (typeof window !== "undefined" && !window.isSecureContext)
+    ) {
+      return;
+    }
+    void navigator.clipboard.writeText(generatePlainText(estimationOutput));
+  }, [estimationOutput]);
   if (isLoading) {
     return (
       <Stack hasGutter>
@@ -168,135 +280,86 @@ export const TimeEstimationResult: React.FC<TimeEstimationResultProps> = ({
   }
 
   const schemas = Object.entries(estimationOutput);
-
   const gridSpan = schemas.length > 1 ? 6 : 12;
 
   return (
-    <Stack hasGutter>
-      <StackItem>
-        <Grid hasGutter className={equalHeightGridStyle}>
-          {schemas.map(([schemaName, result]) => {
-            const display = getSchemaDisplay(schemaName);
-            const breakdownEntries = result.breakdown
-              ? Object.entries(result.breakdown)
-              : [];
+    <div className={outerCardStyle}>
+      <Flex
+        justifyContent={{ default: "justifyContentSpaceBetween" }}
+        alignItems={{ default: "alignItemsCenter" }}
+        className={cardHeaderStyle}
+      >
+        <FlexItem>
+          <Title headingLevel="h3">Migration time estimation</Title>
+        </FlexItem>
+        <FlexItem>
+          <Button
+            variant="link"
+            icon={<CopyIcon />}
+            iconPosition="end"
+            onClick={handleCopy}
+          >
+            Copy as plain text
+          </Button>
+        </FlexItem>
+      </Flex>
+      <Grid hasGutter className={equalHeightGridStyle}>
+        {schemas.map(([schemaName, result]) => {
+          const breakdownEntries: [string, EstimationDetail][] =
+            result.breakdown ? Object.entries(result.breakdown) : [];
 
-            return (
-              <GridItem key={schemaName} span={gridSpan}>
-                <div className={sectionStyle}>
-                  <Title headingLevel="h3">{display.summaryTitle}</Title>
-                  <div className={schemaTitleStyle}>
-                    {display.summarySubtitle}
-                  </div>
-                  <div className={totalTimeStyle}>
-                    Total Estimated Time: {formatTotalTime(result)}
-                  </div>
-
-                  <Table
-                    aria-label={`${schemaName} time breakdown`}
-                    variant="compact"
-                  >
-                    <Thead>
-                      <Tr>
-                        <Th>Phase</Th>
-                        <Th>Duration</Th>
-                        <Th>Details</Th>
-                      </Tr>
-                    </Thead>
-                    <Tbody>
-                      {breakdownEntries.map(([phase, detail]) => (
-                        <Tr key={phase}>
-                          <Td>{phase}</Td>
-                          <Td>{formatDetailDuration(detail)}</Td>
-                          <Td>{extractDetailText(detail.reason)}</Td>
-                        </Tr>
-                      ))}
-                    </Tbody>
-                  </Table>
-                </div>
-              </GridItem>
-            );
-          })}
-        </Grid>
-      </StackItem>
-
-      <StackItem>
-        <Grid hasGutter className={equalHeightGridStyle}>
-          {schemas.map(([schemaName, result]) => {
-            const display = getSchemaDisplay(schemaName);
-            const breakdownEntries = result.breakdown
-              ? Object.entries(result.breakdown)
-              : [];
-
-            return (
-              <GridItem key={schemaName} span={gridSpan}>
-                <div className={sectionStyle}>
-                  <Title headingLevel="h3">{display.assumptionsTitle}</Title>
-                  <p className={assumptionsSubtitleStyle}>
-                    The following parameters were used to calculate these
-                    estimates:
-                  </p>
-
-                  {breakdownEntries.map(([phase, detail]) => {
-                    const assumptions = getAssumptions(
-                      schemaName,
-                      phase,
-                      detail.reason,
-                    );
-                    return (
-                      <div key={phase}>
-                        <div className={phaseHeaderStyle}>{phase}</div>
-                        <List>
-                          {assumptions.workload && (
-                            <ListItem>
-                              <strong>Workload:</strong> {assumptions.workload}
-                            </ListItem>
-                          )}
-                          {assumptions.resources && (
-                            <ListItem>
-                              <strong>Resources:</strong>{" "}
-                              {assumptions.resources}
-                            </ListItem>
-                          )}
-                          {assumptions.schedule && (
-                            <ListItem>
-                              <strong>Schedule:</strong> {assumptions.schedule}
-                            </ListItem>
-                          )}
-                          {assumptions.volume && (
-                            <ListItem>
-                              <strong>Volume:</strong> {assumptions.volume}
-                            </ListItem>
-                          )}
-                          {assumptions.transferSpeed && (
-                            <ListItem>
-                              <strong>Transfer Speed:</strong>{" "}
-                              {assumptions.transferSpeed}
-                            </ListItem>
-                          )}
-                          {assumptions.transferRate && (
-                            <ListItem>
-                              <strong>Transfer Rate:</strong>{" "}
-                              {assumptions.transferRate}
-                            </ListItem>
-                          )}
-                          {assumptions.assumption && (
-                            <ListItem>
-                              <strong>Assumption:</strong>{" "}
-                              {assumptions.assumption}
-                            </ListItem>
-                          )}
-                        </List>
+          return (
+            <GridItem key={schemaName} span={gridSpan}>
+              <div className={cardStyle}>
+                <div className={schemaTitleStyle}>
+                  <span>{getSchemaLabel(schemaName)}</span>
+                  <PopoverIcon
+                    noVerticalAlign
+                    headerContent={getSchemaLabel(schemaName)}
+                    bodyContent={
+                      <div>
+                        <p>Estimates are based on the following parameters:</p>
+                        {buildPopoverBody(schemaName, breakdownEntries)}
                       </div>
-                    );
-                  })}
+                    }
+                  />
                 </div>
-              </GridItem>
-            );
-          })}
-        </Grid>
-      </StackItem>
-    </Stack>
+
+                <Title headingLevel="h2" className={totalTimeStyle}>
+                  {formatTotalDisplay(result)}
+                </Title>
+
+                <div className={hoursSubtitleStyle}>
+                  {formatHoursSubtitle(result)}
+                </div>
+
+                <Table
+                  aria-label={`${schemaName} time breakdown`}
+                  variant="compact"
+                >
+                  <Thead>
+                    <Tr>
+                      <Th>Phase</Th>
+                      <Th>Duration</Th>
+                      <Th>Details</Th>
+                    </Tr>
+                  </Thead>
+                  <Tbody>
+                    {breakdownEntries.map(([phase, detail]) => (
+                      <Tr key={phase}>
+                        <Td>{phase}</Td>
+                        <Td>{formatDetailDuration(detail)}</Td>
+                        <Td>{extractDetailText(detail.reason)}</Td>
+                      </Tr>
+                    ))}
+                  </Tbody>
+                </Table>
+              </div>
+            </GridItem>
+          );
+        })}
+      </Grid>
+    </div>
   );
 };
 

--- a/src/ui/report/views/cluster-sizer/__tests__/ClusterSizingWizard.test.tsx
+++ b/src/ui/report/views/cluster-sizer/__tests__/ClusterSizingWizard.test.tsx
@@ -20,6 +20,8 @@ const mockCalculateEstimation = vi.fn();
 const mockCalculateComplexity = vi.fn();
 const mockEnsureEstimationForMenu = vi.fn();
 
+const mockSetEstimationFormValues = vi.fn();
+
 const mockViewModel = {
   formValues: {
     clusterMode: "full-ha" as const,
@@ -36,6 +38,13 @@ const mockViewModel = {
     controlPlaneMemoryGb: 32,
   },
   setFormValues: mockSetFormValues,
+  estimationFormValues: {
+    transferRateMbps: 5000,
+    workHoursPerDay: 12,
+    troubleshootMinsPerVm: 90,
+    postMigrationEngineers: 25,
+  },
+  setEstimationFormValues: mockSetEstimationFormValues,
   calculate: mockCalculate,
   isCalculating: false,
   sizerOutput: null,

--- a/src/ui/report/views/cluster-sizer/__tests__/timeUtils.test.ts
+++ b/src/ui/report/views/cluster-sizer/__tests__/timeUtils.test.ts
@@ -111,14 +111,24 @@ describe("formatHumanDuration", () => {
     expect(formatHumanDuration(23)).toBe("23 hours");
   });
 
+  it("uses singular 'hour' when value is 1", () => {
+    expect(formatHumanDuration(1)).toBe("1 hour");
+  });
+
+  it("formats 24 hours as singular day", () => {
+    expect(formatHumanDuration(24)).toBe("1 day");
+  });
+
   it("formats 24+ hours as days (rounded up)", () => {
-    expect(formatHumanDuration(24)).toBe("1 days");
     expect(formatHumanDuration(48)).toBe("2 days");
     expect(formatHumanDuration(49)).toBe("3 days");
   });
 
-  it("formats 730+ hours as months", () => {
-    expect(formatHumanDuration(730)).toBe("1 months");
+  it("formats 730 hours as singular month", () => {
+    expect(formatHumanDuration(730)).toBe("1 month");
+  });
+
+  it("formats multiple months", () => {
     expect(formatHumanDuration(1460)).toBe("2 months");
   });
 

--- a/src/ui/report/views/cluster-sizer/__tests__/timeUtils.test.ts
+++ b/src/ui/report/views/cluster-sizer/__tests__/timeUtils.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  durationToHours,
+  formatDuration,
+  formatHumanDuration,
+  parseDuration,
+} from "../timeUtils";
+
+// ---------------------------------------------------------------------------
+// parseDuration
+// ---------------------------------------------------------------------------
+
+describe("parseDuration", () => {
+  it("parses hours, minutes and seconds", () => {
+    expect(parseDuration("989h19m27s")).toBe(989 * 3600 + 19 * 60 + 27);
+  });
+
+  it("parses fractional seconds", () => {
+    expect(parseDuration("1h0m30.5s")).toBeCloseTo(3630.5);
+  });
+
+  it("parses standalone seconds", () => {
+    expect(parseDuration("90s")).toBe(90);
+  });
+
+  it("parses milliseconds", () => {
+    expect(parseDuration("500ms")).toBeCloseTo(0.5);
+  });
+
+  it("parses microseconds (us)", () => {
+    expect(parseDuration("1000us")).toBeCloseTo(0.001);
+  });
+
+  it("parses microseconds (µs / μs)", () => {
+    expect(parseDuration("1000µs")).toBeCloseTo(0.001);
+    expect(parseDuration("1000μs")).toBeCloseTo(0.001);
+  });
+
+  it("parses nanoseconds", () => {
+    expect(parseDuration("1000000000ns")).toBeCloseTo(1);
+  });
+
+  it("returns 0 for an empty string", () => {
+    expect(parseDuration("")).toBe(0);
+  });
+
+  it("handles a complex Go duration with fractional seconds", () => {
+    const seconds = parseDuration("989h19m27.587096774s");
+    expect(seconds).toBeCloseTo(989 * 3600 + 19 * 60 + 27.587096774, 5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatDuration
+// ---------------------------------------------------------------------------
+
+describe("formatDuration", () => {
+  it("formats days, hours and minutes", () => {
+    expect(formatDuration("49h30m0s")).toBe("2 days 1 hour 30 minutes");
+  });
+
+  it("returns '0 minutes' for zero-length durations", () => {
+    expect(formatDuration("0s")).toBe("0 minutes");
+    expect(formatDuration("")).toBe("0 minutes");
+  });
+
+  it("uses singular forms correctly", () => {
+    expect(formatDuration("25h1m15s")).toBe("1 day 1 hour 1 minute");
+  });
+
+  it("omits zero-valued higher units", () => {
+    expect(formatDuration("45m0s")).toBe("45 minutes");
+  });
+
+  it("omits minutes when exactly zero but has larger units", () => {
+    expect(formatDuration("48h0m0s")).toBe("2 days");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// durationToHours
+// ---------------------------------------------------------------------------
+
+describe("durationToHours", () => {
+  it("returns 1 for anything under an hour", () => {
+    expect(durationToHours("30m")).toBe(1);
+    expect(durationToHours("1s")).toBe(1);
+  });
+
+  it("returns exact hours for whole-hour durations", () => {
+    expect(durationToHours("2h0m0s")).toBe(2);
+  });
+
+  it("rounds up partial hours", () => {
+    expect(durationToHours("2h1m0s")).toBe(3);
+  });
+
+  it("handles large durations", () => {
+    expect(durationToHours("989h19m27s")).toBe(990);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatHumanDuration
+// ---------------------------------------------------------------------------
+
+describe("formatHumanDuration", () => {
+  it("formats small values as hours", () => {
+    expect(formatHumanDuration(5)).toBe("5 hours");
+    expect(formatHumanDuration(23)).toBe("23 hours");
+  });
+
+  it("formats 24+ hours as days (rounded up)", () => {
+    expect(formatHumanDuration(24)).toBe("1 days");
+    expect(formatHumanDuration(48)).toBe("2 days");
+    expect(formatHumanDuration(49)).toBe("3 days");
+  });
+
+  it("formats 730+ hours as months", () => {
+    expect(formatHumanDuration(730)).toBe("1 months");
+    expect(formatHumanDuration(1460)).toBe("2 months");
+  });
+
+  it("formats fractional months with one decimal", () => {
+    expect(formatHumanDuration(1095)).toBe("1.5 months");
+  });
+});

--- a/src/ui/report/views/cluster-sizer/constants.ts
+++ b/src/ui/report/views/cluster-sizer/constants.ts
@@ -1,5 +1,6 @@
 import type {
   ClusterMode,
+  EstimationFormValues,
   HAReplicaCount,
   MemoryOvercommitRatio,
   OvercommitRatio,
@@ -223,6 +224,23 @@ export const DEFAULT_FORM_VALUES: SizingFormValues = {
   controlPlaneCpu: 16,
   controlPlaneMemoryGb: 32,
 };
+
+/**
+ * Default migration estimation form values
+ */
+export const DEFAULT_ESTIMATION_FORM_VALUES: EstimationFormValues = {
+  transferRateMbps: 5000,
+  workHoursPerDay: 12,
+  troubleshootMinsPerVm: 90,
+  postMigrationEngineers: 25,
+};
+
+export const ESTIMATION_SLIDER_LIMITS = {
+  transferRateMbps: { min: 0.1, max: 10_000, step: 0.1 },
+  workHoursPerDay: { min: 0.5, max: 24, step: 0.5 },
+  troubleshootMinsPerVm: { min: 1, max: 180, step: 1 },
+  postMigrationEngineers: { min: 1, max: 50, step: 1 },
+} as const;
 
 /**
  * Validation constraints for custom worker node configuration

--- a/src/ui/report/views/cluster-sizer/timeUtils.ts
+++ b/src/ui/report/views/cluster-sizer/timeUtils.ts
@@ -78,13 +78,14 @@ export const durationToHours = (duration: string): number =>
 export const formatHumanDuration = (hours: number): string => {
   if (hours >= 730) {
     const months = hours / 730;
+    const label = months === 1 ? "month" : "months";
     return months % 1 === 0
-      ? `${months} months`
-      : `${months.toFixed(1)} months`;
+      ? `${months} ${label}`
+      : `${months.toFixed(1)} ${label}`;
   }
   if (hours >= 24) {
     const days = Math.ceil(hours / 24);
-    return `${days} days`;
+    return `${days} ${days === 1 ? "day" : "days"}`;
   }
-  return `${hours} hours`;
+  return `${hours} ${hours === 1 ? "hour" : "hours"}`;
 };

--- a/src/ui/report/views/cluster-sizer/timeUtils.ts
+++ b/src/ui/report/views/cluster-sizer/timeUtils.ts
@@ -64,3 +64,27 @@ export const formatDuration = (duration: string): string => {
 
   return parts.join(" ");
 };
+
+/**
+ * Converts a Go duration string to a whole number of hours (rounded up).
+ */
+export const durationToHours = (duration: string): number =>
+  Math.ceil(parseDuration(duration) / 3600);
+
+/**
+ * Formats a number of hours into the most appropriate human-readable unit
+ * (months, days, or hours).
+ */
+export const formatHumanDuration = (hours: number): string => {
+  if (hours >= 730) {
+    const months = hours / 730;
+    return months % 1 === 0
+      ? `${months} months`
+      : `${months.toFixed(1)} months`;
+  }
+  if (hours >= 24) {
+    const days = Math.ceil(hours / 24);
+    return `${days} days`;
+  }
+  return `${hours} hours`;
+};

--- a/src/ui/report/views/cluster-sizer/types.ts
+++ b/src/ui/report/views/cluster-sizer/types.ts
@@ -96,6 +96,32 @@ export interface SizingFormValues {
 export type WizardStep = "input" | "result";
 
 /**
+ * User input for migration time estimation parameters (form state)
+ */
+export interface EstimationFormValues {
+  /** Network transfer rate in Mbps */
+  transferRateMbps: number;
+  /** Work hours per day */
+  workHoursPerDay: number;
+  /** Troubleshooting time per VM in minutes */
+  troubleshootMinsPerVm: number;
+  /** Number of post-migration engineers */
+  postMigrationEngineers: number;
+}
+
+/**
+ * Convert estimation form values to the params map expected by the API
+ */
+export const estimationFormToParams = (
+  values: EstimationFormValues,
+): Record<string, number> => ({
+  transfer_rate_mbps: values.transferRateMbps,
+  work_hours_per_day: values.workHoursPerDay,
+  troubleshoot_mins_per_vm: values.troubleshootMinsPerVm,
+  post_migration_engineers: values.postMigrationEngineers,
+});
+
+/**
  * Mapping from numeric CPU over-commit ratio to API enum value
  */
 const CPU_OVERCOMMIT_RATIO_MAP: Record<


### PR DESCRIPTION
- Send user-configurable params (transfer_rate_mbps, work_hours_per_day, post_migration_engineers) to the migration-estimation endpoint.
- Replace read-only form with interactive sliders, show network-based and storage-offload results in bordered cards with popover assumptions and copy-as-plain-text support.
- Added min values for the params:
<img width="1088" height="130" alt="image" src="https://github.com/user-attachments/assets/74b1561e-6ad9-4a21-b45b-27992892b62a" />
- Extract the functions formatting the duration in the same place with some basic tests



https://github.com/user-attachments/assets/81c4a0d3-7b42-4576-a57a-dcfbe44d3a92



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editable sliders/fields for migration time estimation and "Copy as plain text" for results

* **Improvements**
  * Estimation inputs are persisted and trigger recalculation when changed
  * Streamlined migration preferences UI and updated action text
  * Clearer, localized duration formatting and more concise per-phase assumption display

* **Tests**
  * View model tests updated to include estimation form state handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->