### PR TITLE
ECOPROJECT-4430 | fix: use the same default parameters to calculate time estimation and complexity estimation

### DIFF
--- a/src/ui/report/view-models/useClusterSizingWizardViewModel.ts
+++ b/src/ui/report/view-models/useClusterSizingWizardViewModel.ts
@@ -244,9 +244,9 @@ export const useClusterSizingWizardViewModel = (
             clusterId,
             estimationSchema: ["network-based", "storage-offload"],
             params: {
-              work_hours_per_day: 6,
-              post_migration_engineers: 4,
-              transfer_rate_mbps: 600,
+              work_hours_per_day: 8,
+              post_migration_engineers: 10,
+              transfer_rate_mbps: 620,
             },
           },
         });

--- a/src/ui/report/views/cluster-sizer/constants.ts
+++ b/src/ui/report/views/cluster-sizer/constants.ts
@@ -229,10 +229,10 @@ export const DEFAULT_FORM_VALUES: SizingFormValues = {
  * Default migration estimation form values
  */
 export const DEFAULT_ESTIMATION_FORM_VALUES: EstimationFormValues = {
-  transferRateMbps: 5000,
-  workHoursPerDay: 12,
-  troubleshootMinsPerVm: 90,
-  postMigrationEngineers: 25,
+  transferRateMbps: 620,
+  workHoursPerDay: 8,
+  troubleshootMinsPerVm: 60,
+  postMigrationEngineers: 10,
 };
 
 export const ESTIMATION_SLIDER_LIMITS = {


### PR DESCRIPTION
These are the default parameters:




| Param Name (key)           | Display Name                | Type      | Unit    | Min | Max | Default | Used By Schema       |     |
| -------------------------- | --------------------------- | --------- | ------- | --- | --- | ------- | -------------------- | --- |
| `transfer_rate_mbps`       | Network Transfer Rate       | `number`  | Mbps    | 0.1 | —   | 620.0   | `network-based` only |     |
| `work_hours_per_day`       | Work Hours per Day          | `number`  | hours   | 0.5 | —   | 8.0     | all schemas          |     |
| `troubleshoot_mins_per_vm` | Troubleshooting Time per VM | `number`  | minutes | 1.0 | —   | 60.0    | all schemas          |     |
| `post_migration_engineers` | Post-Migration Engineers    | `integer` | —       | 1   | —   | 10      | all schemas          |     |


And these are the calls from the UI with the latest changes:

<img width="1260" height="300" alt="Captura desde 2026-04-21 10-56-20" src="https://github.com/user-attachments/assets/5d068063-ef75-4a6f-84b8-c9bdbfe72980" />
<img width="1260" height="300" alt="Captura desde 2026-04-21 10-56-08" src="https://github.com/user-attachments/assets/138dfba6-ae53-4e27-8ad6-cc90d0c3f7f1" />
