### PR TITLE
ECOPROJECT-4330 | fix: Edit environment network and proxy correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "@emotion/css": "^11.13.5",
         "@hookform/resolvers": "^5.2.2",
-        "@openshift-migration-advisor/planner-sdk": "0.12.0",
+        "@openshift-migration-advisor/planner-sdk": "^0.12.0-390afc4a9dfe",
         "@patternfly/react-charts": "7.4.9",
         "@patternfly/react-core": "^6.4.1",
         "@patternfly/react-icons": "^6.4.0",
@@ -2721,9 +2721,9 @@
       }
     },
     "node_modules/@openshift-migration-advisor/planner-sdk": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@openshift-migration-advisor/planner-sdk/-/planner-sdk-0.12.0.tgz",
-      "integrity": "sha512-HQvnVh+lsxmn1p+mxxGV6OK/VTzGYGdYGBY3ypeYydUJYwncjW1uYzkLEFBTLCJUYA3pIIgXpEh0hSEuHf5SpA==",
+      "version": "0.12.0-390afc4a9dfe",
+      "resolved": "https://registry.npmjs.org/@openshift-migration-advisor/planner-sdk/-/planner-sdk-0.12.0-390afc4a9dfe.tgz",
+      "integrity": "sha512-KFv6M2RGsXds8V2PxDPIadxDCeLoZk8vfmc9yVX68renFzCL2ZxQlV7J/qdUdlKsLJ0pTl6A7wRBDD6fESfk/A==",
       "license": "Apache-2.0"
     },
     "node_modules/@openshift/dynamic-plugin-sdk": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@emotion/css": "^11.13.5",
     "@hookform/resolvers": "^5.2.2",
-    "@openshift-migration-advisor/planner-sdk": "0.12.0",
+    "@openshift-migration-advisor/planner-sdk": "^0.12.0-390afc4a9dfe",
     "@patternfly/react-charts": "7.4.9",
     "@patternfly/react-core": "^6.4.1",
     "@patternfly/react-icons": "^6.4.0",

--- a/src/data/stores/SourcesStore.ts
+++ b/src/data/stores/SourcesStore.ts
@@ -1,4 +1,8 @@
-import type { SourceApiInterface } from "@openshift-migration-advisor/planner-sdk";
+import type {
+  SourceApiInterface,
+  SourceCreate,
+  SourceUpdate,
+} from "@openshift-migration-advisor/planner-sdk";
 import { UpdateInventoryFromJSON } from "@openshift-migration-advisor/planner-sdk";
 
 import { PollableStoreBase } from "../../lib/mvvm/PollableStore";
