### PR TITLE
ECOPROJECT-4474 | feat: Add assessment sharing for customer users

### DIFF
--- a/src/data/stores/AssessmentsStore.ts
+++ b/src/data/stores/AssessmentsStore.ts
@@ -195,6 +195,10 @@ export class AssessmentsStore
     return deletedAssessment;
   }
 
+  async share(id: string) {
+    await this.api.shareAssessment({ id });
+  }
+
   calculateAssessmentClusterRequirements(
     requestParameters: CalculateAssessmentClusterRequirementsRequest,
     initOverrides?: RequestInit | InitOverrideFunction,

--- a/src/data/stores/interfaces/IAssessmentsStore.ts
+++ b/src/data/stores/interfaces/IAssessmentsStore.ts
@@ -41,6 +41,7 @@ export interface IAssessmentsStore extends ExternalStore<AssessmentModel[]> {
     id: string,
     initOverrides?: RequestInit | InitOverrideFunction,
   ): Promise<AssessmentModel>;
+  share(id: string): Promise<void>;
   calculateAssessmentClusterRequirements(
     requestParameters: CalculateAssessmentClusterRequirementsRequest,
     initOverrides?: RequestInit | InitOverrideFunction,

--- a/src/ui/assessment/view-models/__tests__/useAssessmentPageViewModel.test.ts
+++ b/src/ui/assessment/view-models/__tests__/useAssessmentPageViewModel.test.ts
@@ -1,4 +1,4 @@
-import type { Job } from "@openshift-migration-advisor/planner-sdk";
+import type { Identity, Job } from "@openshift-migration-advisor/planner-sdk";
 import { JobStatus } from "@openshift-migration-advisor/planner-sdk";
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -17,6 +17,12 @@ vi.mock("react-router-dom", () => ({
 }));
 
 // Mock stores that will be injected
+let mockAccountStore: {
+  getIdentity: ReturnType<typeof vi.fn>;
+  subscribe: ReturnType<typeof vi.fn>;
+  getSnapshot: ReturnType<typeof vi.fn>;
+};
+
 let mockAssessmentsStore: {
   list: ReturnType<typeof vi.fn>;
   update: ReturnType<typeof vi.fn>;
@@ -38,10 +44,12 @@ let mockJobsStore: {
 
 let jobsStoreState: JobsStoreState;
 let jobsListeners: Set<() => void>;
+let accountStoreState: Identity | null;
 
 vi.mock("@y0n1/react-ioc", () => ({
   useInjection: (symbol: symbol) => {
     const key = symbol.description;
+    if (key === "AccountStore") return mockAccountStore;
     if (key === "AssessmentsStore") return mockAssessmentsStore;
     if (key === "JobsStore") return mockJobsStore;
     throw new Error(`Unexpected symbol: ${String(symbol)}`);
@@ -73,12 +81,22 @@ describe("useAssessmentPageViewModel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
+    accountStoreState = null;
     jobsStoreState = {
       currentJob: null,
       isCreating: false,
       createError: undefined,
     };
     jobsListeners = new Set();
+
+    mockAccountStore = {
+      getIdentity: vi.fn().mockResolvedValue(null),
+      subscribe: vi.fn((_fn: () => void) => {
+        // no-op for account store in these tests
+        return () => {};
+      }),
+      getSnapshot: vi.fn(() => accountStoreState),
+    };
 
     mockAssessmentsStore = {
       list: vi.fn().mockResolvedValue([]),
@@ -124,6 +142,20 @@ describe("useAssessmentPageViewModel", () => {
     expect(result.current.deleteError).toBeUndefined();
     expect(result.current.isUpdatingAssessment).toBe(false);
     expect(result.current.updateError).toBeUndefined();
+  });
+
+  it("exposes identity for a regular user", () => {
+    const regularUser: Identity = {
+      username: "user-1",
+      kind: "regular",
+      groupId: "group-regular-1",
+      partnerId: null,
+    };
+    accountStoreState = regularUser;
+
+    const { result } = renderHook(() => useAssessmentPageViewModel());
+
+    expect(result.current.identity).toEqual(regularUser);
   });
 
   // -- createRVToolsJob -----------------------------------------------------

--- a/src/ui/assessment/view-models/useAssessmentPageViewModel.ts
+++ b/src/ui/assessment/view-models/useAssessmentPageViewModel.ts
@@ -1,4 +1,4 @@
-import type { Job } from "@openshift-migration-advisor/planner-sdk";
+import type { Identity, Job } from "@openshift-migration-advisor/planner-sdk";
 import { JobStatus } from "@openshift-migration-advisor/planner-sdk";
 import { useInjection } from "@y0n1/react-ioc";
 import {
@@ -13,6 +13,7 @@ import { useNavigate } from "react-router-dom";
 import { useAsyncFn } from "react-use";
 
 import { Symbols } from "../../../config/Dependencies";
+import type { IAccountStore } from "../../../data/stores/interfaces/IAccountStore";
 import type { IAssessmentsStore } from "../../../data/stores/interfaces/IAssessmentsStore";
 import type { IJobsStore } from "../../../data/stores/interfaces/IJobsStore";
 import {
@@ -83,6 +84,8 @@ const extractErrorMessage = (message: string): string => {
 // ---------------------------------------------------------------------------
 
 export interface AssessmentPageViewModel {
+  /** Current user identity (null when not logged in). */
+  identity: Identity | null;
   /** Current RVTools job (null when idle). */
   currentJob: Job | null;
   /** `true` while the create-job request is in flight. */
@@ -142,8 +145,14 @@ export interface AssessmentPageViewModel {
   cancelRVToolsJob: () => Promise<void>;
   /** Update an existing assessment's name. */
   updateAssessment: (id: string, name: string) => Promise<void>;
+
   /** Delete an assessment by id. */
   deleteAssessment: (id: string) => Promise<void>;
+
+  /** Share assessment with partner. */
+  shareAssessment: (id: string) => Promise<void>;
+  isSharingAssessment: boolean;
+  shareError?: Error;
 }
 
 // ---------------------------------------------------------------------------
@@ -153,10 +162,16 @@ export interface AssessmentPageViewModel {
 export const useAssessmentPageViewModel = (): AssessmentPageViewModel => {
   const navigate = useNavigate();
 
+  const accountStore = useInjection<IAccountStore>(Symbols.AccountStore);
   const assessmentsStore = useInjection<IAssessmentsStore>(
     Symbols.AssessmentsStore,
   );
   const jobsStore = useInjection<IJobsStore>(Symbols.JobsStore);
+
+  const identity = useSyncExternalStore(
+    accountStore.subscribe.bind(accountStore),
+    accountStore.getSnapshot.bind(accountStore),
+  );
 
   const jobState = useSyncExternalStore(
     jobsStore.subscribe.bind(jobsStore),
@@ -289,6 +304,13 @@ export const useAssessmentPageViewModel = (): AssessmentPageViewModel => {
     [assessmentsStore],
   );
 
+  const [shareState, doShareAssessment] = useAsyncFn(
+    async (id: string): Promise<void> => {
+      await assessmentsStore.share(id);
+    },
+    [assessmentsStore],
+  );
+
   const [deleteState, doDeleteAssessment] = useAsyncFn(
     async (id: string): Promise<void> => {
       await assessmentsStore.remove(id);
@@ -329,6 +351,7 @@ export const useAssessmentPageViewModel = (): AssessmentPageViewModel => {
     );
 
   return {
+    identity,
     currentJob,
     isCreatingJob: jobState.isCreating,
     jobCreateError: jobState.createError,
@@ -352,5 +375,8 @@ export const useAssessmentPageViewModel = (): AssessmentPageViewModel => {
     cancelRVToolsJob,
     updateAssessment: doUpdateAssessment,
     deleteAssessment: doDeleteAssessment,
+    shareAssessment: doShareAssessment,
+    isSharingAssessment: shareState.loading,
+    shareError: shareState.error,
   };
 };

--- a/src/ui/assessment/views/AssessmentsPage.tsx
+++ b/src/ui/assessment/views/AssessmentsPage.tsx
@@ -26,7 +26,8 @@ import CreateAssessmentDropdown from "../../core/components/CreateAssessmentDrop
 import FilterPill from "../../core/components/FilterPill";
 import { useAssessmentPageViewModel } from "../view-models/useAssessmentPageViewModel";
 import AssessmentEmptyState from "./AssessmentEmptyState";
-import AssessmentsTable, {
+import {
+  AssessmentsTable,
   type ColumnKey,
   Columns,
   MANDATORY_COLUMNS,
@@ -37,7 +38,7 @@ import CreateAssessmentModal, {
 } from "./CreateAssessmentModal";
 import UpdateAssessment from "./UpdateAssessment";
 
-type AssessmentProps = {
+type AssessmentsPageProps = {
   assessments: AssessmentModel[];
   // When this token changes, the component should open the RVTools modal.
   rvtoolsOpenToken?: string;
@@ -79,11 +80,12 @@ const tableContainerStyle = css`
   overflow: auto;
 `;
 
-const Assessment: React.FC<AssessmentProps> = ({
+export const AssessmentsPage: React.FC<AssessmentsPageProps> = ({
   assessments,
   rvtoolsOpenToken,
 }) => {
   const {
+    identity,
     isCreatingJob,
     jobCreateError,
     isJobProcessing,
@@ -91,6 +93,7 @@ const Assessment: React.FC<AssessmentProps> = ({
     jobProgressLabel,
     jobError,
     isNavigatingToReport,
+    isSharingAssessment,
     isDeletingAssessment,
     isColumnSelectOpen,
     setIsColumnSelectOpen,
@@ -101,8 +104,9 @@ const Assessment: React.FC<AssessmentProps> = ({
     createRVToolsJob,
     clearJobCreateError,
     cancelRVToolsJob,
-    updateAssessment: vmUpdateAssessment,
-    deleteAssessment: vmDeleteAssessment,
+    updateAssessment,
+    shareAssessment,
+    deleteAssessment,
   } = useAssessmentPageViewModel();
 
   const [search, setSearch] = useState("");
@@ -110,6 +114,7 @@ const Assessment: React.FC<AssessmentProps> = ({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalMode, setModalMode] = useState<AssessmentMode>("inventory");
   const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
+  const [isSharingModalOpen, setIsSharingModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [selectedAssessment, setSelectedAssessment] =
     useState<AssessmentModel | null>(null);
@@ -197,6 +202,13 @@ const Assessment: React.FC<AssessmentProps> = ({
       setIsUpdateModalOpen(true);
     }
   };
+  const handleShareAssessment = (assessmentId: string): void => {
+    const assessment = assessments.find((a) => a.id === assessmentId);
+    if (assessment) {
+      setSelectedAssessment(assessment);
+      setIsSharingModalOpen(true);
+    }
+  };
 
   const isTableEmpty = (): boolean => {
     return !Array.isArray(assessments) || assessments.length === 0;
@@ -215,6 +227,11 @@ const Assessment: React.FC<AssessmentProps> = ({
     setSelectedAssessment(null);
   };
 
+  const handleCloseSharingModal = (): void => {
+    setIsSharingModalOpen(false);
+    setSelectedAssessment(null);
+  };
+
   const handleCloseDeleteModal = (): void => {
     setIsDeleteModalOpen(false);
     setSelectedAssessment(null);
@@ -222,13 +239,19 @@ const Assessment: React.FC<AssessmentProps> = ({
 
   const handleConfirmUpdate = async (name: string): Promise<void> => {
     if (!selectedAssessment) return;
-    await vmUpdateAssessment(selectedAssessment.id, name);
+    await updateAssessment(selectedAssessment.id, name);
     handleCloseUpdateModal();
+  };
+
+  const handleConfirmShare = async (): Promise<void> => {
+    if (!selectedAssessment) return;
+    await shareAssessment(selectedAssessment.id);
+    handleCloseSharingModal();
   };
 
   const handleConfirmDelete = async (): Promise<void> => {
     if (!selectedAssessment) return;
-    await vmDeleteAssessment(selectedAssessment.id);
+    await deleteAssessment(selectedAssessment.id);
     handleCloseDeleteModal();
   };
 
@@ -481,9 +504,11 @@ const Assessment: React.FC<AssessmentProps> = ({
             onSort={onSort}
             onDelete={handleDeleteAssessment}
             onUpdate={handleUpdateAssessment}
+            onShareAssessment={handleShareAssessment}
             selectedSourceTypes={selectedSourceTypes}
             selectedOwners={selectedOwners}
             visibleColumns={visibleColumns}
+            canShareAssessment={identity?.kind === "customer"}
           />
         </div>
       )}
@@ -514,6 +539,23 @@ const Assessment: React.FC<AssessmentProps> = ({
       />
 
       <ConfirmationModal
+        isOpen={isSharingModalOpen}
+        onClose={handleCloseSharingModal}
+        onCancel={handleCloseSharingModal}
+        onConfirm={() => {
+          void handleConfirmShare();
+        }}
+        isDisabled={isSharingAssessment}
+        title="Share Assessment"
+        primaryButtonVariant="primary"
+        confirmButtonText="Share"
+      >
+        Are you sure you want to share{" "}
+        <b>{(selectedAssessment as AssessmentModel)?.name}</b> with your
+        partner?
+      </ConfirmationModal>
+
+      <ConfirmationModal
         isOpen={isDeleteModalOpen}
         onClose={handleCloseDeleteModal}
         onCancel={handleCloseDeleteModal}
@@ -532,6 +574,4 @@ const Assessment: React.FC<AssessmentProps> = ({
   );
 };
 
-Assessment.displayName = "Assessment";
-
-export default Assessment;
+AssessmentsPage.displayName = "AssessmentsPage";

--- a/src/ui/assessment/views/AssessmentsScreen.tsx
+++ b/src/ui/assessment/views/AssessmentsScreen.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { LoadingSpinner } from "../../core/components/LoadingSpinner";
 import { useAssessmentsScreenViewModel } from "../view-models/useAssessmentsScreenViewModel";
-import AssessmentPage from "./Assessment";
+import { AssessmentsPage } from "./AssessmentsPage";
 
 export const AssessmentsScreen: React.FC = () => {
   const { assessments, isLoading, hasInitialLoad, rvtoolsOpenToken } =
@@ -15,10 +15,11 @@ export const AssessmentsScreen: React.FC = () => {
 
   // Always show assessment component
   return (
-    <AssessmentPage
+    <AssessmentsPage
       assessments={assessments}
       rvtoolsOpenToken={rvtoolsOpenToken}
     />
   );
 };
+
 AssessmentsScreen.displayName = "AssessmentsScreen";

--- a/src/ui/assessment/views/AssessmentsTable.tsx
+++ b/src/ui/assessment/views/AssessmentsTable.tsx
@@ -46,7 +46,7 @@ const openAssistedInstaller = (): void => {
   }
 };
 
-type Props = {
+type AssessmentsTableProps = {
   assessments: AssessmentModel[];
   search?: string;
   filterBy?: string;
@@ -62,6 +62,8 @@ type Props = {
   onDelete?: (assessmentId: string) => void;
   onUpdate?: (assessmentId: string) => void;
   visibleColumns?: ColumnKey[];
+  canShareAssessment: boolean;
+  onShareAssessment: (assessmentId: string) => void;
 };
 
 export const Columns = {
@@ -92,7 +94,7 @@ export const SORTABLE_COLUMNS: SortableColumn[] = [
   "Datastores",
 ];
 
-export const AssessmentsTable: React.FC<Props> = ({
+export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
   assessments,
   search: _search = "",
   filterBy = "Filter",
@@ -103,6 +105,8 @@ export const AssessmentsTable: React.FC<Props> = ({
   onSort,
   onDelete,
   visibleColumns = Object.keys(Columns) as ColumnKey[],
+  canShareAssessment,
+  onShareAssessment,
 }) => {
   const navigate = useNavigate();
   const [openDropdowns, setOpenDropdowns] = useState<Record<string, boolean>>(
@@ -585,13 +589,28 @@ export const AssessmentsTable: React.FC<Props> = ({
                     >
                       Edit assessment
                     </DropdownItem>
+                    {canShareAssessment && (
+                      <DropdownItem
+                        onClick={() => {
+                          toggleDropdown(row.id);
+                          return onShareAssessment(row.id);
+                        }}
+                      >
+                        Share with partner
+                      </DropdownItem>
+                    )}
                     <DropdownItem
                       onClick={openAssistedInstaller}
                       isDisabled={!row.hasData}
                     >
                       Create a target cluster
                     </DropdownItem>
-                    <DropdownItem onClick={() => handleDelete(row.id)}>
+                    <DropdownItem
+                      onClick={() => {
+                        toggleDropdown(row.id);
+                        return handleDelete(row.id);
+                      }}
+                    >
                       Delete assessment
                     </DropdownItem>
                   </DropdownList>
@@ -606,5 +625,3 @@ export const AssessmentsTable: React.FC<Props> = ({
 };
 
 AssessmentsTable.displayName = "AssessmentsTable";
-
-export default AssessmentsTable;

--- a/src/ui/core/components/ConfirmationModal.tsx
+++ b/src/ui/core/components/ConfirmationModal.tsx
@@ -43,7 +43,7 @@ export const ConfirmationModal: React.FC<
     onConfirm,
     onCancel,
     variant = "small",
-    titleIconVariant = "info",
+    titleIconVariant,
     primaryButtonVariant = "danger",
     confirmButtonText = "Delete",
     cancelButtonText = "Cancel",

--- a/src/ui/partner/partner/components/CustomersTable.tsx
+++ b/src/ui/partner/partner/components/CustomersTable.tsx
@@ -24,7 +24,7 @@ export const CustomersTable: React.FC<CustomersTableProps> = ({
         variant="sm"
       >
         <EmptyStateBody>
-          No customers yet. To get started, accept a pending requests.
+          No customers yet. To get started, accept a pending request.
         </EmptyStateBody>
       </EmptyState>
     );

--- a/src/ui/partner/partner/views/CustomerRequestsSection.tsx
+++ b/src/ui/partner/partner/views/CustomerRequestsSection.tsx
@@ -125,7 +125,7 @@ export const CustomerRequestsSection: React.FC = () => {
                     <RequestStatus status={request.requestStatus} />
                   )}
                 </Td>
-                <Td dataLabel="Status reason">
+                <Td dataLabel="Reason">
                   {request.reason ? request.reason : "N/A"}
                 </Td>
               </Tr>

--- a/src/ui/partner/regularUser/components/ContactFormModal.tsx
+++ b/src/ui/partner/regularUser/components/ContactFormModal.tsx
@@ -28,12 +28,7 @@ export const ContactFormModal: React.FC<ContactFormModalProps> = ({
   };
 
   return (
-    <Modal
-      variant={ModalVariant.medium}
-      isOpen={isOpen}
-      onClose={onClose}
-      aria-label="Connect with a partner"
-    >
+    <Modal variant={ModalVariant.medium} isOpen={isOpen} onClose={onClose}>
       <ModalHeader title="Request a partner" />
       <ModalBody>
         <ContactForm


### PR DESCRIPTION
Enable customer users to share assessments with their partners through a new share action in the assessments table.
The feature includes identity tracking to conditionally display the share option, a confirmation modal workflow, and backend API integration via the AssessmentsStore.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assessment sharing capability added – users can now share assessments with partners via a dedicated "Share with partner" action in the assessment table.
  * Share confirmation modal implemented to ensure intentional sharing actions.
  * User identity information now displayed and integrated throughout the assessment workflow.

* **Bug Fixes**
  * Corrected text singularization in customer request messages.
  * Updated column header labels for clarity in partner tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->