### PR TITLE
ECOPROJECT-4322 | fix: update disk size tier legend for new backend granulatiry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@emotion/css": "^11.13.5",
-        "@openshift-migration-advisor/planner-sdk": "0.10.0-783d8b3a2dc4",
+        "@openshift-migration-advisor/planner-sdk": "0.11.0-92891f5da8a7",
         "@patternfly/react-charts": "7.4.9",
         "@patternfly/react-core": "^6.4.1",
         "@patternfly/react-icons": "^6.4.0",
@@ -2230,25 +2230,10 @@
         "eslint-scope": "5.1.1"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@openshift-migration-advisor/planner-sdk": {
-      "version": "0.10.0-783d8b3a2dc4",
-      "resolved": "https://registry.npmjs.org/@openshift-migration-advisor/planner-sdk/-/planner-sdk-0.10.0-783d8b3a2dc4.tgz",
-      "integrity": "sha512-Bn3+y6QyiA9u6iZ0yxRTMEJA0UUM1R0z0c32t/315yRw9ZJQ4Pnvar3AmJrRV1RBSJjvzcchR+73sUzpFXHK5Q==",
+      "version": "0.11.0-92891f5da8a7",
+      "resolved": "https://registry.npmjs.org/@openshift-migration-advisor/planner-sdk/-/planner-sdk-0.11.0-92891f5da8a7.tgz",
+      "integrity": "sha512-Gqq84zg7EYXZZnAQg5Uv4mknvlc0GFiYNk5igg2W41vxSJY4AHn4fKpr8kkDLyarK13IgAfW7hu4sd/ada9LwA==",
       "license": "Apache-2.0"
     },
     "node_modules/@openshift/dynamic-plugin-sdk": {
@@ -18703,24 +18688,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@emotion/css": "^11.13.5",
-    "@openshift-migration-advisor/planner-sdk": "0.10.0-783d8b3a2dc4",
+    "@openshift-migration-advisor/planner-sdk": "0.11.0-92891f5da8a7",
     "@patternfly/react-charts": "7.4.9",
     "@patternfly/react-core": "^6.4.1",
     "@patternfly/react-icons": "^6.4.0",

--- a/src/ui/core/components/MigrationDonutChart.tsx
+++ b/src/ui/core/components/MigrationDonutChart.tsx
@@ -47,7 +47,16 @@ interface MigrationDonutChartProps {
   }) => string;
 }
 
-const legendColors = ["#0066cc", "#5e40be", "#b6a6e9", "#b98412"];
+const legendColors = [
+  "#0066cc",
+  "#5e40be",
+  "#009596",
+  "#4cb140",
+  "#f0ab00",
+  "#b98412",
+  "#a30000",
+  "#b6a6e9",
+];
 
 const MigrationDonutChart: React.FC<MigrationDonutChartProps> = ({
   data,

--- a/src/ui/report/views/assessment-report/StorageOverview.tsx
+++ b/src/ui/report/views/assessment-report/StorageOverview.tsx
@@ -62,10 +62,22 @@ const TIER_CONFIG: Record<
   string,
   { order: number; label: string; legendCategory: string }
 > = {
-  Easy: { order: 0, label: "0-10 TB", legendCategory: "Easy" },
-  Medium: { order: 1, label: "11-20 TB", legendCategory: "Medium" },
-  Hard: { order: 2, label: "21-50 TB", legendCategory: "Hard" },
-  White: { order: 3, label: "> 50 TB", legendCategory: "White glove" },
+  "0-100GiB": { order: 0, label: "0-100GiB", legendCategory: "0-100GiB" },
+  "100-500GiB": {
+    order: 1,
+    label: "100-500GiB",
+    legendCategory: "100-500GiB",
+  },
+  "500GiB-1TiB": {
+    order: 2,
+    label: "500GiB-1TiB",
+    legendCategory: "500GiB-1TiB",
+  },
+  "1-2TiB": { order: 3, label: "1-2TiB", legendCategory: "1-2TiB" },
+  "2-5TiB": { order: 4, label: "2-5TiB", legendCategory: "2-5TiB" },
+  "5-10TiB": { order: 5, label: "5-10TiB", legendCategory: "5-10TiB" },
+  "10-20TiB": { order: 6, label: "10-20TiB", legendCategory: "10-20TiB" },
+  "20+TiB": { order: 7, label: "20+TiB", legendCategory: "20+TiB" },
 };
 
 type TierChartDatum = {
@@ -447,9 +459,9 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
                   : `${totals.totalSize.toFixed(2)} TB`
               }
               subTitleColor="var(--pf-t--global--text--color--subtle)"
-              itemsPerRow={Math.ceil(chartData.length / 2)}
-              labelFontSize={18}
-              marginLeft={viewMode === "totalSize" ? "42%" : "52%"}
+              itemsPerRow={Math.min(Math.ceil(chartData.length / 2), 2)}
+              legendWidth={420}
+              labelFontSize={14}
               tooltipLabelFormatter={({ datum, percent }) =>
                 `${datum.countDisplay}\n${percent.toFixed(1)}%`
               }
@@ -536,9 +548,12 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
                 title={`${totals.totalVMs} VMs`}
                 subTitle={`${totals.totalSize.toFixed(2)} TB`}
                 subTitleColor="var(--pf-t--global--text--color--subtle)"
-                itemsPerRow={Math.ceil(chartDataForVmCount.length / 2)}
-                labelFontSize={18}
-                marginLeft="52%"
+                itemsPerRow={Math.min(
+                  Math.ceil(chartDataForVmCount.length / 2),
+                  2,
+                )}
+                legendWidth={420}
+                labelFontSize={14}
                 tooltipLabelFormatter={({ datum, percent }) =>
                   `${datum.countDisplay}\n${percent.toFixed(1)}%`
                 }
@@ -557,9 +572,12 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
                 title={`${totals.totalSize.toFixed(2)} TB`}
                 subTitle={`${totals.totalVMs} VMs`}
                 subTitleColor="var(--pf-t--global--text--color--subtle)"
-                itemsPerRow={Math.ceil(chartDataForTotalSize.length / 2)}
-                labelFontSize={18}
-                marginLeft="42%"
+                itemsPerRow={Math.min(
+                  Math.ceil(chartDataForTotalSize.length / 2),
+                  2,
+                )}
+                legendWidth={420}
+                labelFontSize={14}
                 tooltipLabelFormatter={({ datum, percent }) =>
                   `${datum.countDisplay}\n${percent.toFixed(1)}%`
                 }


### PR DESCRIPTION
- Bump planner-sdk to 0.11.0. The backend now returns fine-grained disk size tiers (0-100GiB → 20+TiB) instead of the old Easy/Medium/Hard/White prefix-based tiers.
- Update TIER_CONFIG to match the new keys and their correct size order.
- Cap legend columns to 2 and constrain legendWidth to 420 px (matching chart width) so the legend no longer overflows the card under overflow:hidden.
- Reduce legend labelFontSize to 14 to fit two columns of long tier names within 420 px.
- Extend MigrationDonutChart legendColors from 4 to 8 distinct PatternFly colours so all tiers get a unique colour without cycling.

<img width="754" height="533" alt="Captura desde 2026-04-17 11-35-44" src="https://github.com/user-attachments/assets/f72d49fe-50f4-486f-93c7-653127ef8f7c" />
<img width="754" height="533" alt="Captura desde 2026-04-17 11-35-38" src="https://github.com/user-attachments/assets/a1c28a3b-cb7a-401b-b51d-5a73bddb51e0" />
