### PR TITLE
ECOPROJECT-4458 | fix: Prevent infinite re-render in GroupMembersSection

### DIFF
--- a/src/data/stores/GroupMembersStore.ts
+++ b/src/data/stores/GroupMembersStore.ts
@@ -17,6 +17,10 @@ export class GroupMembersStore
   private members: Member[] = [];
   private api: AccountApiInterface;
   private currentGroupId: string | null = null;
+  private snapshot: GroupMembersSnapshot = {
+    groupId: null,
+    members: [],
+  };
 
   constructor(api: AccountApiInterface) {
     super();
@@ -26,6 +30,10 @@ export class GroupMembersStore
   async list(groupId: string): Promise<Member[]> {
     this.members = await this.api.listGroupMembers({ id: groupId });
     this.currentGroupId = groupId;
+    this.snapshot = {
+      groupId: this.currentGroupId,
+      members: this.members,
+    };
     this.notify();
     return this.members;
   }
@@ -37,6 +45,10 @@ export class GroupMembersStore
     });
     if (this.currentGroupId === groupId) {
       this.members = [...this.members, newMember];
+      this.snapshot = {
+        groupId: this.currentGroupId,
+        members: this.members,
+      };
       this.notify();
     }
     return newMember;
@@ -51,14 +63,15 @@ export class GroupMembersStore
       this.members = this.members.filter(
         (member) => member.username !== username,
       );
+      this.snapshot = {
+        groupId: this.currentGroupId,
+        members: this.members,
+      };
       this.notify();
     }
   }
 
   override getSnapshot(): GroupMembersSnapshot {
-    return {
-      groupId: this.currentGroupId,
-      members: this.members,
-    };
+    return this.snapshot;
   }
 }

--- a/src/data/stores/__tests__/GroupMembersStore.test.ts
+++ b/src/data/stores/__tests__/GroupMembersStore.test.ts
@@ -194,4 +194,30 @@ describe("GroupMembersStore", () => {
 
     expect(listener).not.toHaveBeenCalled();
   });
+
+  // Non-regression test for infinite re-render bug
+  it("getSnapshot() returns same reference when state unchanged", () => {
+    const snapshot1 = store.getSnapshot();
+    const snapshot2 = store.getSnapshot();
+    const snapshot3 = store.getSnapshot();
+
+    expect(snapshot1).toBe(snapshot2);
+    expect(snapshot2).toBe(snapshot3);
+  });
+
+  it("getSnapshot() returns new reference after list() updates state", async () => {
+    const snapshotBefore = store.getSnapshot();
+
+    const members = [makeMember({ username: "user1" })];
+    vi.mocked(api.listGroupMembers).mockResolvedValue(members as never);
+    await store.list("g-1");
+
+    const snapshotAfter1 = store.getSnapshot();
+    const snapshotAfter2 = store.getSnapshot();
+
+    // New reference after update
+    expect(snapshotAfter1).not.toBe(snapshotBefore);
+    // Same reference for subsequent calls
+    expect(snapshotAfter1).toBe(snapshotAfter2);
+  });
 });

--- a/src/ui/partner/admin/components/CreateGroupMemberModal.tsx
+++ b/src/ui/partner/admin/components/CreateGroupMemberModal.tsx
@@ -13,15 +13,17 @@ import {
   GroupMemberForm,
 } from "./GroupMemberForm";
 
-interface CreateAuthorizedMemberModalProps {
+interface CreateGroupMemberModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSubmit: (values: CreateGroupMemberFormValues) => void | Promise<void>;
 }
 
-export const CreateGroupMemberModal: React.FC<
-  CreateAuthorizedMemberModalProps
-> = ({ isOpen, onClose, onSubmit }) => {
+export const CreateGroupMemberModal: React.FC<CreateGroupMemberModalProps> = ({
+  isOpen,
+  onClose,
+  onSubmit,
+}) => {
   const handleSubmit = async (values: CreateGroupMemberFormValues) => {
     await onSubmit(values);
     onClose();
@@ -32,23 +34,19 @@ export const CreateGroupMemberModal: React.FC<
       variant={ModalVariant.medium}
       isOpen={isOpen}
       onClose={onClose}
-      aria-label="Add authorized member"
+      aria-label="Add group member"
     >
-      <ModalHeader title="Add authorized member" />
+      <ModalHeader title="Add group member" />
       <ModalBody>
         <GroupMemberForm
-          id="create-authorized-member-form"
+          id="create-group-member-form"
           onSubmit={(values) => {
             void handleSubmit(values);
           }}
         />
       </ModalBody>
       <ModalFooter>
-        <Button
-          variant="primary"
-          type="submit"
-          form="create-authorized-member-form"
-        >
+        <Button variant="primary" type="submit" form="create-group-member-form">
           Add
         </Button>
         <Button variant="link" onClick={onClose}>
@@ -59,4 +57,4 @@ export const CreateGroupMemberModal: React.FC<
   );
 };
 
-CreateGroupMemberModal.displayName = "CreateAuthorizedMemberModal";
+CreateGroupMemberModal.displayName = "CreateGroupMemberModal";

--- a/src/ui/partner/admin/views/GroupMembersSection.tsx
+++ b/src/ui/partner/admin/views/GroupMembersSection.tsx
@@ -165,4 +165,4 @@ export const GroupMembersSection: React.FC<GroupMembersSectionProps> = ({
   );
 };
 
-GroupMembersSection.displayName = "AuthorizedUsersSection";
+GroupMembersSection.displayName = "GroupMembersSection";


### PR DESCRIPTION
Cache the snapshot object in GroupMembersStore to ensure getSnapshot() returns the same reference when state is unchanged. Previously, getSnapshot() created a new object on every call, causing useSyncExternalStore to trigger infinite re-renders.

Also fixes display names and labels:
* GroupMembersSection.displayName: "AuthorizedUsersSection" > "GroupMembersSection"
* CreateGroupMemberModal: "authorized member" > "group member"