### PR TITLE
ECOPROJECT-4456 | feat: Add customer requests view for partner users

### DIFF
--- a/src/data/stores/PartnerRequestsStore.ts
+++ b/src/data/stores/PartnerRequestsStore.ts
@@ -2,6 +2,7 @@ import type {
   PartnerApiInterface,
   PartnerRequest,
   PartnerRequestCreate,
+  PartnerRequestUpdate,
 } from "@openshift-migration-advisor/planner-sdk";
 
 import { ExternalStoreBase } from "../../lib/mvvm/ExternalStore";
@@ -41,6 +42,40 @@ export class PartnerRequestsStore
   async cancel(partnerRequestId: string): Promise<void> {
     await this.api.cancelPartnerRequest({ id: partnerRequestId });
     await this.list();
+  }
+
+  async accept(partnerRequestId: string): Promise<PartnerRequest> {
+    const updateData: PartnerRequestUpdate = {
+      status: "accepted",
+    };
+    const updatedRequest = await this.api.updatePartnerRequest({
+      id: partnerRequestId,
+      partnerRequestUpdate: updateData,
+    });
+    this.partnerRequests = this.partnerRequests.map((req) =>
+      req.id === partnerRequestId ? updatedRequest : req,
+    );
+    this.notify();
+    return updatedRequest;
+  }
+
+  async reject(
+    partnerRequestId: string,
+    reason: string,
+  ): Promise<PartnerRequest> {
+    const updateData: PartnerRequestUpdate = {
+      status: "rejected",
+      reason,
+    };
+    const updatedRequest = await this.api.updatePartnerRequest({
+      id: partnerRequestId,
+      partnerRequestUpdate: updateData,
+    });
+    this.partnerRequests = this.partnerRequests.map((req) =>
+      req.id === partnerRequestId ? updatedRequest : req,
+    );
+    this.notify();
+    return updatedRequest;
   }
 
   override getSnapshot(): PartnerRequest[] {

--- a/src/data/stores/__tests__/PartnerRequestsStore.test.ts
+++ b/src/data/stores/__tests__/PartnerRequestsStore.test.ts
@@ -1,0 +1,299 @@
+import type {
+  PartnerApiInterface,
+  PartnerRequest,
+} from "@openshift-migration-advisor/planner-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PartnerRequestsStore } from "../PartnerRequestsStore";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makePartnerRequest = (
+  overrides: Partial<PartnerRequest> = {},
+): PartnerRequest =>
+  ({
+    id: "req-1",
+    requestStatus: "pending",
+    partner: {
+      id: "partner-1",
+      name: "Test Partner",
+      kind: "partner" as const,
+      icon: "",
+      company: "Test Company",
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+    },
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  }) as PartnerRequest;
+
+const createMockApi = (): PartnerApiInterface =>
+  ({
+    listPartnerRequests: vi.fn(),
+    createPartnerRequest: vi.fn(),
+    cancelPartnerRequest: vi.fn(),
+    updatePartnerRequest: vi.fn(),
+  }) as unknown as PartnerApiInterface;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PartnerRequestsStore", () => {
+  let api: PartnerApiInterface;
+  let store: PartnerRequestsStore;
+
+  beforeEach(() => {
+    api = createMockApi();
+    store = new PartnerRequestsStore(api);
+  });
+
+  it("initial snapshot is empty array", () => {
+    expect(store.getSnapshot()).toEqual([]);
+  });
+
+  it("list() fetches partner requests and updates snapshot", async () => {
+    const requests = [
+      makePartnerRequest({ id: "req-1" }),
+      makePartnerRequest({ id: "req-2" }),
+    ];
+    vi.mocked(api.listPartnerRequests).mockResolvedValue(requests as never);
+
+    const result = await store.list();
+
+    expect(api.listPartnerRequests).toHaveBeenCalledWith({});
+    expect(result).toEqual(requests);
+    expect(store.getSnapshot()).toEqual(requests);
+  });
+
+  it("create() adds new partner request", async () => {
+    const created = makePartnerRequest({ id: "req-1" });
+    vi.mocked(api.createPartnerRequest).mockResolvedValue(created as never);
+
+    const input = {
+      name: "Customer Name",
+      contactName: "John Doe",
+      email: "john@example.com",
+      contactPhone: "+1-555-0123",
+      location: "us-east-1",
+    };
+    const result = await store.create("partner-1", input);
+
+    expect(api.createPartnerRequest).toHaveBeenCalledWith({
+      id: "partner-1",
+      partnerRequestCreate: input,
+    });
+    expect(result).toEqual(created);
+    expect(store.getSnapshot()).toHaveLength(1);
+    expect(store.getSnapshot()[0]).toEqual(created);
+  });
+
+  it("create() appends to existing requests", async () => {
+    const existing = [makePartnerRequest({ id: "req-1" })];
+    vi.mocked(api.listPartnerRequests).mockResolvedValue(existing as never);
+    await store.list();
+
+    const created = makePartnerRequest({ id: "req-2" });
+    vi.mocked(api.createPartnerRequest).mockResolvedValue(created as never);
+
+    await store.create("partner-1", {
+      name: "Customer Name",
+      contactName: "John Doe",
+      email: "john@example.com",
+      contactPhone: "+1-555-0123",
+      location: "us-east-1",
+    });
+
+    expect(store.getSnapshot()).toHaveLength(2);
+    expect(store.getSnapshot()[1]).toEqual(created);
+  });
+
+  it("cancel() removes request and refreshes list", async () => {
+    const requests = [
+      makePartnerRequest({ id: "req-1" }),
+      makePartnerRequest({ id: "req-2" }),
+    ];
+    vi.mocked(api.listPartnerRequests).mockResolvedValue(requests as never);
+    await store.list();
+
+    const afterCancel = [makePartnerRequest({ id: "req-2" })];
+    vi.mocked(api.listPartnerRequests).mockResolvedValue(afterCancel as never);
+    vi.mocked(api.cancelPartnerRequest).mockResolvedValue(undefined as never);
+
+    await store.cancel("req-1");
+
+    expect(api.cancelPartnerRequest).toHaveBeenCalledWith({ id: "req-1" });
+    expect(api.listPartnerRequests).toHaveBeenCalledTimes(2);
+    expect(store.getSnapshot()).toEqual(afterCancel);
+  });
+
+  it("accept() updates request status to accepted", async () => {
+    const pending = makePartnerRequest({
+      id: "req-1",
+      requestStatus: "pending",
+    });
+    vi.mocked(api.listPartnerRequests).mockResolvedValue([pending] as never);
+    await store.list();
+
+    const accepted = makePartnerRequest({
+      id: "req-1",
+      requestStatus: "accepted",
+    });
+    vi.mocked(api.updatePartnerRequest).mockResolvedValue(accepted as never);
+
+    const result = await store.accept("req-1");
+
+    expect(api.updatePartnerRequest).toHaveBeenCalledWith({
+      id: "req-1",
+      partnerRequestUpdate: { status: "accepted" },
+    });
+    expect(result).toEqual(accepted);
+    expect(store.getSnapshot()[0].requestStatus).toBe("accepted");
+  });
+
+  it("accept() preserves other requests", async () => {
+    const requests = [
+      makePartnerRequest({ id: "req-1", requestStatus: "pending" }),
+      makePartnerRequest({ id: "req-2", requestStatus: "pending" }),
+    ];
+    vi.mocked(api.listPartnerRequests).mockResolvedValue(requests as never);
+    await store.list();
+
+    const accepted = makePartnerRequest({
+      id: "req-1",
+      requestStatus: "accepted",
+    });
+    vi.mocked(api.updatePartnerRequest).mockResolvedValue(accepted as never);
+
+    await store.accept("req-1");
+
+    expect(store.getSnapshot()).toHaveLength(2);
+    expect(store.getSnapshot()[0].requestStatus).toBe("accepted");
+    expect(store.getSnapshot()[1].requestStatus).toBe("pending");
+  });
+
+  it("reject() updates request status to rejected with reason", async () => {
+    const pending = makePartnerRequest({
+      id: "req-1",
+      requestStatus: "pending",
+    });
+    vi.mocked(api.listPartnerRequests).mockResolvedValue([pending] as never);
+    await store.list();
+
+    const rejected = makePartnerRequest({
+      id: "req-1",
+      requestStatus: "rejected",
+      reason: "Does not meet criteria",
+    });
+    vi.mocked(api.updatePartnerRequest).mockResolvedValue(rejected as never);
+
+    const result = await store.reject("req-1", "Does not meet criteria");
+
+    expect(api.updatePartnerRequest).toHaveBeenCalledWith({
+      id: "req-1",
+      partnerRequestUpdate: {
+        status: "rejected",
+        reason: "Does not meet criteria",
+      },
+    });
+    expect(result).toEqual(rejected);
+    expect(store.getSnapshot()[0].requestStatus).toBe("rejected");
+  });
+
+  it("reject() preserves other requests", async () => {
+    const requests = [
+      makePartnerRequest({ id: "req-1", requestStatus: "pending" }),
+      makePartnerRequest({ id: "req-2", requestStatus: "pending" }),
+    ];
+    vi.mocked(api.listPartnerRequests).mockResolvedValue(requests as never);
+    await store.list();
+
+    const rejected = makePartnerRequest({
+      id: "req-1",
+      requestStatus: "rejected",
+      reason: "Test reason",
+    });
+    vi.mocked(api.updatePartnerRequest).mockResolvedValue(rejected as never);
+
+    await store.reject("req-1", "Test reason");
+
+    expect(store.getSnapshot()).toHaveLength(2);
+    expect(store.getSnapshot()[0].requestStatus).toBe("rejected");
+    expect(store.getSnapshot()[1].requestStatus).toBe("pending");
+  });
+
+  it("subscriber notification on list()", async () => {
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    vi.mocked(api.listPartnerRequests).mockResolvedValue([
+      makePartnerRequest(),
+    ] as never);
+    await store.list();
+
+    expect(listener).toHaveBeenCalled();
+  });
+
+  it("subscriber notification on create()", async () => {
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    const created = makePartnerRequest({ id: "req-1" });
+    vi.mocked(api.createPartnerRequest).mockResolvedValue(created as never);
+    await store.create("partner-1", {
+      name: "Customer Name",
+      contactName: "John Doe",
+      email: "john@example.com",
+      contactPhone: "+1-555-0123",
+      location: "us-east-1",
+    });
+
+    expect(listener).toHaveBeenCalled();
+  });
+
+  it("subscriber notification on accept()", async () => {
+    const pending = makePartnerRequest({
+      id: "req-1",
+      requestStatus: "pending",
+    });
+    vi.mocked(api.listPartnerRequests).mockResolvedValue([pending] as never);
+    await store.list();
+
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    const accepted = makePartnerRequest({
+      id: "req-1",
+      requestStatus: "accepted",
+    });
+    vi.mocked(api.updatePartnerRequest).mockResolvedValue(accepted as never);
+    await store.accept("req-1");
+
+    expect(listener).toHaveBeenCalled();
+  });
+
+  it("subscriber notification on reject()", async () => {
+    const pending = makePartnerRequest({
+      id: "req-1",
+      requestStatus: "pending",
+    });
+    vi.mocked(api.listPartnerRequests).mockResolvedValue([pending] as never);
+    await store.list();
+
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    const rejected = makePartnerRequest({
+      id: "req-1",
+      requestStatus: "rejected",
+      reason: "Test reason",
+    });
+    vi.mocked(api.updatePartnerRequest).mockResolvedValue(rejected as never);
+    await store.reject("req-1", "Test reason");
+
+    expect(listener).toHaveBeenCalled();
+  });
+});

