### PR TITLE
ECOPROJECT-4453 | feat: Add pending requests badge to Partner tab

### DIFF
--- a/src/ui/home/components/PartnerTab.tsx
+++ b/src/ui/home/components/PartnerTab.tsx
@@ -1,0 +1,43 @@
+import { Badge, Tab, TabTitleIcon, TabTitleText } from "@patternfly/react-core";
+import React from "react";
+
+interface PartnerTabProps {
+  eventKey: number;
+  label: string;
+  pendingRequestsCount: number;
+  shouldShowBadge: boolean;
+  isLoading: boolean;
+}
+
+export const PartnerTab: React.FC<PartnerTabProps> = ({
+  eventKey,
+  label,
+  pendingRequestsCount,
+  shouldShowBadge,
+  isLoading,
+}) => {
+  const pendingRequestText = `${pendingRequestsCount} pending partner request${
+    pendingRequestsCount === 1 ? "" : "s"
+  }`;
+
+  return (
+    <Tab
+      eventKey={eventKey}
+      title={
+        <>
+          <TabTitleText>{label}</TabTitleText>{" "}
+          {shouldShowBadge && pendingRequestsCount > 0 && !isLoading && (
+            <TabTitleIcon>
+              <Badge screenReaderText={pendingRequestText}>
+                {pendingRequestsCount}
+              </Badge>
+            </TabTitleIcon>
+          )}
+        </>
+      }
+      aria-label={`${label} tab`}
+    />
+  );
+};
+
+PartnerTab.displayName = "PartnerTab";

--- a/src/ui/home/view-models/__tests__/useHomeScreenViewModel.test.ts
+++ b/src/ui/home/view-models/__tests__/useHomeScreenViewModel.test.ts
@@ -1,3 +1,7 @@
+import type {
+  Identity,
+  PartnerRequest,
+} from "@openshift-migration-advisor/planner-sdk";
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -11,10 +15,19 @@ import { useHomeScreenViewModel } from "../useHomeScreenViewModel";
 let mockPathname = "/assessments";
 const mockNavigate = vi.fn();
 
