### PR TITLE
ECOPROJECT-4420 | fix: reset job state immediately on cancel and abort stale poll requests

### DIFF
--- a/src/data/stores/JobsStore.ts
+++ b/src/data/stores/JobsStore.ts
@@ -116,8 +116,14 @@ export class JobsStore
       this.abortController = null;
     }
 
-    let latestJob: Job | null = null;
+    // Capture job reference before resetting so we can still cancel it server-side.
     const currentJob = this.state.currentJob;
+
+    // Reset store state immediately so the UI shows a clean, interactive form
+    // the moment the user cancels — without waiting for the server round-trips below.
+    this.reset();
+
+    let latestJob: Job | null = null;
 
     if (currentJob) {
       try {
@@ -135,7 +141,6 @@ export class JobsStore
       }
     }
 
-    this.reset();
     this.cancelInProgress = false;
     return latestJob;
   }
@@ -177,7 +182,7 @@ export class JobsStore
     });
   }
 
-  protected override async poll(_signal: AbortSignal): Promise<void> {
+  protected override async poll(signal: AbortSignal): Promise<void> {
     if (this.cancelInProgress) {
       return;
     }
@@ -188,7 +193,11 @@ export class JobsStore
     }
 
     try {
-      const updated = await this.api.getJob({ id: currentJob.id });
+      // Forward the poll signal so stopPolling() aborts the in-flight request.
+      // Without this, a stale getJob response can arrive after reset() and
+      // repopulate currentJob — causing the progress bar to reappear and
+      // eventually triggering navigation even after the user cancelled.
+      const updated = await this.api.getJob({ id: currentJob.id }, { signal });
       if (this.cancelInProgress) {
         return;
       }
@@ -197,6 +206,9 @@ export class JobsStore
       // State is kept with the terminal job — the view model reacts to
       // this change (e.g. stopping polling, navigating to the report).
     } catch (err) {
+      if (signal.aborted) {
+        return;
+      }
       console.error("Failed to poll job status:", err);
     }
   }

--- a/src/data/stores/__tests__/JobsStore.test.ts
+++ b/src/data/stores/__tests__/JobsStore.test.ts
@@ -1,3 +1,4 @@
+import type { InitOverrideFunction } from "@openshift-migration-advisor/planner-sdk";
 import type { JobApi } from "@openshift-migration-advisor/planner-sdk";
 import type { Job } from "@openshift-migration-advisor/planner-sdk";
 import {
@@ -187,7 +188,15 @@ describe("JobsStore", () => {
     vi.mocked(api.getJob).mockResolvedValue(updatedJob);
 
     await vi.advanceTimersByTimeAsync(1000);
-    expect(api.getJob).toHaveBeenCalledWith({ id: 1 });
+
+    // The poll now forwards an AbortSignal to getJob so stopPolling() can abort it.
+    const [firstArg, secondArg] = vi.mocked(api.getJob).mock.calls[0] as [
+      { id: number },
+      RequestInit | undefined,
+    ];
+    expect(firstArg).toEqual({ id: 1 });
+    expect(secondArg?.signal).toBeInstanceOf(AbortSignal);
+
     expect(store.getSnapshot().currentJob).toEqual(updatedJob);
 
     store.stopPolling();
@@ -258,6 +267,73 @@ describe("JobsStore", () => {
   it("returns null when there is no current job", async () => {
     const result = await store.cancelRVToolsJob();
     expect(result).toBeNull();
+  });
+
+  it("resets store state immediately (before the server getJob/cancelJob round-trips)", async () => {
+    const runningJob = makeJob({ status: JobStatus.Parsing });
+    vi.mocked(api.createRVToolsAssessment).mockResolvedValue(runningJob);
+    await store.createRVToolsJob("t", new File([], "f.xlsx"));
+
+    // Make getJob hang so we can observe intermediate state.
+    let resolveGetJob!: (job: Job) => void;
+    vi.mocked(api.getJob).mockReturnValue(
+      new Promise<Job>((resolve) => {
+        resolveGetJob = resolve;
+      }),
+    );
+
+    const cancelPromise = store.cancelRVToolsJob();
+
+    // State should already be clean even though getJob hasn't resolved yet.
+    expect(store.getSnapshot().currentJob).toBeNull();
+    expect(store.getSnapshot().isCreating).toBe(false);
+
+    // Let getJob resolve so the cancel promise can finish.
+    vi.mocked(api.cancelJob).mockResolvedValue(undefined as never);
+    resolveGetJob(runningJob);
+    await cancelPromise;
+  });
+
+  it("stale in-flight poll response does not repopulate currentJob after cancel", async () => {
+    const runningJob = makeJob({ status: JobStatus.Parsing });
+    vi.mocked(api.createRVToolsAssessment).mockResolvedValue(runningJob);
+    await store.createRVToolsJob("t", new File([], "f.xlsx"));
+
+    // Set up a poll getJob that we will resolve AFTER cancel completes.
+    let resolvePollGetJob!: (job: Job) => void;
+    vi.mocked(api.getJob)
+      // First call: the poll tick (hangs until we release it)
+      .mockImplementationOnce(
+        (_params, initOverrides?: RequestInit | InitOverrideFunction) =>
+          new Promise<Job>((resolve, reject) => {
+            resolvePollGetJob = resolve;
+            // Narrow to RequestInit (not the async function overload) to read signal.
+            const init =
+              typeof initOverrides !== "function" ? initOverrides : undefined;
+            init?.signal?.addEventListener("abort", () =>
+              reject(new DOMException("Aborted", "AbortError")),
+            );
+          }),
+      )
+      // Second call: the cancel's own getJob for status check
+      .mockResolvedValueOnce(runningJob);
+
+    store.startPolling(1000);
+
+    // Advance timer to kick off the poll tick (starts getJob but doesn't resolve it).
+    await vi.advanceTimersByTimeAsync(1000);
+
+    // Now cancel — this calls stopPolling() (aborting the poll signal) and reset().
+    vi.mocked(api.cancelJob).mockResolvedValue(undefined as never);
+    const cancelPromise = store.cancelRVToolsJob();
+
+    // Simulate the stale poll getJob resolving AFTER cancel has reset state.
+    resolvePollGetJob(runningJob);
+
+    await cancelPromise;
+
+    // The stale response must NOT put the job back.
+    expect(store.getSnapshot().currentJob).toBeNull();
   });
 
   // -- clearCreateError ------------------------------------------------------


### PR DESCRIPTION
- cancelRVToolsJob now calls reset() before the async server round-trips, so the modal reopens in a clean state the instant the user cancels
- poll() now forwards its AbortSignal to getJob, so stopPolling() actually terminates in-flight requests — previously a stale response could resurrect currentJob after reset and trigger unwanted navigation to the report

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed issue where stale polling responses could overwrite cancelled job state
  * Job cancellations now immediately reflect in the UI

* **Performance Improvements**
  * In-flight polling requests now properly abort when stopping polls, improving responsiveness and resource usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->