--- a/src/data/stores/interfaces/IPartnerRequestsStore.ts
+++ b/src/data/stores/interfaces/IPartnerRequestsStore.ts
@@ -8,5 +8,7 @@ import type { ExternalStore } from "../../../lib/mvvm/ExternalStore";
 export interface IPartnerRequestsStore extends ExternalStore<PartnerRequest[]> {
   list(): Promise<PartnerRequest[]>;
   create(groupId: string, data: PartnerRequestCreate): Promise<PartnerRequest>;
+  accept(partnerRequestId: string): Promise<PartnerRequest>;
   cancel(partnerRequestId: string): Promise<void>;
+  reject(partnerRequestId: string, reason: string): Promise<PartnerRequest>;
 }

--- a/src/ui/partner/partner/components/RejectPartnerRequestForm.tsx
+++ b/src/ui/partner/partner/components/RejectPartnerRequestForm.tsx
@@ -1,0 +1,65 @@
+import { yupResolver } from "@hookform/resolvers/yup";
+import { Form } from "@patternfly/react-core";
+import React, { useEffect } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import * as yup from "yup";
+
+import { TextAreaFormGroup } from "../../../core/components/form";
+
+export interface RejectPartnerRequestFormValues {
+  reason: string;
+}
+
+const validationSchema: yup.ObjectSchema<RejectPartnerRequestFormValues> = yup
+  .object()
+  .shape({
+    reason: yup.string().trim().required("Reason is required"),
+  });
+
+interface RejectPartnerRequestFormProps {
+  id: string;
+  onSubmit: (values: RejectPartnerRequestFormValues) => void;
+  setIsValid?: (isValid: boolean) => void;
+}
+
+export const RejectPartnerRequestForm: React.FC<
+  RejectPartnerRequestFormProps
+> = ({ id, onSubmit, setIsValid }) => {
+  const methods = useForm<RejectPartnerRequestFormValues>({
+    resolver: yupResolver(validationSchema),
+    mode: "onTouched",
+    defaultValues: {
+      reason: "",
+    },
+  });
+
+  useEffect(() => {
+    setIsValid?.(methods.formState.isValid);
+  }, [methods.formState.isValid, setIsValid]);
+
+  const handleFormSubmit = (data: RejectPartnerRequestFormValues) => {
+    onSubmit(data);
+  };
+
+  return (
+    <FormProvider {...methods}>
+      <Form
+        noValidate
+        id={id}
+        onSubmit={(e) => {
+          void methods.handleSubmit(handleFormSubmit)(e);
+        }}
+      >
+        <TextAreaFormGroup
+          label="Reason for rejection"
+          id="reject-reason"
+          name="reason"
+          isRequired
+          placeholder="Please provide a reason for rejecting this request..."
+        />
+      </Form>
+    </FormProvider>
+  );
+};
+
+RejectPartnerRequestForm.displayName = "RejectPartnerRequestForm";

