### PR TITLE
ECOPROJECT-4412 | fix: solving issues in Dark mode

### DIFF
--- a/dev/src/AppShell.tsx
+++ b/dev/src/AppShell.tsx
@@ -1,7 +1,9 @@
 import {
   Brand,
+  Button,
   Masthead,
   MastheadBrand,
+  MastheadContent,
   MastheadLogo,
   MastheadMain,
   MastheadToggle,
@@ -10,16 +12,29 @@ import {
   PageSidebar,
   PageSidebarBody,
   PageToggleButton,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
 } from "@patternfly/react-core";
-import { useState } from "react";
+import MoonIcon from "@patternfly/react-icons/dist/esm/icons/moon-icon";
+import SunIcon from "@patternfly/react-icons/dist/esm/icons/sun-icon";
+import { useEffect, useState } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 import MainApp from "../../src/MainApp";
 
+const DARK_CLASS = "pf-v6-theme-dark";
 const logoUrl = new URL("/oma-logo.svg", import.meta.url);
 
 export const AppShell: React.FC = () => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [isDark, setIsDark] = useState(() =>
+    document.documentElement.classList.contains(DARK_CLASS),
+  );
+
+  useEffect(() => {
+    document.documentElement.classList.toggle(DARK_CLASS, isDark);
+  }, [isDark]);
 
   const onSidebarToggle = () => {
     setIsSidebarOpen(!isSidebarOpen);
@@ -47,6 +62,22 @@ export const AppShell: React.FC = () => {
           </MastheadLogo>
         </MastheadBrand>
       </MastheadMain>
+      <MastheadContent>
+        <Toolbar>
+          <ToolbarContent>
+            <ToolbarItem align={{ default: "alignEnd" }}>
+              <Button
+                variant="plain"
+                aria-label={
+                  isDark ? "Switch to light mode" : "Switch to dark mode"
+                }
+                onClick={() => setIsDark((d) => !d)}
+                icon={isDark ? <SunIcon /> : <MoonIcon />}
+              />
+            </ToolbarItem>
+          </ToolbarContent>
+        </Toolbar>
+      </MastheadContent>
     </Masthead>
   );
 

--- a/src/ui/report/views/assessment-report/StorageOverview.tsx
+++ b/src/ui/report/views/assessment-report/StorageOverview.tsx
@@ -270,13 +270,22 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
   const smallFontTheme = getCustomTheme(ChartThemeColor.multiUnordered, {
     axis: {
       style: {
-        tickLabels: { fontSize: 8 },
-        axisLabel: { fontSize: 8 },
+        tickLabels: {
+          fontSize: 8,
+          fill: "var(--pf-t--global--text--color--regular)",
+        },
+        axisLabel: {
+          fontSize: 8,
+          fill: "var(--pf-t--global--text--color--regular)",
+        },
       },
     },
     legend: {
       style: {
-        labels: { fontSize: 8 },
+        labels: {
+          fontSize: 8,
+          fill: "var(--pf-t--global--text--color--regular)",
+        },
       },
     },
   });
@@ -381,7 +390,10 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
                         tickFormat={(x: string) => String(x)}
                         style={{
                           axis: { stroke: "none" },
-                          tickLabels: { fontSize: 8 },
+                          tickLabels: {
+                            fontSize: 8,
+                            fill: "var(--pf-t--global--text--color--regular)",
+                          },
                         }}
                       />
                       <ChartBar
@@ -499,7 +511,10 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
                       }}
                       style={{
                         axis: { stroke: "none" },
-                        tickLabels: { fontSize: 8 },
+                        tickLabels: {
+                          fontSize: 8,
+                          fill: "var(--pf-t--global--text--color--regular)",
+                        },
                       }}
                     />
                     <ChartBar

--- a/src/ui/report/views/cluster-sizer/ComplexityResult.tsx
+++ b/src/ui/report/views/cluster-sizer/ComplexityResult.tsx
@@ -227,15 +227,16 @@ export const ComplexityResult: React.FC<ComplexityResultProps> = ({
                   labelComponent={
                     <ChartTooltip
                       style={{
-                        fontSize: 8,
+                        fontSize: 9,
                         fill: "var(--pf-t--global--text--color--inverse)",
                       }}
                       flyoutStyle={{
                         stroke:
-                          "var(--pf-t--global--background--color--inverse)",
+                          "var(--pf-t--global--background--color--inverse--default)",
                         strokeWidth: 1,
-                        fill: "var(--pf-t--global--background--color--inverse)",
+                        fill: "var(--pf-t--global--background--color--inverse--default)",
                       }}
+                      flyoutPadding={{ top: 6, bottom: 6, left: 10, right: 10 }}
                     />
                   }
                   constrainToVisibleArea
@@ -380,9 +381,10 @@ export const ComplexityResult: React.FC<ComplexityResultProps> = ({
                       fill: "var(--pf-t--global--text--color--inverse)",
                     }}
                     flyoutStyle={{
-                      stroke: "var(--pf-t--global--background--color--inverse)",
+                      stroke:
+                        "var(--pf-t--global--background--color--inverse--default)",
                       strokeWidth: 1,
-                      fill: "var(--pf-t--global--background--color--inverse)",
+                      fill: "var(--pf-t--global--background--color--inverse--default)",
                     }}
                   />
                 }


### PR DESCRIPTION
- On the Assessment Report page → Disks tab → Virtual Machine Count by Disk Type: add contrast to the legend in dark mode
<img width="909" height="540" alt="Captura desde 2026-04-17 10-28-42" src="https://github.com/user-attachments/assets/970d7409-ea5b-46ec-b68c-76acfa927248" />

- On Recommendations → Migration complexity : add contrast in tooltips when we hover in the charts
<img width="1008" height="571" alt="Captura desde 2026-04-17 10-38-46" src="https://github.com/user-attachments/assets/d6765474-55cb-48c4-8775-a4bb4b085f48" />

<img width="1008" height="571" alt="Captura desde 2026-04-17 10-39-33" src="https://github.com/user-attachments/assets/8739f36d-33a8-442e-9b15-ec88deca0519" />
