### PR TITLE
ECOPROJECT-4396 | fix: content in cluster recommendations modal is not aligned properly

### DIFF
--- a/src/ui/report/views/cluster-sizer/RecommendationTemplate.tsx
+++ b/src/ui/report/views/cluster-sizer/RecommendationTemplate.tsx
@@ -140,6 +140,7 @@ export const RecommendationTemplate: React.FC<RecommendationTemplateProps> = ({
                   ? expandableSectionDisabledStyle
                   : expandableSectionStyle
               }
+              isIndented
             >
               <Stack hasGutter className={preferencesContentStackStyle}>
                 <StackItem>{preferencesContent}</StackItem>


### PR DESCRIPTION
Before changes:
<img width="1034" height="521" alt="image" src="https://github.com/user-attachments/assets/784dc017-59f4-4c57-85a6-c90211ad662d" />

After changes:
<img width="1008" height="505" alt="image" src="https://github.com/user-attachments/assets/7ec358e1-a85f-4c8a-acbb-f73b765513ae" />