+const mockIdentity = null;
+const mockPartnerRequests: PartnerRequest[] = [];
+
 let mockAccountStore = {
   getIdentity: vi.fn().mockResolvedValue(null),
   subscribe: vi.fn(() => () => {}),
-  getSnapshot: vi.fn(() => null),
+  getSnapshot: vi.fn(() => mockIdentity),
+};
+
+let mockPartnerRequestsStore = {
+  list: vi.fn().mockResolvedValue([]),
+  subscribe: vi.fn(() => () => {}),
+  getSnapshot: vi.fn(() => mockPartnerRequests),
 };
 
 vi.mock("react-router-dom", () => ({
@@ -26,9 +39,33 @@ vi.mock("@y0n1/react-ioc", () => ({
   useInjection: (symbol: symbol) => {
     const key = symbol.description;
     if (key === "AccountStore") return mockAccountStore;
+    if (key === "PartnerRequestsStore") return mockPartnerRequestsStore;
     throw new Error(`Unexpected symbol: ${String(symbol)}`);
   },
 }));
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const createMockIdentity = (kind: Identity["kind"]): Identity => ({
+  username: "test-user",
+  kind,
+  groupId: "group-1",
+  partnerId: null,
+});
+
+const createMockPartnerRequest = (
+  status: PartnerRequest["requestStatus"],
+): PartnerRequest =>
+  ({
+    id: `request-${status}`,
+    requestStatus: status,
+    partner: {
+      id: "partner-1",
+      name: "Partner 1",
+    },
+  }) as PartnerRequest;
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -42,7 +79,13 @@ describe("useHomeScreenViewModel", () => {
     mockAccountStore = {
       getIdentity: vi.fn().mockResolvedValue(null),
       subscribe: vi.fn(() => () => {}),
-      getSnapshot: vi.fn(() => null),
+      getSnapshot: vi.fn(() => mockIdentity),
+    };
+
+    mockPartnerRequestsStore = {
+      list: vi.fn().mockResolvedValue([]),
+      subscribe: vi.fn(() => () => {}),
+      getSnapshot: vi.fn(() => mockPartnerRequests),
     };
   });
 
@@ -105,5 +148,171 @@ describe("useHomeScreenViewModel", () => {
     });
     expect(result.current.rvtoolsOpenToken).toBe(true);
     expect(mockNavigate).toHaveBeenCalledWith(routes.assessments);
+  });
+
+  describe("Partner badge functionality", () => {
+    it("shouldShowBadge is true when identity.kind is partner", async () => {
+      const unsubscribe = vi.fn();
+      const partnerIdentity = createMockIdentity("partner");
+      const emptyRequests: PartnerRequest[] = [];
+
+      mockAccountStore = {
+        getIdentity: vi.fn().mockResolvedValue(null),
+        subscribe: vi.fn(() => unsubscribe),
+        getSnapshot: vi.fn().mockReturnValue(partnerIdentity),
+      };
+
+      mockPartnerRequestsStore = {
+        subscribe: vi.fn(() => unsubscribe),
+        getSnapshot: vi.fn().mockReturnValue(emptyRequests),
+        list: vi.fn().mockResolvedValue(emptyRequests),
+      };
+
+      const { result } = renderHook(() => useHomeScreenViewModel());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current.shouldShowBadge).toBe(true);
+    });
+
+    it("shouldShowBadge is false when identity.kind is not partner", async () => {
+      const unsubscribe = vi.fn();
+      const regularIdentity = createMockIdentity("regular");
+      const emptyRequests: PartnerRequest[] = [];
+
+      mockAccountStore = {
+        getIdentity: vi.fn().mockResolvedValue(null),
+        subscribe: vi.fn(() => unsubscribe),
+        getSnapshot: vi.fn().mockReturnValue(regularIdentity),
+      };
+
+      mockPartnerRequestsStore = {
+        subscribe: vi.fn(() => unsubscribe),
+        getSnapshot: vi.fn().mockReturnValue(emptyRequests),
+        list: vi.fn().mockResolvedValue(emptyRequests),
+      };
+
+      const { result } = renderHook(() => useHomeScreenViewModel());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current.shouldShowBadge).toBe(false);
+    });
+
+    it("pendingRequestsCount counts pending requests", async () => {
+      const unsubscribe = vi.fn();
+      const partnerIdentity = createMockIdentity("partner");
+      const requests: PartnerRequest[] = [
+        createMockPartnerRequest("pending"),
+        createMockPartnerRequest("pending"),
+        createMockPartnerRequest("accepted"),
+        createMockPartnerRequest("rejected"),
+        createMockPartnerRequest("cancelled"),
+      ];
+
+      mockAccountStore = {
+        getIdentity: vi.fn().mockResolvedValue(null),
+        subscribe: vi.fn(() => unsubscribe),
+        getSnapshot: vi.fn().mockReturnValue(partnerIdentity),
+      };
+
+      mockPartnerRequestsStore = {
+        subscribe: vi.fn(() => unsubscribe),
+        getSnapshot: vi.fn().mockReturnValue(requests),
+        list: vi.fn().mockResolvedValue(requests),
+      };
+
+      const { result } = renderHook(() => useHomeScreenViewModel());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current.pendingRequestsCount).toBe(2);
+    });
+
+    it("pendingRequestsCount is 0 when there are no pending requests", async () => {
+      const unsubscribe = vi.fn();
+      const partnerIdentity = createMockIdentity("partner");
+      const requests: PartnerRequest[] = [
+        createMockPartnerRequest("accepted"),
+        createMockPartnerRequest("rejected"),
+      ];
+
+      mockAccountStore = {
+        getIdentity: vi.fn().mockResolvedValue(null),
+        subscribe: vi.fn(() => unsubscribe),
+        getSnapshot: vi.fn().mockReturnValue(partnerIdentity),
+      };
+
+      mockPartnerRequestsStore = {
+        subscribe: vi.fn(() => unsubscribe),
+        getSnapshot: vi.fn().mockReturnValue(requests),
+        list: vi.fn().mockResolvedValue(requests),
+      };
+
+      const { result } = renderHook(() => useHomeScreenViewModel());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current.shouldShowBadge).toBe(true);
+      expect(result.current.pendingRequestsCount).toBe(0);
+    });
+    it("calls partnerRequestsStore.list on mount if partner", async () => {
+      const unsubscribe = vi.fn();
+      const partnerIdentity = createMockIdentity("partner");
+      const emptyRequests: PartnerRequest[] = [];
+
+      mockAccountStore = {
+        getIdentity: vi.fn().mockResolvedValue(null),
+        subscribe: vi.fn(() => unsubscribe),
+        getSnapshot: vi.fn().mockReturnValue(partnerIdentity),
+      };
+
+      mockPartnerRequestsStore = {
+        subscribe: vi.fn(() => unsubscribe),
+        getSnapshot: vi.fn().mockReturnValue(emptyRequests),
+        list: vi.fn().mockResolvedValue(emptyRequests),
+      };
+
+      renderHook(() => useHomeScreenViewModel());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockPartnerRequestsStore.list).toHaveBeenCalledTimes(1);
+    });
+    it("don't calls partnerRequestsStore.list on mount if not partner", async () => {
+      const unsubscribe = vi.fn();
+      const partnerIdentity = createMockIdentity("regular");
+      const emptyRequests: PartnerRequest[] = [];
+
+      mockAccountStore = {
+        getIdentity: vi.fn().mockResolvedValue(null),
+        subscribe: vi.fn(() => unsubscribe),
+        getSnapshot: vi.fn().mockReturnValue(partnerIdentity),
+      };
+
+      mockPartnerRequestsStore = {
+        subscribe: vi.fn(() => unsubscribe),
+        getSnapshot: vi.fn().mockReturnValue(emptyRequests),
+        list: vi.fn().mockResolvedValue(emptyRequests),
+      };
+
+      renderHook(() => useHomeScreenViewModel());
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockPartnerRequestsStore.list).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/ui/home/view-models/useHomeScreenViewModel.ts
+++ b/src/ui/home/view-models/useHomeScreenViewModel.ts
@@ -1,9 +1,11 @@
 import { useInjection } from "@y0n1/react-ioc";
 import { useState, useSyncExternalStore } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+import { useAsync } from "react-use";
 
 import { Symbols } from "../../../config/Dependencies";
 import type { IAccountStore } from "../../../data/stores/interfaces/IAccountStore";
+import type { IPartnerRequestsStore } from "../../../data/stores/interfaces/IPartnerRequestsStore";
 import { PARTNER_FEATURE_VISIBLE_KEY } from "../../../data/stubs/stubPartners";
 import useLocalStorage from "../../../hooks/useLocalStorage";
 import { routes } from "../../../routing/Routes";
@@ -30,6 +32,9 @@ export interface HomeScreenViewModel {
     tabIndex: string | number,
   ) => void;
   handleOpenRVToolsModal: () => void;
+  pendingRequestsCount: number;
+  shouldShowBadge: boolean;
+  isLoadingPartnerRequests: boolean;
 }
 
 export const useHomeScreenViewModel = (): HomeScreenViewModel => {
@@ -48,6 +53,30 @@ export const useHomeScreenViewModel = (): HomeScreenViewModel => {
     PARTNER_FEATURE_VISIBLE_KEY,
     false,
   );
+
+  // Partner requests store subscription
+  const partnerRequestsStore = useInjection<IPartnerRequestsStore>(
+    Symbols.PartnerRequestsStore,
+  );
+
+  const requests = useSyncExternalStore(
+    partnerRequestsStore.subscribe.bind(partnerRequestsStore),
+    partnerRequestsStore.getSnapshot.bind(partnerRequestsStore),
+  );
+
+  const shouldShowBadge = identity?.kind === "partner";
+
+  const { loading: isLoadingPartnerRequestsRaw } = useAsync(async () => {
+    if (!shouldShowBadge) return [];
+    return partnerRequestsStore.list();
+  }, [partnerRequestsStore, shouldShowBadge]);
+
+  const isLoadingPartnerRequests =
+    shouldShowBadge && isLoadingPartnerRequestsRaw;
+
+  const pendingRequestsCount = requests.filter(
+    (request) => request.requestStatus === "pending",
+  ).length;
 
   const getActiveTabKey = (): number => {
     if (location.pathname.startsWith(routes.environments)) return 1;
@@ -153,6 +182,9 @@ export const useHomeScreenViewModel = (): HomeScreenViewModel => {
     breadcrumbs,
     rvtoolsOpenToken,
     partnerTab,
+    pendingRequestsCount,
+    shouldShowBadge,
+    isLoadingPartnerRequests,
     handleTabClick,
     handleOpenRVToolsModal,
   };

--- a/src/ui/home/views/HomeScreen.tsx
+++ b/src/ui/home/views/HomeScreen.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Outlet } from "react-router-dom";
 
 import { AppPage } from "../../core/components/AppPage";
+import { PartnerTab } from "../components/PartnerTab";
 import { useHomeScreenViewModel } from "../view-models/useHomeScreenViewModel";
 import HowDoesItWork from "./HowDoesItWork";
 
@@ -32,10 +33,12 @@ export const HomeScreen: React.FC = () => {
           aria-label="Environments tab"
         />
         {vm.partnerTab && (
-          <Tab
+          <PartnerTab
             eventKey={vm.partnerTab.key}
-            title={<TabTitleText>{vm.partnerTab.label}</TabTitleText>}
-            aria-label={`${vm.partnerTab.label} tab`}
+            label={vm.partnerTab.label}
+            pendingRequestsCount={vm.pendingRequestsCount}
+            shouldShowBadge={vm.shouldShowBadge}
+            isLoading={vm.isLoadingPartnerRequests}
           />
         )}
       </Tabs>


### PR DESCRIPTION
Added a visual indicator (badge) on the Partner tab in the home screen to display the count of pending partner assignment requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New partner tab component with a conditional badge showing pending partner-request counts, accessible aria-labels, and screen-reader text.
  * Loading state support while fetching partner requests; badge hidden during load or when count is zero or not applicable.
* **Tests**
  * Added tests validating badge visibility, pending-count calculation, and that request fetching occurs only for partner identities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->