@@ -11,6 +15,7 @@ export type SourceNetworkConfigType = "dhcp" | "static";
 export type SourceCreateInput = {
   name: string;
   sshPublicKey: string;
+  enableProxy: boolean;
   httpProxy: string;
   httpsProxy: string;
   noProxy: string;
@@ -25,15 +30,9 @@ export type SourceUpdateInput = Omit<SourceCreateInput, "name"> & {
   sourceId: string;
 };
 
-type SourceCreatePayload = Parameters<
-  SourceApiInterface["createSource"]
->[0]["sourceCreate"];
-type SourceUpdatePayload = Parameters<
-  SourceApiInterface["updateSource"]
->[0]["sourceUpdate"];
 type UpdateInventoryInput = Parameters<typeof UpdateInventoryFromJSON>[0];
-type ProxyPayload = NonNullable<SourceCreatePayload["proxy"]>;
-type NetworkPayload = NonNullable<SourceCreatePayload["network"]>;
+type ProxyPayload = NonNullable<SourceCreate["proxy"]>;
+type NetworkPayload = NonNullable<SourceCreate["vmNetwork"]>;
 
 const buildProxyPayload = (
   httpProxy: string,
@@ -81,10 +80,8 @@ const buildNetworkPayload = (
   return undefined;
 };
 
-const buildSourceCreatePayload = (
-  input: SourceCreateInput,
-): SourceCreatePayload => {
-  const payload: SourceCreatePayload = {
+const buildSourceCreatePayload = (input: SourceCreateInput): SourceCreate => {
+  const payload: SourceCreate = {
     name: input.name,
   };
 
@@ -92,44 +89,40 @@ const buildSourceCreatePayload = (
     payload.sshPublicKey = input.sshPublicKey;
   }
 
-  const proxy = buildProxyPayload(
-    input.httpProxy,
-    input.httpsProxy,
-    input.noProxy,
-  );
-  if (proxy) {
-    payload.proxy = proxy;
+  if (input.enableProxy) {
+    payload.proxy = buildProxyPayload(
+      input.httpProxy,
+      input.httpsProxy,
+      input.noProxy,
+    );
   }
 
-  const network = buildNetworkPayload(input);
-  if (network) {
-    payload.network = network;
+  if (input.networkConfigType === "static") {
+    payload.vmNetwork = buildNetworkPayload(input);
   }
 
   return payload;
 };
 
-const buildSourceUpdatePayload = (
-  input: SourceUpdateInput,
-): SourceUpdatePayload => {
-  const payload: SourceUpdatePayload = {};
+const buildSourceUpdatePayload = (input: SourceUpdateInput): SourceUpdate => {
+  const payload: SourceUpdate = {};
 
   if (input.sshPublicKey && input.sshPublicKey.trim()) {
     payload.sshPublicKey = input.sshPublicKey;
   }
 
-  const proxy = buildProxyPayload(
-    input.httpProxy,
-    input.httpsProxy,
-    input.noProxy,
-  );
-  if (proxy) {
-    payload.proxy = proxy;
+  payload.enableProxy = input.enableProxy;
+  if (input.enableProxy) {
+    payload.proxy = buildProxyPayload(
+      input.httpProxy,
+      input.httpsProxy,
+      input.noProxy,
+    );
   }
 
-  const network = buildNetworkPayload(input);
-  if (network) {
-    payload.network = network;
+  payload.networkConfigType = input.networkConfigType;
+  if (input.networkConfigType === "static") {
+    payload.vmNetwork = buildNetworkPayload(input);
   }
 
   return payload;

--- a/src/data/stores/__tests__/SourcesStore.test.ts
+++ b/src/data/stores/__tests__/SourcesStore.test.ts
@@ -84,6 +84,7 @@ describe("SourcesStore", () => {
     const input = {
       name: "New Source",
       sshPublicKey: "ssh-key",
+      enableProxy: false,
       httpProxy: "",
       httpsProxy: "",
       noProxy: "",
@@ -115,6 +116,7 @@ describe("SourcesStore", () => {
     const input = {
       sourceId: "s-1",
       sshPublicKey: "new-key",
+      enableProxy: false,
       httpProxy: "",
       httpsProxy: "",
       noProxy: "",
@@ -185,6 +187,7 @@ describe("SourcesStore", () => {
     await store.create({
       name: "New",
       sshPublicKey: "",
+      enableProxy: false,
       httpProxy: "",
       httpsProxy: "",
       noProxy: "",

--- a/src/ui/environment/view-models/__tests__/useEnvironmentPageViewModel.test.ts
+++ b/src/ui/environment/view-models/__tests__/useEnvironmentPageViewModel.test.ts
@@ -257,6 +257,7 @@ describe("useEnvironmentPageViewModel", () => {
       result.current.createDownloadSource({
         name: "my-env",
         sshPublicKey: "ssh-rsa AAAA",
+        enableProxy: false,
         httpProxy: "",
         httpsProxy: "",
         noProxy: "",
@@ -284,6 +285,7 @@ describe("useEnvironmentPageViewModel", () => {
       result.current.createDownloadSource({
         name: "bad",
         sshPublicKey: "",
+        enableProxy: false,
         httpProxy: "",
         httpsProxy: "",
         noProxy: "",
@@ -310,6 +312,7 @@ describe("useEnvironmentPageViewModel", () => {
       result.current.updateSource({
         sourceId: "upd-1",
         sshPublicKey: "ssh-ed25519 BBB",
+        enableProxy: false,
         httpProxy: "",
         httpsProxy: "",
         noProxy: "",
@@ -335,6 +338,7 @@ describe("useEnvironmentPageViewModel", () => {
       result.current.updateSource({
         sourceId: "fail-1",
         sshPublicKey: "",
+        enableProxy: false,
         httpProxy: "",
         httpsProxy: "",
         noProxy: "",
@@ -392,6 +396,7 @@ describe("useEnvironmentPageViewModel", () => {
       result.current.createDownloadSource({
         name: "tmp",
         sshPublicKey: "",
+        enableProxy: false,
         httpProxy: "",
         httpsProxy: "",
         noProxy: "",
@@ -422,6 +427,7 @@ describe("useEnvironmentPageViewModel", () => {
       result.current.createDownloadSource({
         name: "err",
         sshPublicKey: "",
+        enableProxy: false,
         httpProxy: "",
         httpsProxy: "",
         noProxy: "",
@@ -442,6 +448,7 @@ describe("useEnvironmentPageViewModel", () => {
       result.current.updateSource({
         sourceId: "x",
         sshPublicKey: "",
+        enableProxy: false,
         httpProxy: "",
         httpsProxy: "",
         noProxy: "",
@@ -463,6 +470,7 @@ describe("useEnvironmentPageViewModel", () => {
       result.current.createDownloadSource({
         name: "err1",
         sshPublicKey: "",
+        enableProxy: false,
         httpProxy: "",
         httpsProxy: "",
         noProxy: "",
@@ -483,6 +491,7 @@ describe("useEnvironmentPageViewModel", () => {
       result.current.createDownloadSource({
         name: "err",
         sshPublicKey: "",
+        enableProxy: false,
         httpProxy: "",
         httpsProxy: "",
         noProxy: "",
@@ -585,6 +594,7 @@ describe("useEnvironmentPageViewModel", () => {
       promise = result.current.createDownloadSource({
         name: "loading-test",
         sshPublicKey: "",
+        enableProxy: false,
         httpProxy: "",
         httpsProxy: "",
         noProxy: "",
@@ -625,6 +635,7 @@ describe("useEnvironmentPageViewModel", () => {
       promise = result.current.updateSource({
         sourceId: "upd-loading",
         sshPublicKey: "",
+        enableProxy: false,
         httpProxy: "",
         httpsProxy: "",
         noProxy: "",

--- a/src/ui/environment/views/DiscoverySourceSetupModal.tsx
+++ b/src/ui/environment/views/DiscoverySourceSetupModal.tsx
@@ -278,6 +278,7 @@ export const DiscoverySourceSetupModal: React.FC<
             .updateSource({
               sourceId: sourceIdToUpdate,
               sshPublicKey: normalizeSshKey(sshKey),
+              enableProxy,
               httpProxy,
               httpsProxy,
               noProxy,
@@ -332,6 +333,7 @@ export const DiscoverySourceSetupModal: React.FC<
           void vm.createDownloadSource({
             name: environmentName,
             sshPublicKey: normalizeSshKey(sshKey),
+            enableProxy,
             httpProxy,
             httpsProxy,
             noProxy,


### PR DESCRIPTION
The Edit Environment option doesn’t work properly: changes aren’t saved, and the modal closes automatically without offering the option to download the OVA

This patch fixes the issue, and reuse the consistent vmNetwork field for creation and update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit enable/disable proxy toggle for creating and updating sources; UI now sends this flag.

* **Chores**
  * Adjusted network configuration handling so static network settings are written with the correct field and network type is propagated.
  * Updated SDK dependency range.

* **Tests**
  * Updated tests to include the new proxy enablement flag in request payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->