### PR TITLE
ECOPROJECT-4213 | feat: export the cluster recommendation to the pdf report

### DIFF
--- a/src/data/stores/AssessmentsStore.ts
+++ b/src/data/stores/AssessmentsStore.ts
@@ -4,6 +4,7 @@ import {
   type CalculateMigrationComplexityRequest,
   type CalculateMigrationEstimationByComplexityRequest,
   type CalculateMigrationEstimationRequest,
+  type GetAssessmentClusterRequirementsStoredInputRequest,
   ResponseError,
 } from "@openshift-migration-advisor/planner-sdk";
 import { type Assessment } from "@openshift-migration-advisor/planner-sdk";
@@ -200,6 +201,16 @@ export class AssessmentsStore
     initOverrides?: RequestInit | InitOverrideFunction,
   ) {
     return this.api.calculateAssessmentClusterRequirements(
+      requestParameters,
+      initOverrides,
+    );
+  }
+
+  getAssessmentClusterRequirementsStoredInput(
+    requestParameters: GetAssessmentClusterRequirementsStoredInputRequest,
+    initOverrides?: RequestInit | InitOverrideFunction,
+  ) {
+    return this.api.getAssessmentClusterRequirementsStoredInput(
       requestParameters,
       initOverrides,
     );

--- a/src/data/stores/ReportStore.ts
+++ b/src/data/stores/ReportStore.ts
@@ -4,7 +4,10 @@ import type {
   InventoryData,
   SnapshotLike,
 } from "../../services/html-export/types";
-import type { PdfExportService } from "../../services/pdf-export/PdfExportService";
+import type {
+  PdfExtraPage,
+  PdfExportService,
+} from "../../services/pdf-export/PdfExportService";
 import type { IReportStore, ReportStoreState } from "./interfaces/IReportStore";
 
 const IDLE_STATE: ReportStoreState = Object.freeze({
@@ -35,7 +38,11 @@ export class ReportStore
 
   async exportPdf(
     container: HTMLElement,
-    options?: { documentTitle?: string },
+    options?: {
+      documentTitle?: string;
+      additionalTocItems?: string[];
+      extraPages?: PdfExtraPage[];
+    },
   ): Promise<void> {
     this.setState({ loadingState: "generating-pdf", error: null });
 

--- a/src/data/stores/interfaces/IAssessmentsStore.ts
+++ b/src/data/stores/interfaces/IAssessmentsStore.ts
@@ -4,6 +4,8 @@ import type {
   CalculateMigrationEstimationByComplexityRequest,
   CalculateMigrationEstimationRequest,
   ClusterRequirementsResponse,
+  ClusterRequirementsStoredInput,
+  GetAssessmentClusterRequirementsStoredInputRequest,
   InitOverrideFunction,
   MigrationComplexityResponse,
   MigrationEstimationByComplexityResponse,
@@ -45,6 +47,10 @@ export interface IAssessmentsStore extends ExternalStore<AssessmentModel[]> {
     requestParameters: CalculateAssessmentClusterRequirementsRequest,
     initOverrides?: RequestInit | InitOverrideFunction,
   ): Promise<ClusterRequirementsResponse>;
+  getAssessmentClusterRequirementsStoredInput(
+    requestParameters: GetAssessmentClusterRequirementsStoredInputRequest,
+    initOverrides?: RequestInit | InitOverrideFunction,
+  ): Promise<ClusterRequirementsStoredInput>;
   calculateMigrationEstimation(
     requestParameters: CalculateMigrationEstimationRequest,
     initOverrides?: RequestInit | InitOverrideFunction,

--- a/src/data/stores/interfaces/IReportStore.ts
+++ b/src/data/stores/interfaces/IReportStore.ts
@@ -21,7 +21,11 @@ export interface ReportStoreState {
 export interface IReportStore extends ExternalStore<ReportStoreState> {
   exportPdf(
     container: HTMLElement,
-    options?: { documentTitle?: string },
+    options?: {
+      documentTitle?: string;
+      additionalTocItems?: string[];
+      extraPages?: import("../../../services/pdf-export/PdfExportService").PdfExtraPage[];
+    },
   ): Promise<void>;
   exportHtml(
     inventory: unknown,

--- a/src/services/pdf-export/PdfExportService.ts
+++ b/src/services/pdf-export/PdfExportService.ts
@@ -42,8 +42,27 @@ const TOC_ITEMS = [
  */
 const EXPECTED_CUSTOM_SEGMENTS = 3;
 
+export interface PdfExtraPageItem {
+  label: string;
+  value: string;
+}
+
+export interface PdfExtraPage {
+  title: string;
+  items: PdfExtraPageItem[];
+  footer?: string;
+}
+
 export interface PdfExportOptions {
   documentTitle?: string;
+  /** Extra items appended to the table of contents on the cover page. */
+  additionalTocItems?: string[];
+  /**
+   * Additional pages appended after the canvas-based report pages.
+   * Each entry becomes one new PDF page rendered with native jsPDF text,
+   * so it is guaranteed to start on a fresh page with no bleed.
+   */
+  extraPages?: PdfExtraPage[];
 }
 
 interface BlockBoundary {
@@ -89,6 +108,8 @@ export class PdfExportService {
       container.clientWidth,
       options.documentTitle,
       backgroundColor,
+      options.additionalTocItems,
+      options.extraPages,
     );
     this.downloadPdf(pdf, options.documentTitle);
   }
@@ -163,6 +184,8 @@ export class PdfExportService {
     containerClientWidth: number,
     documentTitle?: string,
     backgroundColor = "#ffffff",
+    additionalTocItems?: string[],
+    extraPages?: PdfExtraPage[],
   ): jsPDF {
     const pdf = new jsPDF("p", "mm", "a4");
     const pageWidth = pdf.internal.pageSize.getWidth();
@@ -176,7 +199,14 @@ export class PdfExportService {
     const imgHeight = canvas.height;
 
     // Build cover page with TOC
-    this.buildCoverPage(pdf, pageWidth, pageHeight, margin, documentTitle);
+    this.buildCoverPage(
+      pdf,
+      pageWidth,
+      pageHeight,
+      margin,
+      documentTitle,
+      additionalTocItems,
+    );
     pdf.addPage();
 
     // Calculate scaling
@@ -231,6 +261,11 @@ export class PdfExportService {
       );
     }
 
+    // Append any extra pages (e.g. cluster sizing recommendations)
+    if (extraPages && extraPages.length > 0) {
+      this.addExtraPages(pdf, extraPages, pageWidth, pageHeight, margin);
+    }
+
     // Add page numbers
     this.addPageNumbers(pdf, pageWidth, pageHeight);
 
@@ -243,6 +278,7 @@ export class PdfExportService {
     pageHeight: number,
     margin: number,
     documentTitle?: string,
+    additionalTocItems?: string[],
   ): void {
     pdf.setFillColor(255, 255, 255);
     pdf.rect(0, 0, pageWidth, pageHeight, "F");
@@ -278,9 +314,11 @@ export class PdfExportService {
     pdf.setFontSize(14);
     pdf.text("Table of contents", margin, tocStartY);
 
+    const allTocItems: string[] = [...TOC_ITEMS, ...(additionalTocItems ?? [])];
+
     pdf.setFontSize(11);
     let tocY = tocStartY + 10;
-    TOC_ITEMS.forEach((line) => {
+    allTocItems.forEach((line) => {
       if (tocY > pageHeight - margin - 10) {
         pdf.addPage();
         tocY = margin;
@@ -541,6 +579,77 @@ export class PdfExportService {
       renderWidthMm,
       renderHeightMm,
     );
+  }
+
+  private addExtraPages(
+    pdf: jsPDF,
+    extraPages: PdfExtraPage[],
+    pageWidth: number,
+    pageHeight: number,
+    margin: number,
+  ): void {
+    const LABEL_COL_WIDTH = 68; // mm — enough for the longest label
+    const VALUE_COL_X = margin + LABEL_COL_WIDTH;
+    const VALUE_COL_WIDTH = pageWidth - margin - LABEL_COL_WIDTH;
+    const LINE_HEIGHT = 7; // mm between rows
+
+    for (const page of extraPages) {
+      pdf.addPage();
+      let y = margin + 8;
+
+      // Title
+      pdf.setFontSize(16);
+      pdf.setFont("helvetica", "bold");
+      pdf.text(page.title, margin, y);
+      y += 10;
+
+      // Accent line below title
+      pdf.setDrawColor(0, 103, 187);
+      pdf.setLineWidth(0.5);
+      pdf.line(margin, y, pageWidth - margin, y);
+      y += 10;
+
+      pdf.setFontSize(11);
+
+      for (const item of page.items) {
+        // Label column (bold)
+        pdf.setFont("helvetica", "bold");
+        const labelLines = pdf.splitTextToSize(
+          item.label,
+          LABEL_COL_WIDTH - 4,
+        ) as string[];
+        pdf.text(labelLines, margin, y);
+
+        // Value column (normal)
+        pdf.setFont("helvetica", "normal");
+        const valueLines = pdf.splitTextToSize(
+          item.value,
+          VALUE_COL_WIDTH,
+        ) as string[];
+        pdf.text(valueLines, VALUE_COL_X, y);
+
+        y += LINE_HEIGHT * Math.max(labelLines.length, valueLines.length);
+
+        if (y > pageHeight - margin - 25) {
+          pdf.addPage();
+          y = margin + 10;
+        }
+      }
+
+      // Footer disclaimer
+      if (page.footer) {
+        y += 4;
+        pdf.setFontSize(9);
+        pdf.setFont("helvetica", "bolditalic");
+        const footerLines = pdf.splitTextToSize(
+          page.footer,
+          pageWidth - margin * 2,
+        ) as string[];
+        pdf.text(footerLines, margin, y);
+        pdf.setFont("helvetica", "normal");
+        pdf.setFontSize(11);
+      }
+    }
   }
 
   private addPageNumbers(

--- a/src/ui/report/view-models/useReportPageViewModel.ts
+++ b/src/ui/report/view-models/useReportPageViewModel.ts
@@ -1,4 +1,5 @@
 import type {
+  ClusterRequirementsResponse,
   Infra,
   InventoryData,
   Job,
@@ -31,15 +32,144 @@ import type { AssessmentModel } from "../../../models/AssessmentModel";
 import type { SourceModel } from "../../../models/SourceModel";
 import { routes } from "../../../routing/Routes";
 import type { SnapshotLike } from "../../../services/html-export/types";
+import type {
+  PdfExtraPage,
+  PdfExtraPageItem,
+} from "../../../services/pdf-export/PdfExportService";
 import {
   buildClusterViewModel,
   type ClusterViewModel,
   compareClustersByVmCount,
 } from "../helpers/clusterViewModel";
+import {
+  formatNumber,
+  formatRatio,
+  getCpuOvercommitLabel,
+  getMemoryOvercommitLabel,
+} from "./ClusterSizingHelpers";
+import type { SizingFormValues } from "../views/cluster-sizer/types";
+
+// ---------------------------------------------------------------------------
+// Sizing → PDF page builder
+// ---------------------------------------------------------------------------
+
+const buildSizingPdfExtraPage = (data: SizingPdfData): PdfExtraPage => {
+  const { result, formValues, clusterName } = data;
+  const isSNO = formValues.clusterMode === "single-node";
+  const hasControlPlane = result.clusterSizing.controlPlaneNodes > 0;
+
+  const cpuOverCommitRatio =
+    result.resourceConsumption.overCommitRatio?.cpu ?? 0;
+  const memoryOverCommitRatio =
+    result.resourceConsumption.overCommitRatio?.memory ?? 0;
+  const cpuLimits = result.resourceConsumption.limits?.cpu ?? 0;
+  const memoryLimits = result.resourceConsumption.limits?.memory ?? 0;
+
+  const items: PdfExtraPageItem[] = [
+    { label: "Cluster name", value: clusterName },
+    { label: "Target platform", value: "Bare metal" },
+  ];
+
+  if (isSNO) {
+    items.push(
+      {
+        label: "Total nodes",
+        value: String(result.clusterSizing.totalNodes),
+      },
+      {
+        label: "Node size",
+        value: `${formValues.controlPlaneCpu} CPU, ${formValues.controlPlaneMemoryGb} GB memory`,
+      },
+      {
+        label: "VMs to migrate",
+        value: formatNumber(result.inventoryTotals.totalVMs),
+      },
+      {
+        label: "VM resources (request)",
+        value: `${formatNumber(result.inventoryTotals.totalCPU)} CPU, ${formatNumber(result.inventoryTotals.totalMemory)} GB memory`,
+      },
+    );
+  } else {
+    items.push(
+      {
+        label: "Total nodes",
+        value: `${result.clusterSizing.totalNodes} (${result.clusterSizing.workerNodes} workers + ${result.clusterSizing.controlPlaneNodes} control plane)`,
+      },
+      {
+        label: "Failover capacity",
+        value: `${result.clusterSizing.failoverNodes} failover nodes`,
+      },
+    );
+
+    if (hasControlPlane) {
+      items.push(
+        {
+          label: "Worker node size",
+          value: `${formValues.customCpu} CPU, ${formValues.customMemoryGb} GB memory`,
+        },
+        {
+          label: "Control plane node size",
+          value: `${formValues.controlPlaneCpu} CPU, ${formValues.controlPlaneMemoryGb} GB memory`,
+        },
+      );
+    } else {
+      items.push({
+        label: "Node size",
+        value: `${formValues.customCpu} CPU, ${formValues.customMemoryGb} GB memory`,
+      });
+    }
+
+    items.push(
+      {
+        label: "Overcommitment",
+        value: `CPU ${getCpuOvercommitLabel(formValues.cpuOvercommitRatio)}, Memory ${getMemoryOvercommitLabel(formValues.memoryOvercommitRatio)}`,
+      },
+      {
+        label: "VMs to migrate",
+        value: formatNumber(result.inventoryTotals.totalVMs),
+      },
+      {
+        label: "CPU over-commit ratio",
+        value: formatRatio(cpuOverCommitRatio),
+      },
+      {
+        label: "Memory over-commit ratio",
+        value: formatRatio(memoryOverCommitRatio),
+      },
+      {
+        label: "VM resources (request)",
+        value: `${formatNumber(result.inventoryTotals.totalCPU)} CPU, ${formatNumber(result.inventoryTotals.totalMemory)} GB memory`,
+      },
+      {
+        label: "With over-commit (limits)",
+        value: `${formatNumber(cpuLimits)} CPU, ${formatNumber(memoryLimits)} GB memory`,
+      },
+      {
+        label: "Physical capacity",
+        value: `${formatNumber(result.clusterSizing.totalCPU)} CPU, ${formatNumber(result.clusterSizing.totalMemory)} GB memory`,
+      },
+    );
+  }
+
+  return {
+    title: "Cluster sizing recommendations",
+    items,
+    footer:
+      "Note: Resource requirements are estimates based on current workloads. Please verify this architecture with your SME team to ensure optimal performance.",
+  };
+};
 
 // ---------------------------------------------------------------------------
 // Public interface
 // ---------------------------------------------------------------------------
+
+/** Sizing result cached for inclusion in the PDF export. */
+export interface SizingPdfData {
+  result: ClusterRequirementsResponse;
+  formValues: SizingFormValues;
+  clusterName: string;
+  clusterId: string;
+}
 
 export interface ReportPageViewModel {
   // Route param
@@ -86,6 +216,12 @@ export interface ReportPageViewModel {
   // Sizing wizard
   isSizingWizardOpen: boolean;
   setIsSizingWizardOpen: (open: boolean) => void;
+  /**
+   * All sizing results calculated in this session, keyed by clusterId.
+   * Used by exportPdf to include recommendations for every sized cluster.
+   */
+  savedSizingDataMap: Record<string, SizingPdfData>;
+  onSizingCalculated: (data: SizingPdfData) => void;
 
   // RVTools modal (create-new-assessment from report page)
   isRvtoolsModalOpen: boolean;
@@ -236,6 +372,13 @@ export const useReportPageViewModel = (): ReportPageViewModel => {
   >(null);
   const [isClusterSelectOpen, setIsClusterSelectOpen] = useState(false);
   const [isSizingWizardOpen, setIsSizingWizardOpen] = useState(false);
+  const [savedSizingDataMap, setSavedSizingDataMap] = useState<
+    Record<string, SizingPdfData>
+  >({});
+
+  const onSizingCalculated = useCallback((data: SizingPdfData): void => {
+    setSavedSizingDataMap((prev) => ({ ...prev, [data.clusterId]: data }));
+  }, []);
 
   // ---- Snapshot data -------------------------------------------------------
   const latestSnapshot = useMemo((): SnapshotLike => {
@@ -428,11 +571,30 @@ export const useReportPageViewModel = (): ReportPageViewModel => {
   const exportPdf = useCallback(
     (container: HTMLElement): void => {
       const title = `${assessment?.name || `Assessment ${id}`} - vCenter report`;
+
+      // Determine which sizing entries to include:
+      // - Single cluster view → only that cluster (if calculated)
+      // - All-clusters view → every cluster that has been sized
+      const sizingEntries: SizingPdfData[] =
+        selectedClusterId === "all"
+          ? Object.values(savedSizingDataMap)
+          : savedSizingDataMap[selectedClusterId]
+            ? [savedSizingDataMap[selectedClusterId]]
+            : [];
+
+      const additionalTocItems = sizingEntries.map(
+        (entry) => `- Cluster sizing recommendations: ${entry.clusterName}`,
+      );
+
+      const extraPages = sizingEntries.map(buildSizingPdfExtraPage);
+
       void reportStore.exportPdf(container, {
         documentTitle: title,
+        additionalTocItems,
+        extraPages,
       });
     },
-    [reportStore, assessment?.name, id],
+    [reportStore, assessment?.name, id, savedSizingDataMap, selectedClusterId],
   );
 
   const exportHtml = useCallback((): void => {
@@ -579,6 +741,8 @@ export const useReportPageViewModel = (): ReportPageViewModel => {
 
     isSizingWizardOpen,
     setIsSizingWizardOpen,
+    savedSizingDataMap,
+    onSizingCalculated,
 
     isRvtoolsModalOpen,
     openRvtoolsModal,

--- a/src/ui/report/views/Report.tsx
+++ b/src/ui/report/views/Report.tsx
@@ -352,6 +352,14 @@ const ReportContent: React.FC = () => {
         clusterName={vm.clusterView.selectionLabel}
         clusterId={vm.selectedClusterId}
         assessmentId={vm.assessmentId || ""}
+        onCalculated={(result, formValues) => {
+          vm.onSizingCalculated({
+            result,
+            formValues,
+            clusterName: vm.clusterView.selectionLabel,
+            clusterId: vm.selectedClusterId,
+          });
+        }}
       />
 
       {/* Off-screen render target for PDF export — React owns the rendering,

--- a/src/ui/report/views/__tests__/Report.test.tsx
+++ b/src/ui/report/views/__tests__/Report.test.tsx
@@ -211,6 +211,8 @@ function makeBaseVm(
     clearExportError: vi.fn(),
     isSizingWizardOpen: false,
     setIsSizingWizardOpen: vi.fn(),
+    savedSizingDataMap: {},
+    onSizingCalculated: vi.fn(),
     ...overrides,
   };
 }

--- a/src/ui/report/views/cluster-sizer/ClusterSizingWizard.tsx
+++ b/src/ui/report/views/cluster-sizer/ClusterSizingWizard.tsx
@@ -20,6 +20,7 @@ import { SizingInputForm } from "./SizingInputForm";
 import { SizingResult } from "./SizingResult";
 import { TimeEstimationForm } from "./TimeEstimationForm";
 import { TimeEstimationResult } from "./TimeEstimationResult";
+import type { ClusterRequirementsResponse, SizingFormValues } from "./types";
 
 interface ClusterSizingWizardProps {
   isOpen: boolean;
@@ -28,6 +29,14 @@ interface ClusterSizingWizardProps {
   clusterId: string;
   /** Assessment ID for the API endpoint */
   assessmentId: string;
+  /**
+   * Called whenever a sizing calculation succeeds. Used by the parent to
+   * cache the result for inclusion in the PDF export.
+   */
+  onCalculated?: (
+    result: ClusterRequirementsResponse,
+    formValues: SizingFormValues,
+  ) => void;
 }
 
 type MenuItem = "architecture" | "time-estimation" | "complexity" | "plan";
@@ -91,10 +100,19 @@ export const ClusterSizingWizard: React.FC<ClusterSizingWizardProps> = ({
   clusterName,
   clusterId,
   assessmentId,
+  onCalculated,
 }) => {
   const vm = useClusterSizingWizardViewModel(assessmentId, clusterId);
   const [selectedMenuItem, setSelectedMenuItem] =
     useState<MenuItem>("architecture");
+
+  useEffect(() => {
+    if (vm.sizerOutput && onCalculated) {
+      onCalculated(vm.sizerOutput, vm.formValues);
+    }
+    // Only fire when sizerOutput changes (not on every formValues keystroke)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [vm.sizerOutput]);
 
   const handleClose = useCallback(() => {
     vm.reset();


### PR DESCRIPTION
- Use the new stored-input GET endpoint into the store layer
- Add the sizing recommendations as a dedicated jsPDF page in the exported report

1. PDF for one specific cluster
[recording - 2026-04-24T113356.546.webm](https://github.com/user-attachments/assets/8e29b92d-f622-44d2-9580-b7b303a9c773)

2. PDF for all clusters
[recording - 2026-04-24T114343.051.webm](https://github.com/user-attachments/assets/24c7fb2e-bc73-484e-9ea4-5fd75b70b1d8)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * PDF exports now support custom table-of-contents items and additional pages for enhanced report customization
  * Automatic "Cluster sizing recommendations" page is generated and included in PDFs when cluster sizing calculations are completed
  * New capability to retrieve previously stored cluster requirements input data
  * Enhanced sizing wizard with improved integration for PDF export workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->