### PR TITLE
ECOPROJECT-4491 | fix: use routes.assessments in index redirect to prevent problems in the navigation

### DIFF
--- a/src/routing/AppRoutes.tsx
+++ b/src/routing/AppRoutes.tsx
@@ -11,6 +11,7 @@ import { CustomersScreen } from "../ui/partner/partner/views/CustomersScreen";
 import { PartnersScreen } from "../ui/partner/regularUser/views/PartnersScreen";
 import { PartnerViewRequireRole } from "../ui/partner/views/PartnerViewRequireRole";
 import { IdentityWrapper } from "./IdentityWrapper";
+import { routes } from "./Routes";
 
 const Report = lazy(
   () => import(/* webpackChunkName: "Report" */ "../ui/report/views/Report"),
@@ -48,7 +49,7 @@ export const AppRoutes: React.FC = () => (
   <Routes>
     {/* Identity wrapper loads current identity and renders child routes */}
     <Route element={<IdentityWrapper />}>
-      <Route index element={<Navigate to="assessments" replace />} />
+      <Route index element={<Navigate to={routes.assessments} replace />} />
 
       {/* Pathless layout route — HomeScreen renders the shell + <Outlet /> */}
       <Route element={<HomeScreen />} errorElement={<InvalidObject />}>


### PR DESCRIPTION
- The index route was using a relative path `to="assessments"` in its <Navigate> element. In the microfrontend (Console) environment, MainApp is rendered directly into Chrome's React tree without a parent <Route path="/openshift/migration-advisor/*"> wrapping it, so ReactRouter has no route-context prefix to resolve relative paths against.
As a result, "assessments" resolved from the router root, producing /assessments instead of /openshift/migration-advisor/assessments. Chrome has no handler for /assessments, which caused a crash. The issue
surfaced specifically on browser back-navigation because pressing Back from the assessments list can land the user on the bare index URL /openshift/migration-advisor, re-triggering the redirect.
- Replace the relative string with routes.assessments, consistent with every other <Navigate> in the codebase (e.g. PartnerViewRedirect) and with the architecture rule that all navigable paths must use the routes object from src/routing/Routes.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal routing configuration consistency to maintain existing app behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->