### PR TITLE
ECOPROJECT-4400 | fix: add more options in the agent version column in the Environments table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8202,9 +8202,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
       "optionalDependencies": {

--- a/src/ui/environment/views/SourcesTable.tsx
+++ b/src/ui/environment/views/SourcesTable.tsx
@@ -564,6 +564,7 @@ export const SourcesTable: React.FC<SourceTableProps> = ({
                         Boolean(source.onPremises) &&
                         source.inventory !== undefined
                       }
+                      agentVersion={source.agentVersion}
                       agentVersionWarning={source.agentVersionWarning}
                     />
                   </Td>

--- a/src/ui/environment/views/VersionStatus.tsx
+++ b/src/ui/environment/views/VersionStatus.tsx
@@ -15,7 +15,7 @@ import React from "react";
 
 import { VCenterSetupInstructions } from "../../core/components/VCenterSetupInstructions";
 
-const VALUE_NOT_AVAILABLE = "-";
+const VALUE_NOT_AVAILABLE = "N/A";
 
 const splitGap = css`
   gap: 0.5rem;
@@ -69,6 +69,61 @@ const OvaDownloading: React.FC = () => (
   </Split>
 );
 
+const OvaDownloaded: React.FC = () => (
+  <Split hasGutter className={splitGap}>
+    <SplitItem>
+      <span className={ovaDownloadingStyle}>OVA downloaded</span>
+    </SplitItem>
+    <SplitItem>
+      <Popover
+        aria-label="OVA installation instructions"
+        headerContent="Install the OVA in your vCenter"
+        headerComponent="h2"
+        bodyContent={<VCenterSetupInstructions />}
+        minWidth="600px"
+      >
+        <Button
+          variant="plain"
+          aria-label="OVA installation instructions"
+          className={popoverButton}
+        >
+          <Icon isInline>
+            <QuestionCircleIcon color={globalInfoColor.value} />
+          </Icon>
+        </Button>
+      </Popover>
+    </SplitItem>
+  </Split>
+);
+
+const NotAvailable: React.FC<{ warning?: string | null }> = ({ warning }) => (
+  <Split hasGutter className={splitGap}>
+    <SplitItem>
+      <span>{VALUE_NOT_AVAILABLE}</span>
+    </SplitItem>
+    {warning && (
+      <SplitItem>
+        <Popover
+          aria-label="Version information"
+          headerContent="Version Information"
+          headerComponent="h2"
+          bodyContent={<div>{warning}</div>}
+        >
+          <Button
+            variant="plain"
+            aria-label="Version information"
+            className={popoverButton}
+          >
+            <Icon isInline>
+              <InfoCircleIcon color={globalInfoColor.value} />
+            </Icon>
+          </Button>
+        </Popover>
+      </SplitItem>
+    )}
+  </Split>
+);
+
 const VersionWarning: React.FC<{ warning: string }> = ({ warning }) => (
   <Split hasGutter className={splitGap}>
     <SplitItem>
@@ -99,23 +154,51 @@ const VersionWarning: React.FC<{ warning: string }> = ({ warning }) => (
 // Main component
 // ---------------------------------------------------------------------------
 
+/**
+ * Renders the "Agent Version" column cell in the Sources table.
+ *
+ * The displayed value is derived from three inputs:
+ *
+ * | displayStatus                 | isUploadedManually | agentVersion | agentVersionWarning | Renders                             |
+ * |-------------------------------|--------------------|--------------|---------------------|-------------------------------------|
+ * | `not-connected`               | `false`            | falsy        | any                 | "Download pending" (blue) + popover |
+ * | `not-connected`               | `false`            | truthy       | any                 | "OVA downloaded" (blue) + popover   |
+ * | `not-connected`               | `true`             | any          | falsy               | "N/A"                               |
+ * | `not-connected`               | `true`             | any          | truthy              | "N/A" (blue info icon) + popover    |
+ * | `waiting-for-credentials`     | n/a                | any          | falsy               | "Up to date" (green)                |
+ * | `waiting-for-credentials`     | n/a                | any          | truthy              | "Outdated" (yellow) + popover       |
+ * | `gathering-initial-inventory` | n/a                | any          | falsy               | "Up to date" (green)                |
+ * | `gathering-initial-inventory` | n/a                | any          | truthy              | "Outdated" (yellow) + popover       |
+ * | `error`                       | n/a                | any          | falsy               | "Up to date" (green)                |
+ * | `error`                       | n/a                | any          | truthy              | "Outdated" (yellow) + popover       |
+ * | `up-to-date`                  | n/a                | any          | falsy               | "Up to date" (green)                |
+ * | `up-to-date`                  | n/a                | any          | truthy              | "Outdated" (yellow) + popover       |
+ *
+ * `isUploadedManually` = `source.onPremises === true && source.inventory !== undefined`.
+ * `agentVersion` is stored by the backend when the OVA is downloaded; its presence means
+ * the OVA has been downloaded (and likely deployed in vCenter) even if the agent has not
+ * yet connected back.
+ * `agentVersionWarning` comes directly from the `Source.agentVersionWarning` API field.
+ */
 type VersionStatusProps = {
   displayStatus: Agent["status"];
   isUploadedManually: boolean;
+  agentVersion?: string | null;
   agentVersionWarning?: string | null;
 };
 
 export const VersionStatus: React.FC<VersionStatusProps> = ({
   displayStatus,
   isUploadedManually,
+  agentVersion,
   agentVersionWarning,
 }) => {
   if (displayStatus === "not-connected" && !isUploadedManually) {
-    return <OvaDownloading />;
+    return agentVersion ? <OvaDownloaded /> : <OvaDownloading />;
   }
 
   if (displayStatus === "not-connected") {
-    return <>{VALUE_NOT_AVAILABLE}</>;
+    return <NotAvailable warning={agentVersionWarning} />;
   }
 
   if (agentVersionWarning) {

--- a/src/ui/environment/views/__tests__/SourcesTable.test.tsx
+++ b/src/ui/environment/views/__tests__/SourcesTable.test.tsx
@@ -120,18 +120,35 @@ const makeSource = (
   } as Source);
 
 const ALL_STATUS_SOURCES: SourceModel[] = [
-  // 1. Not connected — no agent → "OVA downloading"
+  // 1. Not connected — no agent, no agentVersion → "Download pending"
   makeSource({
     id: "src-ova-downloading",
     name: "Lab vCenter (OVA downloading)",
   }),
 
-  // 2. Uploaded manually — no agent, onPremises with inventory
+  // 2. Not connected — no agent, agentVersion set → "OVA downloaded"
+  makeSource({
+    id: "src-ova-downloaded",
+    name: "Lab vCenter (OVA downloaded)",
+    agentVersion: "1.4.0",
+  }),
+
+  // 3. Uploaded manually — no agent, onPremises with inventory
   makeSource({
     id: "src-uploaded-manually",
     name: "On-prem vCenter (uploaded)",
     onPremises: true,
     inventory: SAMPLE_INVENTORY,
+  }),
+
+  // 4. Uploaded manually — with agentVersionWarning → "N/A" + popover
+  makeSource({
+    id: "src-uploaded-manually-warning",
+    name: "On-prem vCenter (uploaded, warning)",
+    onPremises: true,
+    inventory: SAMPLE_INVENTORY,
+    agentVersionWarning:
+      "No version information available for this OVA. Current system version: release-0.12-093b9bb. Consider downloading a new OVA to ensure compatibility.",
   }),
 
   // 3. Waiting for credentials
@@ -256,20 +273,24 @@ describe("SourcesTable — all status states", () => {
     render(<SourcesTable onAddEnvironment={vi.fn()} />);
     const table = screen.getByRole("grid", { name: "Sources table" });
     const rows = within(table).getAllByRole("row");
-    // header row + 7 data rows
+    // header row + 9 data rows
     expect(rows).toHaveLength(1 + ALL_STATUS_SOURCES.length);
   });
 
   // --- Discovery VM Status column -----------------------------------------
 
-  it('shows "Not connected" for a source with no agent', () => {
+  it('shows "Not connected" for sources with no agent', () => {
     render(<SourcesTable onAddEnvironment={vi.fn()} />);
-    expect(screen.getByText("Not connected")).toBeInTheDocument();
+    // Two not-connected sources: one with no agentVersion, one with agentVersion set
+    const labels = screen.getAllByText("Not connected");
+    expect(labels.length).toBeGreaterThanOrEqual(2);
   });
 
-  it('shows "Uploaded manually" for an on-premises source with inventory', () => {
+  it('shows "Uploaded manually" for on-premises sources with inventory', () => {
     render(<SourcesTable onAddEnvironment={vi.fn()} />);
-    expect(screen.getByText("Uploaded manually")).toBeInTheDocument();
+    // Two uploaded-manually sources: one without warning, one with agentVersionWarning
+    const labels = screen.getAllByText("Uploaded manually");
+    expect(labels.length).toBeGreaterThanOrEqual(2);
   });
 
   it('shows "Waiting for credentials" status', () => {
@@ -296,12 +317,31 @@ describe("SourcesTable — all status states", () => {
 
   // --- Agent version column -----------------------------------------------
 
-  it('shows "Download pending" when agent is not connected and not uploaded manually', () => {
+  it('shows "Download pending" when agent is not connected, no agentVersion', () => {
     render(<SourcesTable onAddEnvironment={vi.fn()} />);
     expect(screen.getByText("Download pending")).toBeInTheDocument();
   });
 
-  it('shows "-" for the agent version of an uploaded-manually source', () => {
+  it('shows "OVA downloaded" when not connected but agentVersion is set', () => {
+    mockVm = makeBaseVm({
+      sources: [
+        makeSource({
+          id: "src-ova-downloaded-only",
+          name: "OVA downloaded only",
+          agentVersion: "1.4.0",
+        }),
+      ],
+    });
+
+    render(<SourcesTable onAddEnvironment={vi.fn()} />);
+
+    const table = screen.getByRole("grid", { name: "Sources table" });
+    const dataRow = within(table).getAllByRole("row")[1];
+    const cells = within(dataRow).getAllByRole("cell");
+    expect(cells[2]).toHaveTextContent("OVA downloaded");
+  });
+
+  it('shows "N/A" for the agent version of an uploaded-manually source', () => {
     mockVm = makeBaseVm({
       sources: [
         makeSource({
@@ -319,7 +359,32 @@ describe("SourcesTable — all status states", () => {
     const dataRow = within(table).getAllByRole("row")[1];
     const cells = within(dataRow).getAllByRole("cell");
     // Agent version is the 3rd column (index 2)
-    expect(cells[2]).toHaveTextContent("-");
+    expect(cells[2]).toHaveTextContent("N/A");
+  });
+
+  it('shows "N/A" with an info popover when uploaded manually and agentVersionWarning is set', () => {
+    mockVm = makeBaseVm({
+      sources: [
+        makeSource({
+          id: "src-uploaded-warning",
+          name: "Uploaded with warning",
+          onPremises: true,
+          inventory: SAMPLE_INVENTORY,
+          agentVersionWarning:
+            "No version information available for this OVA. Current system version: release-0.12-093b9bb. Consider downloading a new OVA to ensure compatibility.",
+        }),
+      ],
+    });
+
+    render(<SourcesTable onAddEnvironment={vi.fn()} />);
+
+    const table = screen.getByRole("grid", { name: "Sources table" });
+    const dataRow = within(table).getAllByRole("row")[1];
+    const cells = within(dataRow).getAllByRole("cell");
+    expect(cells[2]).toHaveTextContent("N/A");
+    expect(
+      within(cells[2]).getByRole("button", { name: "Version information" }),
+    ).toBeInTheDocument();
   });
 
   it('shows "Up to date" in the agent version column for sources with a current agent', () => {


### PR DESCRIPTION

- VALUE_NOT_AVAILABLE changed from "-" to "N/A"
- New NotAvailable sub-component: renders "N/A" and, when agentVersionWarning is present, a blue info icon that opens a popover with the warning message
- The not-connected + isUploadedManually branch now returns <NotAvailable warning={agentVersionWarning} /> instead of the bare dash

<img width="1240" height="600" alt="image" src="https://github.com/user-attachments/assets/29b4fa86-7431-47e2-839f-312116fed73c" />
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated status display text for consistency

* **New Features**
  * Enhanced status indicators to reflect agent version information
  * Added conditional warning information display for unavailable statuses
  * Improved OVA download feedback, distinguishing between completed and pending states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->