### PR TITLE
ECOPROJECT-4394 | refactor: change over-commited memory default to 1:4

### DIFF
--- a/src/ui/report/views/cluster-sizer/constants.ts
+++ b/src/ui/report/views/cluster-sizer/constants.ts
@@ -217,7 +217,7 @@ export const DEFAULT_FORM_VALUES: SizingFormValues = {
   customMemoryGb: 32,
   haReplicas: 3,
   cpuOvercommitRatio: 4,
-  memoryOvercommitRatio: 2,
+  memoryOvercommitRatio: 4,
   scheduleOnControlPlane: false,
   smtEnabled: false,
   smtThreads: 32,


### PR DESCRIPTION
- The default memoryOvercommitRatio has been changed from 2 (1:2) to 4 (1:4)

<img width="960" height="249" alt="image" src="https://github.com/user-attachments/assets/e876e4f8-0209-4c39-9151-3a1c5841bbc7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default memory overcommit ratio from 2 to 4 in cluster sizing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->