--- a/src/ui/partner/partner/components/RejectPartnerRequestModal.tsx
+++ b/src/ui/partner/partner/components/RejectPartnerRequestModal.tsx
@@ -1,0 +1,62 @@
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+} from "@patternfly/react-core";
+import React from "react";
+
+import {
+  RejectPartnerRequestForm,
+  type RejectPartnerRequestFormValues,
+} from "./RejectPartnerRequestForm";
+
+interface RejectPartnerRequestModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (values: RejectPartnerRequestFormValues) => void | Promise<void>;
+}
+
+export const RejectPartnerRequestModal: React.FC<
+  RejectPartnerRequestModalProps
+> = ({ isOpen, onClose, onSubmit }) => {
+  const handleSubmit = async (values: RejectPartnerRequestFormValues) => {
+    await onSubmit(values);
+    onClose();
+  };
+
+  return (
+    <Modal
+      variant={ModalVariant.medium}
+      isOpen={isOpen}
+      onClose={onClose}
+      aria-label="Reject partner request"
+    >
+      <ModalHeader title="Reject customer request" />
+      <ModalBody>
+        <RejectPartnerRequestForm
+          id="reject-partner-request-form"
+          onSubmit={(values) => {
+            void handleSubmit(values);
+          }}
+        />
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          variant="danger"
+          type="submit"
+          form="reject-partner-request-form"
+        >
+          Reject
+        </Button>
+        <Button variant="link" onClick={onClose}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+RejectPartnerRequestModal.displayName = "RejectPartnerRequestModal";

--- a/src/ui/partner/partner/components/__tests__/RejectPartnerRequestForm.test.tsx
+++ b/src/ui/partner/partner/components/__tests__/RejectPartnerRequestForm.test.tsx
@@ -1,0 +1,138 @@
+import "@testing-library/jest-dom";
+
+import { Button } from "@patternfly/react-core";
+import { render, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { RejectPartnerRequestForm } from "../RejectPartnerRequestForm";
+
+describe("RejectPartnerRequestForm", () => {
+  it("renders the form with a textarea", () => {
+    const mockOnSubmit = vi.fn();
+    const { getByRole } = render(
+      <RejectPartnerRequestForm
+        id="reject-request-form"
+        onSubmit={mockOnSubmit}
+      />,
+    );
+
+    expect(
+      getByRole("textbox", { name: /Reason for rejection/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("submits the form with correct values", async () => {
+    const mockOnSubmit = vi.fn();
+    const user = userEvent.setup();
+    const { getByRole } = render(
+      <>
+        <RejectPartnerRequestForm
+          id="reject-request-form"
+          onSubmit={mockOnSubmit}
+        />
+        <Button variant="danger" type="submit" form="reject-request-form">
+          Reject
+        </Button>
+      </>,
+    );
+
+    const reason = getByRole("textbox", { name: /Reason for rejection/i });
+    await user.type(reason, "The request does not meet our criteria");
+
+    const rejectButton = getByRole("button", { name: /Reject/i });
+    await user.click(rejectButton);
+
+    await waitFor(() => {
+      expect(mockOnSubmit.mock.calls.length).toBe(1);
+      expect(mockOnSubmit.mock.calls[0][0]).toEqual({
+        reason: "The request does not meet our criteria",
+      });
+    });
+  });
+
+  it("displays error message when submitting empty form", async () => {
+    const mockOnSubmit = vi.fn();
+    const user = userEvent.setup();
+    const { getByRole, getByText } = render(
+      <>
+        <RejectPartnerRequestForm
+          id="reject-request-form"
+          onSubmit={mockOnSubmit}
+        />
+        <Button variant="danger" type="submit" form="reject-request-form">
+          Reject
+        </Button>
+      </>,
+    );
+
+    const rejectButton = getByRole("button", { name: /Reject/i });
+    await user.click(rejectButton);
+
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+    expect(getByText("Reason is required")).toBeInTheDocument();
+  });
+
+  it("clears error when user starts typing", async () => {
+    const mockOnSubmit = vi.fn();
+    const user = userEvent.setup();
+    const { getByRole, getByText, queryByText } = render(
+      <>
+        <RejectPartnerRequestForm
+          id="reject-request-form"
+          onSubmit={mockOnSubmit}
+        />
+        <Button variant="danger" type="submit" form="reject-request-form">
+          Reject
+        </Button>
+      </>,
+    );
+
+    const rejectButton = getByRole("button", { name: /Reject/i });
+    await user.click(rejectButton);
+
+    expect(getByText("Reason is required")).toBeInTheDocument();
+
+    const reason = getByRole("textbox", { name: /Reason for rejection/i });
+    await user.type(reason, "Test");
+
+    await waitFor(() => {
+      expect(queryByText("Reason is required")).not.toBeInTheDocument();
+    });
+  });
+
+  it("displays error on blur for empty required field", async () => {
+    const mockOnSubmit = vi.fn();
+    const user = userEvent.setup();
+    const { getByRole, getByText } = render(
+      <RejectPartnerRequestForm
+        id="reject-request-form"
+        onSubmit={mockOnSubmit}
+      />,
+    );
+
+    const reason = getByRole("textbox", { name: /Reason for rejection/i });
+    await user.click(reason);
+    await user.tab();
+
+    await waitFor(() => {
+      expect(getByText("Reason is required")).toBeInTheDocument();
+    });
+  });
+
+  it("updates form field when typing", async () => {
+    const mockOnSubmit = vi.fn();
+    const user = userEvent.setup();
+    const { getByRole } = render(
+      <RejectPartnerRequestForm
+        id="reject-request-form"
+        onSubmit={mockOnSubmit}
+      />,
+    );
+
+    const reason = getByRole("textbox", { name: /Reason for rejection/i });
+    await user.type(reason, "Test reason");
+
+    expect(reason).toHaveValue("Test reason");
+  });
+});

--- a/src/ui/partner/partner/view-models/useCustomerRequestsViewModel.ts
+++ b/src/ui/partner/partner/view-models/useCustomerRequestsViewModel.ts
@@ -1,0 +1,56 @@
+import type { PartnerRequest } from "@openshift-migration-advisor/planner-sdk";
+import { useInjection } from "@y0n1/react-ioc";
+import { useSyncExternalStore } from "react";
+import { useAsync, useAsyncFn } from "react-use";
+
+import { Symbols } from "../../../../config/Dependencies";
+import type { IPartnerRequestsStore } from "../../../../data/stores/interfaces/IPartnerRequestsStore";
+
+export interface CustomerRequestsViewModel {
+  requests: PartnerRequest[];
+  isLoading: boolean;
+  error?: Error;
+  acceptPartnerRequest: (partnerRequestId: string) => Promise<PartnerRequest>;
+  rejectPartnerRequest: (
+    partnerRequestId: string,
+    reason: string,
+  ) => Promise<PartnerRequest>;
+}
+
+export const useCustomerRequestsViewModel = (): CustomerRequestsViewModel => {
+  const partnerRequestsStore = useInjection<IPartnerRequestsStore>(
+    Symbols.PartnerRequestsStore,
+  );
+
+  const requests = useSyncExternalStore<PartnerRequest[]>(
+    partnerRequestsStore.subscribe.bind(partnerRequestsStore),
+    partnerRequestsStore.getSnapshot.bind(partnerRequestsStore),
+  );
+
+  const { loading, error } = useAsync(() => partnerRequestsStore.list(), []);
+
+  const [acceptState, doAcceptPartnerRequest] = useAsyncFn(
+    async (partnerRequestId: string): Promise<PartnerRequest> => {
+      return await partnerRequestsStore.accept(partnerRequestId);
+    },
+    [partnerRequestsStore],
+  );
+
+  const [rejectState, doRejectPartnerRequest] = useAsyncFn(
+    async (
+      partnerRequestId: string,
+      reason: string,
+    ): Promise<PartnerRequest> => {
+      return await partnerRequestsStore.reject(partnerRequestId, reason);
+    },
+    [partnerRequestsStore],
+  );
+
+  return {
+    requests,
+    isLoading: loading || acceptState.loading || rejectState.loading,
+    error: error || acceptState.error || rejectState.error,
+    acceptPartnerRequest: doAcceptPartnerRequest,
+    rejectPartnerRequest: doRejectPartnerRequest,
+  };
+};

--- a/src/ui/partner/partner/views/CustomerRequestsSection.tsx
+++ b/src/ui/partner/partner/views/CustomerRequestsSection.tsx
@@ -1,0 +1,135 @@
+import { css } from "@emotion/css";
+import type { PartnerRequest } from "@openshift-migration-advisor/planner-sdk";
+import {
+  Alert,
+  Button,
+  Content,
+  Flex,
+  FlexItem,
+  InputGroup,
+  InputGroupItem,
+  PageSection,
+  Title,
+} from "@patternfly/react-core";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+import React, { useState } from "react";
+
+import { sortByNewestFirst } from "../../../../lib/common/Sort";
+import { LoadingSpinner } from "../../../core/components/LoadingSpinner";
+import { RequestStatus } from "../../regularUser/components/RequestStatus";
+import { type RejectPartnerRequestFormValues } from "../components/RejectPartnerRequestForm";
+import { RejectPartnerRequestModal } from "../components/RejectPartnerRequestModal";
+import { useCustomerRequestsViewModel } from "../view-models/useCustomerRequestsViewModel";
+
+const introStyle = css`
+  padding-bottom: 1em;
+`;
+
+export const CustomerRequestsSection: React.FC = () => {
+  const vm = useCustomerRequestsViewModel();
+  const [requestToReject, setRequestToReject] = useState<PartnerRequest | null>(
+    null,
+  );
+
+  const handleAccept = async (request: PartnerRequest) => {
+    await vm.acceptPartnerRequest(request.id);
+  };
+
+  const handleReject = async (values: RejectPartnerRequestFormValues) => {
+    if (requestToReject) {
+      await vm.rejectPartnerRequest(requestToReject.id, values.reason);
+    }
+  };
+
+  return (
+    <PageSection>
+      <Content className={introStyle}>
+        <Title headingLevel="h1">Customer assignment requests</Title>
+        <Content component="p">
+          View and manage customer assignment requests. Approve or reject
+          requests from customers who want to work with you.
+        </Content>
+      </Content>
+
+      {vm.isLoading && <LoadingSpinner />}
+
+      {vm.error && (
+        <div className={introStyle}>
+          <Alert isInline variant="danger" title="Customer Requests API error">
+            {vm.error.message}
+          </Alert>
+        </div>
+      )}
+
+      {!vm.isLoading && !vm.error && vm.requests.length === 0 && (
+        <Content>
+          <Content component="p">No customer requests yet.</Content>
+        </Content>
+      )}
+
+      {!vm.isLoading && !vm.error && vm.requests.length > 0 && (
+        <Table aria-label="Customer request table" variant="compact">
+          <Thead>
+            <Tr>
+              <Th>Customer</Th>
+              <Th>Status</Th>
+              <Th>Reason</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {sortByNewestFirst(vm.requests).map((request) => (
+              <Tr key={request.id}>
+                <Td dataLabel="Customer">{request.partner.name}</Td>
+                <Td dataLabel="Status">
+                  <Flex>
+                    <FlexItem>
+                      <RequestStatus status={request.requestStatus} />
+                    </FlexItem>
+                    <FlexItem>
+                      {request.requestStatus === "pending" && (
+                        <InputGroup>
+                          <InputGroupItem>
+                            <Button
+                              variant="link"
+                              size="sm"
+                              onClick={() => {
+                                void handleAccept(request);
+                              }}
+                            >
+                              Accept
+                            </Button>
+                          </InputGroupItem>
+                          <InputGroupItem>
+                            <Button
+                              variant="link"
+                              size="sm"
+                              isDanger
+                              onClick={() => setRequestToReject(request)}
+                            >
+                              Reject
+                            </Button>
+                          </InputGroupItem>
+                        </InputGroup>
+                      )}
+                    </FlexItem>
+                  </Flex>
+                </Td>
+                <Td dataLabel="Status reason">{request.reason}</Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      )}
+
+      <RejectPartnerRequestModal
+        isOpen={requestToReject !== null}
+        onClose={() => setRequestToReject(null)}
+        onSubmit={(values) => {
+          void handleReject(values);
+        }}
+      />
+    </PageSection>
+  );
+};
+
+CustomerRequestsSection.displayName = "CustomerRequestsSection";

--- a/src/ui/partner/partner/views/CustomersScreen.tsx
+++ b/src/ui/partner/partner/views/CustomersScreen.tsx
@@ -1,14 +1,9 @@
-import { PageSection, Title } from "@patternfly/react-core";
 import type React from "react";
 
+import { CustomerRequestsSection } from "./CustomerRequestsSection";
+
 export const CustomersScreen: React.FC = () => {
-  return (
-    <PageSection>
-      <Title headingLevel="h1" size="2xl">
-        Customers
-      </Title>
-    </PageSection>
-  );
+  return <CustomerRequestsSection />;
 };
 
 CustomersScreen.displayName = "CustomersScreen";


### PR DESCRIPTION
Implement a customer requests section for partner users to view and track customer assignment requests.

Allow a partner to accept or reject a partner requests.