### PR TITLE
ECOPROJECT-4409 | fix: assessment report PDF is not readable in dark mode

### DIFF
--- a/src/services/pdf-export/PdfExportService.ts
+++ b/src/services/pdf-export/PdfExportService.ts
@@ -72,13 +72,23 @@ export class PdfExportService {
     await this.waitForImages(container);
 
     const blockBoundaries = this.collectBlockBoundaries(container);
-    const canvas = await html2canvas(container, { useCORS: true });
+
+    // Read the container's resolved background colour so page-fill in
+    // createSliceCanvas matches the active theme (dark or light).
+    const backgroundColor =
+      window.getComputedStyle(container).backgroundColor || "#ffffff";
+
+    const canvas = await html2canvas(container, {
+      useCORS: true,
+      backgroundColor,
+    });
 
     const pdf = this.buildPdf(
       canvas,
       blockBoundaries,
       container.clientWidth,
       options.documentTitle,
+      backgroundColor,
     );
     this.downloadPdf(pdf, options.documentTitle);
   }
@@ -152,6 +162,7 @@ export class PdfExportService {
     domBlocks: BlockBoundary[],
     containerClientWidth: number,
     documentTitle?: string,
+    backgroundColor = "#ffffff",
   ): jsPDF {
     const pdf = new jsPDF("p", "mm", "a4");
     const pageWidth = pdf.internal.pageSize.getWidth();
@@ -198,6 +209,7 @@ export class PdfExportService {
         contentWidth,
         contentHeight,
         margin,
+        backgroundColor,
       );
     } else {
       const sliceHeights = this.calculateSliceHeights(
@@ -215,6 +227,7 @@ export class PdfExportService {
         contentWidth,
         contentHeight,
         margin,
+        backgroundColor,
       );
     }
 
@@ -408,6 +421,7 @@ export class PdfExportService {
     contentWidth: number,
     contentHeight: number,
     margin: number,
+    backgroundColor = "#ffffff",
   ): void {
     for (let i = 0; i < segments.length; i++) {
       const { top, height } = segments[i];
@@ -418,6 +432,7 @@ export class PdfExportService {
         imgWidth,
         sliceHeightPx,
         top,
+        backgroundColor,
       );
 
       this.addCanvasToPdf(
@@ -445,6 +460,7 @@ export class PdfExportService {
     contentWidth: number,
     contentHeight: number,
     margin: number,
+    backgroundColor = "#ffffff",
   ): void {
     let consumedPx = 0;
 
@@ -456,6 +472,7 @@ export class PdfExportService {
         imgWidth,
         sliceHeightPx,
         consumedPx,
+        backgroundColor,
       );
 
       this.addCanvasToPdf(
@@ -481,6 +498,7 @@ export class PdfExportService {
     width: number,
     height: number,
     offsetY: number,
+    backgroundColor = "#ffffff",
   ): HTMLCanvasElement {
     const pageCanvas = document.createElement("canvas");
     pageCanvas.width = width;
@@ -489,7 +507,9 @@ export class PdfExportService {
     const ctx = pageCanvas.getContext("2d");
     if (!ctx) throw new Error("Canvas 2D context unavailable");
 
-    ctx.fillStyle = "#ffffff";
+    // Fill with the container's actual background colour so the padding area
+    // at the bottom of the last page matches the active theme.
+    ctx.fillStyle = backgroundColor;
     ctx.fillRect(0, 0, width, height);
     ctx.drawImage(sourceCanvas, 0, offsetY, width, height, 0, 0, width, height);
 

--- a/src/ui/core/components/OffScreenRenderer.tsx
+++ b/src/ui/core/components/OffScreenRenderer.tsx
@@ -21,14 +21,17 @@ const offScreenContainer = css`
   width: 1600px;
   min-height: 1200px;
   padding: 2rem;
-  background-color: white;
+  /*
+   * Use the theme's own background so the captured PDF matches whatever
+   * theme (light or dark) is active in the app. Previously this was hard-
+   * coded to white which forced light backgrounds while text remained
+   * dark-mode colours, making labels invisible.
+   */
+  background-color: var(--pf-t--global--background--color--primary--default);
   z-index: -1;
 
   .pf-v6-c-card {
-    background-color: white !important;
     box-shadow: none !important;
-    color: black !important;
-    border: 1px solid rgba(3, 3, 3, 0.25);
     max-height: none !important;
     overflow: visible !important;
   }


### PR DESCRIPTION
This PR fix issues with export PDF in dark mode:


<img width="769" height="660" alt="Captura desde 2026-04-22 11-43-24" src="https://github.com/user-attachments/assets/64d1e1e5-5a0e-40d1-8566-78e4957db485" />
<img width="513" height="886" alt="Captura desde 2026-04-22 11-43-13" src="https://github.com/user-attachments/assets/dc0b7f8f-e059-472c-92b3-fcc50d31a36c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PDF and exported charts now respect the app’s themed background color instead of forcing white, fixing light-/dark-mode display issues.

* **Style**
  * Removed hard-coded color overrides so component cards and exported content inherit the PatternFly theme for more consistent visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->