### PR TITLE
ECOPROJECT-4491 | fix: fix Chrome crash with navigation

### DIFF
--- a/dev/vite.config.ts
+++ b/dev/vite.config.ts
@@ -37,6 +37,10 @@ export default defineConfig(({ mode }) => {
       "process.env.MIGRATION_PLANNER_UI_VERSION": JSON.stringify(
         env.MIGRATION_PLANNER_UI_VERSION,
       ),
+      // Standalone dev mode — app is served at "/", no mount-path prefix.
+      // The microfrontend (Webpack) build sets this to "/openshift/migration-advisor"
+      // via fec.config.js DefinePlugin. See src/routing/Routes.ts.
+      "process.env.MIGRATION_PLANNER_APP_BASENAME": JSON.stringify(""),
     },
     resolve: {
       alias: {

--- a/fec.config.js
+++ b/fec.config.js
@@ -26,6 +26,12 @@ module.exports = {
       "process.env.MIGRATION_PLANNER_UI_VERSION": JSON.stringify(
         process.env.MIGRATION_PLANNER_UI_VERSION,
       ),
+      // Static mount-path prefix — consumed by src/routing/Routes.ts.
+      // Must match appUrl in this file. In standalone (Vite) mode this is
+      // defined as "" in dev/vite.config.ts.
+      "process.env.MIGRATION_PLANNER_APP_BASENAME": JSON.stringify(
+        "/openshift/migration-advisor",
+      ),
     }),
     // Prevent EMFILE (too many open files) by excluding node_modules from
     // webpack's file-system watcher.  The FEC-generated config sets no

--- a/src/routing/Routes.ts
+++ b/src/routing/Routes.ts
@@ -1,122 +1,67 @@
 /**
- * The current app slug used by the Insights Chrome to mount this microfrontend.
- * Matches `appUrl` in `fec.config.js`.
+ * The app's mount-path prefix, injected at build time.
+ *
+ * - **Standalone (dev) mode** — Vite defines this as `""` so every route is
+ *   root-relative (the app is served directly at `/`).
+ *
+ * - **Microfrontend (stage/prod) mode** — Webpack's DefinePlugin (fec.config.js)
+ *   sets this to `"/openshift/migration-advisor"`. The Chrome's BrowserRouter
+ *   has `basename="/"` and mounts the app at this slug, so all navigate() and
+ *   <Link to> calls must include the full mount path as a prefix — exactly the
+ *   same pattern used by the uhc-portal's `withBasename` / `ocmBaseName`.
+ *
+ * Using a static build-time constant (rather than reading window.location at
+ * call-time) avoids a Chrome-specific race condition where the browser updates
+ * window.location synchronously when the back/forward button is pressed, before
+ * React finishes its current render cycle. That stale read caused routes.*
+ * getters to return root-relative paths like /assessments instead of
+ * /openshift/migration-advisor/assessments, crashing the Console.
  */
-const APP_SLUG = "/openshift/migration-advisor";
+const APP_BASENAME: string = process.env.MIGRATION_PLANNER_APP_BASENAME ?? "";
 
 /**
- * The legacy app slug kept alive for backward compatibility.
- * Both slugs serve the same RootApp module (see deploy/frontend.yaml).
+ * The app's mount-path prefix at module-load time.
+ *
+ * @deprecated Use the `routes` object instead. This export exists only for
+ * legacy callers; it has the same value as the internal APP_BASENAME constant.
  */
-const LEGACY_APP_SLUG = "/openshift/migration-assessment";
-
-let lastLoggedBasename: string | null = null;
+export { APP_BASENAME };
 
 /**
- * Resolve the app's base path at runtime.
+ * Centralized route map.
  *
- * - **Standalone (dev) mode** — `BrowserRouter` has `basename="/"` and the
- *   app is mounted at the root. Returns `""` so every route is root-relative.
- *
- * - **Microfrontend (stage) mode** — The Chrome's `BrowserRouter` has
- *   `basename="/"` and mounts the app inside a nested `<Route>` at
- *   `APP_SLUG`. Absolute `navigate()` / `<Link to>` calls must therefore
- *   include the full mount path, otherwise React Router resolves them from
- *   the router root and the URL ends up outside the app.
- *
- * Detection: if the current URL contains the app slug, we're in stage mode.
- * This is called dynamically each time routes are accessed to avoid module-load
- * timing issues with federated modules.
- */
-function resolveAppBasename(): string {
-  try {
-    // Strip known Chrome preview/beta prefixes before matching
-    const pathname = window.location.pathname.replace(/^\/(preview|beta)/, "");
-    const basename = pathname.startsWith(APP_SLUG)
-      ? APP_SLUG
-      : pathname.startsWith(LEGACY_APP_SLUG)
-        ? LEGACY_APP_SLUG
-        : "";
-
-    // Log only when basename changes or on first detection (to track production issues)
-    if (process.env.NODE_ENV !== "test" && lastLoggedBasename !== basename) {
-      console.info("[Routes] Basename detected:", {
-        mode: basename ? "microfrontend" : "standalone",
-        basename: basename || "(root)",
-        currentPathname: window.location.pathname,
-        timestamp: new Date().toISOString(),
-      });
-      lastLoggedBasename = basename;
-    }
-
-    return basename;
-  } catch {
-    return ""; // SSR / test environment without DOM
-  }
-}
-
-/**
- * Get the app's mount-path prefix dynamically.
- * - `""` in standalone (dev) mode
- * - `"/openshift/migration-advisor"` in stage mode (current slug)
- * - `"/openshift/migration-assessment"` in stage mode (legacy slug)
- *
- * This is computed on each access to avoid caching stale values during
- * module hot-reloading or federated module initialization.
- */
-function getAppBasename(): string {
-  return resolveAppBasename();
-}
-
-/**
- * The app's mount-path prefix.
- * - `""` in standalone (dev) mode
- * - `"/openshift/migration-advisor"` in stage mode (current slug)
- * - `"/openshift/migration-assessment"` in stage mode (legacy slug)
- *
- * @deprecated This is a snapshot at module-load time and may be stale.
- * Prefer using the `routes` object which dynamically resolves the basename.
- */
-export const APP_BASENAME = getAppBasename();
-
-/**
- * Centralized route map with dynamic basename resolution.
- *
- * Each route property is a getter that computes the full path at access time,
- * ensuring the basename is always current even during HMR or federated module
- * initialization.
+ * Every path includes the build-time basename prefix so that navigate() and
+ * <Link to> calls work correctly in both standalone and microfrontend mode.
  */
 export const routes = {
   get root() {
-    const base = getAppBasename();
-    return base || "/";
+    return APP_BASENAME || "/";
   },
   get assessments() {
-    return `${getAppBasename()}/assessments`;
+    return `${APP_BASENAME}/assessments`;
   },
-  assessmentById: (id: string) => `${getAppBasename()}/assessments/${id}`,
-  assessmentReport: (id: string) =>
-    `${getAppBasename()}/assessments/${id}/report`,
+  assessmentById: (id: string) => `${APP_BASENAME}/assessments/${id}`,
+  assessmentReport: (id: string) => `${APP_BASENAME}/assessments/${id}/report`,
   get assessmentCreate() {
-    return `${getAppBasename()}/assessments/create`;
+    return `${APP_BASENAME}/assessments/create`;
   },
   get exampleReport() {
-    return `${getAppBasename()}/assessments/example-report`;
+    return `${APP_BASENAME}/assessments/example-report`;
   },
   get environments() {
-    return `${getAppBasename()}/environments`;
+    return `${APP_BASENAME}/environments`;
   },
   get partners() {
-    return `${getAppBasename()}/partners`;
+    return `${APP_BASENAME}/partners`;
   },
   get myPartner() {
-    return `${getAppBasename()}/partners/my`;
+    return `${APP_BASENAME}/partners/my`;
   },
   get customers() {
-    return `${getAppBasename()}/partners/customers`;
+    return `${APP_BASENAME}/partners/customers`;
   },
   get adminGroups() {
-    return `${getAppBasename()}/partners/groups`;
+    return `${APP_BASENAME}/partners/groups`;
   },
-  adminGroupById: (id: string) => `${getAppBasename()}/partners/groups/${id}`,
+  adminGroupById: (id: string) => `${APP_BASENAME}/partners/groups/${id}`,
 } as const;

--- a/src/routing/__tests__/Routes.test.ts
+++ b/src/routing/__tests__/Routes.test.ts
@@ -1,348 +1,165 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { APP_BASENAME, routes } from "../Routes";
-
 // ---------------------------------------------------------------------------
-// Setup
+// Helpers
 // ---------------------------------------------------------------------------
 
-describe("Routes", () => {
-  const originalLocation = window.location;
+/**
+ * Re-import Routes with a specific MIGRATION_PLANNER_APP_BASENAME value.
+ *
+ * Because APP_BASENAME is a module-level constant (computed once on import),
+ * we must reset the module registry and re-import after stubbing the env var.
+ */
+async function importRoutesWithBasename(basename: string) {
+  vi.resetModules();
+  vi.stubEnv("MIGRATION_PLANNER_APP_BASENAME", basename);
+  return import("../Routes");
+}
 
-  beforeEach(() => {
-    // Mock window.location with Object.defineProperty for safe reassignment
-    Object.defineProperty(window, "location", {
-      value: { ...originalLocation, pathname: "/" },
-      writable: true,
-      configurable: true,
-    });
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+// ---------------------------------------------------------------------------
+// Standalone mode (dev) — env var is "" (Vite sets it to empty string)
+// ---------------------------------------------------------------------------
+
+describe("Standalone mode (dev) — APP_BASENAME is empty", () => {
+  let routes: Awaited<ReturnType<typeof importRoutesWithBasename>>["routes"];
+  let APP_BASENAME: string;
+
+  beforeEach(async () => {
+    ({ routes, APP_BASENAME } = await importRoutesWithBasename(""));
   });
 
-  afterEach(() => {
-    // Restore original location
-    Object.defineProperty(window, "location", {
-      value: originalLocation,
-      writable: true,
-      configurable: true,
-    });
-    vi.clearAllMocks();
+  it("APP_BASENAME is empty", () => {
+    expect(APP_BASENAME).toBe("");
   });
 
-  // ---------------------------------------------------------------------------
-  // Standalone mode (dev) tests
-  // ---------------------------------------------------------------------------
-
-  describe("Standalone mode (dev)", () => {
-    beforeEach(() => {
-      Object.defineProperty(window, "location", {
-        value: { ...window.location, pathname: "/assessments" },
-        writable: true,
-        configurable: true,
-      });
-    });
-
-    it("routes.root returns / when in standalone mode", () => {
-      expect(routes.root).toBe("/");
-    });
-
-    it("routes.assessments returns /assessments when in standalone mode", () => {
-      expect(routes.assessments).toBe("/assessments");
-    });
-
-    it("routes.assessmentById returns /assessments/:id when in standalone mode", () => {
-      expect(routes.assessmentById("test-123")).toBe("/assessments/test-123");
-    });
-
-    it("routes.assessmentReport returns /assessments/:id/report when in standalone mode", () => {
-      expect(routes.assessmentReport("test-123")).toBe(
-        "/assessments/test-123/report",
-      );
-    });
-
-    it("routes.assessmentCreate returns /assessments/create when in standalone mode", () => {
-      expect(routes.assessmentCreate).toBe("/assessments/create");
-    });
-
-    it("routes.exampleReport returns /assessments/example-report when in standalone mode", () => {
-      expect(routes.exampleReport).toBe("/assessments/example-report");
-    });
-
-    it("routes.environments returns /environments when in standalone mode", () => {
-      expect(routes.environments).toBe("/environments");
-    });
+  it("routes.root returns /", () => {
+    expect(routes.root).toBe("/");
   });
 
-  // ---------------------------------------------------------------------------
-  // Microfrontend mode (stage/prod) tests
-  // ---------------------------------------------------------------------------
+  it("routes.assessments returns /assessments", () => {
+    expect(routes.assessments).toBe("/assessments");
+  });
 
-  describe("Microfrontend mode (stage/prod)", () => {
+  it("routes.assessmentById returns /assessments/:id", () => {
+    expect(routes.assessmentById("test-123")).toBe("/assessments/test-123");
+  });
+
+  it("routes.assessmentReport returns /assessments/:id/report", () => {
+    expect(routes.assessmentReport("test-123")).toBe(
+      "/assessments/test-123/report",
+    );
+  });
+
+  it("routes.assessmentCreate returns /assessments/create", () => {
+    expect(routes.assessmentCreate).toBe("/assessments/create");
+  });
+
+  it("routes.exampleReport returns /assessments/example-report", () => {
+    expect(routes.exampleReport).toBe("/assessments/example-report");
+  });
+
+  it("routes.environments returns /environments", () => {
+    expect(routes.environments).toBe("/environments");
+  });
+
+  it("routes.partners returns /partners", () => {
+    expect(routes.partners).toBe("/partners");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Microfrontend mode (stage/prod) — Webpack injects the full slug
+// ---------------------------------------------------------------------------
+
+describe("Microfrontend mode (stage/prod) — APP_BASENAME is /openshift/migration-advisor", () => {
+  const BASE = "/openshift/migration-advisor";
+
+  let routes: Awaited<ReturnType<typeof importRoutesWithBasename>>["routes"];
+  let APP_BASENAME: string;
+
+  beforeEach(async () => {
+    ({ routes, APP_BASENAME } = await importRoutesWithBasename(BASE));
+  });
+
+  it("APP_BASENAME matches the app slug", () => {
+    expect(APP_BASENAME).toBe(BASE);
+  });
+
+  it("routes.root returns the basename", () => {
+    expect(routes.root).toBe(BASE);
+  });
+
+  it("routes.assessments includes basename", () => {
+    expect(routes.assessments).toBe(`${BASE}/assessments`);
+  });
+
+  it("routes.assessmentById includes basename", () => {
+    expect(routes.assessmentById("test-123")).toBe(
+      `${BASE}/assessments/test-123`,
+    );
+  });
+
+  it("routes.assessmentReport includes basename", () => {
+    expect(routes.assessmentReport("test-123")).toBe(
+      `${BASE}/assessments/test-123/report`,
+    );
+  });
+
+  it("routes.assessmentCreate includes basename", () => {
+    expect(routes.assessmentCreate).toBe(`${BASE}/assessments/create`);
+  });
+
+  it("routes.exampleReport includes basename", () => {
+    expect(routes.exampleReport).toBe(`${BASE}/assessments/example-report`);
+  });
+
+  it("routes.environments includes basename", () => {
+    expect(routes.environments).toBe(`${BASE}/environments`);
+  });
+
+  it("routes.partners includes basename", () => {
+    expect(routes.partners).toBe(`${BASE}/partners`);
+  });
+
+  it("routes.myPartner includes basename", () => {
+    expect(routes.myPartner).toBe(`${BASE}/partners/my`);
+  });
+
+  it("routes.adminGroupById includes basename", () => {
+    expect(routes.adminGroupById("g-1")).toBe(`${BASE}/partners/groups/g-1`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stability — routes never change mid-session (no window.location dependency)
+// ---------------------------------------------------------------------------
+
+describe("Stability — APP_BASENAME is a static constant", () => {
+  it("routes stay stable regardless of window.location changes", async () => {
     const BASE = "/openshift/migration-advisor";
+    const { routes } = await importRoutesWithBasename(BASE);
 
-    beforeEach(() => {
-      Object.defineProperty(window, "location", {
-        value: { ...window.location, pathname: `${BASE}/assessments` },
-        writable: true,
-        configurable: true,
-      });
+    // Routes are correct when the app is active.
+    expect(routes.assessments).toBe(`${BASE}/assessments`);
+
+    // Simulate Chrome updating window.location before React finishes rendering
+    // (back-button race condition). With a static constant this has no effect.
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, pathname: "/openshift/" },
+      writable: true,
+      configurable: true,
     });
 
-    it("routes.root returns basename when in microfrontend mode", () => {
-      expect(routes.root).toBe(BASE);
-    });
-
-    it("routes.assessments includes basename when in microfrontend mode", () => {
-      expect(routes.assessments).toBe(`${BASE}/assessments`);
-    });
-
-    it("routes.assessmentById includes basename when in microfrontend mode", () => {
-      expect(routes.assessmentById("test-123")).toBe(
-        `${BASE}/assessments/test-123`,
-      );
-    });
-
-    it("routes.assessmentReport includes basename when in microfrontend mode", () => {
-      expect(routes.assessmentReport("test-123")).toBe(
-        `${BASE}/assessments/test-123/report`,
-      );
-    });
-
-    it("routes.assessmentCreate includes basename when in microfrontend mode", () => {
-      expect(routes.assessmentCreate).toBe(`${BASE}/assessments/create`);
-    });
-
-    it("routes.exampleReport includes basename when in microfrontend mode", () => {
-      expect(routes.exampleReport).toBe(`${BASE}/assessments/example-report`);
-    });
-
-    it("routes.environments includes basename when in microfrontend mode", () => {
-      expect(routes.environments).toBe(`${BASE}/environments`);
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // Dynamic resolution tests
-  // ---------------------------------------------------------------------------
-
-  describe("Dynamic basename resolution", () => {
-    it("routes update when window.location changes from standalone to microfrontend", () => {
-      // Start in standalone mode
-      Object.defineProperty(window, "location", {
-        value: { ...window.location, pathname: "/assessments" },
-        writable: true,
-        configurable: true,
-      });
-      expect(routes.assessments).toBe("/assessments");
-
-      // Simulate navigation to microfrontend mode
-      Object.defineProperty(window, "location", {
-        value: {
-          ...window.location,
-          pathname: "/openshift/migration-advisor/assessments",
-        },
-        writable: true,
-        configurable: true,
-      });
-      expect(routes.assessments).toBe(
-        "/openshift/migration-advisor/assessments",
-      );
-    });
-
-    it("routes update when window.location changes from microfrontend to standalone", () => {
-      // Start in microfrontend mode
-      Object.defineProperty(window, "location", {
-        value: {
-          ...window.location,
-          pathname: "/openshift/migration-advisor/assessments",
-        },
-        writable: true,
-        configurable: true,
-      });
-      expect(routes.assessments).toBe(
-        "/openshift/migration-advisor/assessments",
-      );
-
-      // Simulate navigation to standalone mode
-      Object.defineProperty(window, "location", {
-        value: { ...window.location, pathname: "/assessments" },
-        writable: true,
-        configurable: true,
-      });
-      expect(routes.assessments).toBe("/assessments");
-    });
-
-    it("handles /preview prefix correctly in microfrontend mode", () => {
-      Object.defineProperty(window, "location", {
-        value: {
-          ...window.location,
-          pathname: "/preview/openshift/migration-advisor/assessments",
-        },
-        writable: true,
-        configurable: true,
-      });
-      expect(routes.assessments).toBe(
-        "/openshift/migration-advisor/assessments",
-      );
-    });
-
-    it("handles /beta prefix correctly in microfrontend mode", () => {
-      Object.defineProperty(window, "location", {
-        value: {
-          ...window.location,
-          pathname: "/beta/openshift/migration-advisor/assessments",
-        },
-        writable: true,
-        configurable: true,
-      });
-      expect(routes.assessments).toBe(
-        "/openshift/migration-advisor/assessments",
-      );
-    });
-
-    it("handles /preview prefix correctly in standalone mode", () => {
-      Object.defineProperty(window, "location", {
-        value: { ...window.location, pathname: "/preview/assessments" },
-        writable: true,
-        configurable: true,
-      });
-      expect(routes.assessments).toBe("/assessments");
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // APP_BASENAME export (legacy)
-  // ---------------------------------------------------------------------------
-
-  describe("APP_BASENAME export", () => {
-    it("APP_BASENAME is a string", () => {
-      expect(typeof APP_BASENAME).toBe("string");
-    });
-
-    it("APP_BASENAME matches the current resolved basename", () => {
-      // Note: APP_BASENAME is computed once at module-load, so it may be stale.
-      // This test just verifies it's exported and is a string.
-      expect(APP_BASENAME).toMatch(/^(|\/openshift\/migration-assessment)$/);
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // Production bug reproduction test
-  // ---------------------------------------------------------------------------
-
-  describe("Production bug: inconsistent URL generation after login/logout", () => {
-    it("reproduces the 'See an example report' navigation bug where basename is missing", () => {
-      // SCENARIO: User logs in, module loads before Chrome routing is ready
-      // Simulate: Module loads with incorrect pathname (root or incomplete)
-      Object.defineProperty(window, "location", {
-        value: { ...window.location, pathname: "/" },
-        writable: true,
-        configurable: true,
-      });
-
-      // At this point, if routes were static (old behavior), they would cache
-      // the wrong basename and return "/assessments/example-report"
-
-      // User navigates to the app after Chrome routing initializes
-      Object.defineProperty(window, "location", {
-        value: {
-          ...window.location,
-          pathname: "/openshift/migration-advisor/assessments",
-        },
-        writable: true,
-        configurable: true,
-      });
-
-      // User clicks "See an example report" button
-      const exampleReportUrl = routes.exampleReport;
-
-      // EXPECTED: Should return correct URL with basename
-      expect(exampleReportUrl).toBe(
-        "/openshift/migration-advisor/assessments/example-report",
-      );
-
-      // BEFORE FIX: Would return "/assessments/example-report"
-      // AFTER FIX: Returns "/openshift/migration-advisor/assessments/example-report"
-    });
-
-    it("reproduces the RVTools upload navigation bug where basename is missing", () => {
-      // SCENARIO: User uploads RVTools file, job completes, navigates to report
-      // Simulate: Module loaded at wrong time, pathname changes during session
-
-      // Initial load with incomplete pathname
-      Object.defineProperty(window, "location", {
-        value: { ...window.location, pathname: "/assessments" },
-        writable: true,
-        configurable: true,
-      });
-
-      // User is actually in the microfrontend context
-      Object.defineProperty(window, "location", {
-        value: {
-          ...window.location,
-          pathname: "/openshift/migration-advisor/assessments",
-        },
-        writable: true,
-        configurable: true,
-      });
-
-      // Job completes, navigate to report
-      const assessmentId = "d8d38f15-d3f6-49a6-9a8b-2f7efc21aae9";
-      const reportUrl = routes.assessmentReport(assessmentId);
-
-      // EXPECTED: Should return correct URL with basename
-      expect(reportUrl).toBe(
-        `/openshift/migration-advisor/assessments/${assessmentId}/report`,
-      );
-
-      // BEFORE FIX: Would return "/assessments/d8d38f15-.../report"
-      // AFTER FIX: Returns "/openshift/migration-advisor/assessments/d8d38f15-.../report"
-    });
-
-    it("verifies all route getters adapt to pathname changes during the session", () => {
-      // Simulate module load at root
-      Object.defineProperty(window, "location", {
-        value: { ...window.location, pathname: "/" },
-        writable: true,
-        configurable: true,
-      });
-
-      // Routes should work in standalone mode initially
-      expect(routes.assessments).toBe("/assessments");
-      expect(routes.environments).toBe("/environments");
-
-      // User navigates to microfrontend context (Chrome loads)
-      Object.defineProperty(window, "location", {
-        value: {
-          ...window.location,
-          pathname: "/openshift/migration-advisor/assessments",
-        },
-        writable: true,
-        configurable: true,
-      });
-
-      // ALL routes should now include the basename
-      expect(routes.root).toBe("/openshift/migration-advisor");
-      expect(routes.assessments).toBe(
-        "/openshift/migration-advisor/assessments",
-      );
-      expect(routes.assessmentCreate).toBe(
-        "/openshift/migration-advisor/assessments/create",
-      );
-      expect(routes.exampleReport).toBe(
-        "/openshift/migration-advisor/assessments/example-report",
-      );
-      expect(routes.environments).toBe(
-        "/openshift/migration-advisor/environments",
-      );
-
-      // And they should work correctly for navigation
-      const testId = "test-123";
-      expect(routes.assessmentById(testId)).toBe(
-        `/openshift/migration-advisor/assessments/${testId}`,
-      );
-      expect(routes.assessmentReport(testId)).toBe(
-        `/openshift/migration-advisor/assessments/${testId}/report`,
-      );
-    });
+    // Routes must be unchanged — they do not read window.location.
+    expect(routes.assessments).toBe(`${BASE}/assessments`);
   });
 });


### PR DESCRIPTION
- APP_BASENAME is now a string literal baked into the bundle at build time. It never reads window.location. Chrome's synchronous-URL-update-before-React-renders race condition cannot affect it — there's nothing to race against.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed application routing to correctly handle different mount paths in development and production environments through build-time configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->