### PR TITLE
ECOPROJECT-4507 | feat: Add cost estimation tab in assessment report modal

### DIFF
--- a/dev/vite.config.ts
+++ b/dev/vite.config.ts
@@ -59,6 +59,16 @@ export default defineConfig(({ mode }) => {
     server: {
       port: 3000,
       proxy: {
+        [`${env.MIGRATION_PLANNER_API_BASE_URL}/api/v1/cost-estimation`]: {
+          target: "http://localhost:9205",
+          secure: false,
+          changeOrigin: true,
+          rewrite: (path) =>
+            path.replace(
+              new RegExp(`^${env.MIGRATION_PLANNER_API_BASE_URL}`),
+              "",
+            ),
+        },
         [env.MIGRATION_PLANNER_API_BASE_URL]: {
           target,
           secure: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2263,8 +2263,10 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
       "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -2502,9 +2504,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2526,9 +2525,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2550,9 +2546,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2574,9 +2567,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2598,9 +2588,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2622,9 +2609,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3586,9 +3570,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3603,9 +3584,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3620,9 +3598,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3637,9 +3612,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3654,9 +3626,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3671,9 +3640,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3688,9 +3654,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3705,9 +3668,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3722,9 +3682,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3739,9 +3696,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3756,9 +3710,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3773,9 +3724,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3790,9 +3738,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4414,9 +4359,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4434,9 +4376,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4454,9 +4393,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4474,9 +4410,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4494,9 +4427,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4514,9 +4444,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -18889,8 +18816,10 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "extraneous": true,
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/src/data/stores/AssessmentsStore.ts
+++ b/src/data/stores/AssessmentsStore.ts
@@ -8,12 +8,18 @@ import {
   ResponseError,
 } from "@openshift-migration-advisor/planner-sdk";
 import { type Assessment } from "@openshift-migration-advisor/planner-sdk";
-import { type InitOverrideFunction } from "@openshift-migration-advisor/planner-sdk";
+import {
+  type Configuration,
+  type InitOverrideFunction,
+  type Middleware,
+} from "@openshift-migration-advisor/planner-sdk";
 
 import { parseApiError } from "../../lib/common/ErrorParser";
 import { PollableStoreBase } from "../../lib/mvvm/PollableStore";
 import {
   type AssessmentModel,
+  type CalculateCostEstimationRequest,
+  type CostEstimationResponse,
   createAssessmentModel,
 } from "../../models/AssessmentModel";
 import type { IAssessmentsStore } from "./interfaces/IAssessmentsStore";
@@ -248,6 +254,71 @@ export class AssessmentsStore
       requestParameters,
       initOverrides,
     );
+  }
+
+  async calculateCostEstimation(
+    requestParameters: CalculateCostEstimationRequest,
+    initOverrides?: RequestInit,
+  ): Promise<CostEstimationResponse> {
+    try {
+      // Access SDK configuration to use basePath and middleware
+      // AssessmentApi extends BaseAPI which has a protected configuration property
+      const apiWithConfig = this.api as unknown as {
+        configuration: Configuration;
+      };
+      const config = apiWithConfig.configuration;
+      const basePath = config.basePath || "";
+      const middleware: Middleware[] = config.middleware || [];
+      const fetchApi = config.fetchApi || fetch;
+
+      // Build the full URL using SDK's basePath
+      const url = `${basePath}/api/v1/cost-estimation`;
+
+      // Prepare request configuration
+      let init: RequestInit = {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestParameters),
+      };
+
+      // Apply initOverrides if provided (only RequestInit, not function overrides)
+      if (initOverrides && typeof initOverrides !== "function") {
+        init = { ...init, ...initOverrides };
+      }
+
+      // Apply middleware (auth headers) using SDK's middleware chain
+      let requestContext = {
+        fetch: (url: string, init?: RequestInit) => fetchApi(url, init),
+        url,
+        init,
+      };
+      for (const mw of middleware) {
+        if (mw.pre) {
+          const result = await mw.pre(requestContext);
+          if (result) {
+            requestContext = { ...requestContext, ...result };
+          }
+        }
+      }
+
+      const response = await requestContext.fetch(
+        requestContext.url,
+        requestContext.init,
+      );
+
+      if (!response.ok) {
+        const errorData = (await response.json().catch(() => ({}))) as {
+          message?: string;
+        };
+        throw new ResponseError(response, errorData.message);
+      }
+
+      return (await response.json()) as CostEstimationResponse;
+    } catch (err) {
+      throw await parseApiError(err, "Failed to calculate cost estimation");
+    }
   }
 
   override getSnapshot(): AssessmentModel[] {

--- a/src/data/stores/ReportStore.ts
+++ b/src/data/stores/ReportStore.ts
@@ -5,8 +5,8 @@ import type {
   SnapshotLike,
 } from "../../services/html-export/types";
 import type {
-  PdfExtraPage,
   PdfExportService,
+  PdfExtraPage,
 } from "../../services/pdf-export/PdfExportService";
 import type { IReportStore, ReportStoreState } from "./interfaces/IReportStore";
 

--- a/src/data/stores/interfaces/IAssessmentsStore.ts
+++ b/src/data/stores/interfaces/IAssessmentsStore.ts
@@ -13,7 +13,11 @@ import type {
 } from "@openshift-migration-advisor/planner-sdk";
 
 import type { ExternalStore } from "../../../lib/mvvm/ExternalStore";
-import type { AssessmentModel } from "../../../models/AssessmentModel";
+import type {
+  AssessmentModel,
+  CalculateCostEstimationRequest,
+  CostEstimationResponse,
+} from "../../../models/AssessmentModel";
 type AssessmentCreateForm = {
   name: string;
   sourceType?: string;
@@ -60,6 +64,10 @@ export interface IAssessmentsStore extends ExternalStore<AssessmentModel[]> {
     requestParameters: CalculateMigrationComplexityRequest,
     initOverrides?: RequestInit | InitOverrideFunction,
   ): Promise<MigrationComplexityResponse>;
+  calculateCostEstimation(
+    requestParameters: CalculateCostEstimationRequest,
+    initOverrides?: RequestInit | InitOverrideFunction,
+  ): Promise<CostEstimationResponse>;
   calculateEstimationByComplexity(
     requestParameters: CalculateMigrationEstimationByComplexityRequest,
     initOverrides?: RequestInit | InitOverrideFunction,

--- a/src/models/AssessmentModel.ts
+++ b/src/models/AssessmentModel.ts
@@ -63,3 +63,56 @@ export const createAssessmentModel = (raw: Assessment): AssessmentModel => ({
   hasUsefulData: hasUsefulData(raw.snapshots),
   snapshotsSorted: sortSnapshotsDesc(raw.snapshots),
 });
+
+// ---------------------------------------------------------------------------
+// Cost Estimation types
+// ---------------------------------------------------------------------------
+
+export type Discounts = {
+  vcfDiscountPct: number;
+  vvfDiscountPct: number;
+  redhatDiscountPct: number;
+  aapDiscountPct: number;
+};
+
+export type CalculateCostEstimationRequest = {
+  assessmentId: string;
+  clusterId: string;
+  discounts: Discounts;
+};
+
+export type CostEstimationBreakdown = {
+  softwareSubscriptions: number;
+  ansibleAutomationPlatform: number;
+  migrationConsultingServices: number;
+  swingHardwareUpgrades: number;
+  additionalStorageCosts: number;
+  thirdPartyIsvCosts: number;
+};
+
+export type CostEstimationScenario = {
+  totalThreeYearCostEstimation: number;
+  breakdown: CostEstimationBreakdown;
+};
+
+export type SavingsVsReference = {
+  absoluteThreeYearUsd: number;
+  percentage: number;
+};
+
+export type CostEstimateSavings = {
+  vsVcf?: SavingsVsReference;
+  vsVvf?: SavingsVsReference;
+};
+
+export type CostEstimateResults = {
+  vmwareVcf: CostEstimationScenario;
+  vmwareVvf: CostEstimationScenario;
+  openshiftVirtualization: CostEstimationScenario;
+};
+
+export type CostEstimationResponse = {
+  calculatorVersion: string;
+  results: CostEstimateResults;
+  savings: CostEstimateSavings;
+};

--- a/src/ui/report/view-models/useClusterSizingWizardViewModel.ts
+++ b/src/ui/report/view-models/useClusterSizingWizardViewModel.ts
@@ -14,7 +14,9 @@ import {
 import { useAsyncFn } from "react-use";
 
 import { Symbols } from "../../../config/Dependencies";
+import type { IAccountStore } from "../../../data/stores/interfaces/IAccountStore";
 import type { IAssessmentsStore } from "../../../data/stores/interfaces/IAssessmentsStore";
+import type { CostEstimationResponse } from "../../../models/AssessmentModel";
 import {
   DEFAULT_ESTIMATION_FORM_VALUES,
   DEFAULT_FORM_VALUES,
@@ -64,6 +66,11 @@ export interface ClusterSizingWizardViewModel {
   isFormValid: boolean;
   ensureEstimationForMenu: (menuItem: string | null) => void;
   reset: () => void;
+  isCostEstimationTabVisible: boolean;
+  getCostEstimation: () => void;
+  costEstimation: CostEstimationResponse | null;
+  isLoadingCostEstimation: boolean;
+  costEstimationError: Error | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -106,6 +113,12 @@ export const useClusterSizingWizardViewModel = (
     assessmentsStore.getSnapshot.bind(assessmentsStore),
   );
 
+  const accountStore = useInjection<IAccountStore>(Symbols.AccountStore);
+  const identity = useSyncExternalStore(
+    accountStore.subscribe.bind(accountStore),
+    accountStore.getSnapshot.bind(accountStore),
+  );
+
   // Capture initial option values once so reset() can restore them.
   const initialValues = useMemo(
     () => ({
@@ -138,10 +151,15 @@ export const useClusterSizingWizardViewModel = (
     useState<MigrationEstimationByComplexityResponse | null>(
       initialValues.estimationByComplexity,
     );
+  const [costEstimation, setCostEstimation] =
+    useState<CostEstimationResponse | null>(null);
   const [manualCalculateError, setManualCalculateError] = useState<
     Error | undefined
   >(undefined);
   const [manualEstimationError, setManualEstimationError] = useState<
+    Error | undefined
+  >(undefined);
+  const [manualCostEstimationError, setManualCostEstimationError] = useState<
     Error | undefined
   >(undefined);
   const [manualComplexityError, setManualComplexityError] = useState<
@@ -320,8 +338,42 @@ export const useClusterSizingWizardViewModel = (
       }
     }, [assessmentId, assessmentsStore, clusterId]);
 
+  const [costEstimationState, doGetCostEstimation] = useAsyncFn(
+    async () => {
+      setManualCostEstimationError(undefined);
+      const costEstimation = await assessmentsStore.calculateCostEstimation({
+        assessmentId,
+        clusterId,
+        discounts: {
+          vcfDiscountPct: 0,
+          vvfDiscountPct: 0,
+          redhatDiscountPct: 0,
+          aapDiscountPct: 0,
+        },
+      });
+      setCostEstimation(costEstimation);
+    },
+    [assessmentId, assessmentsStore, clusterId],
+    { loading: true },
+  );
+
+  const getCostEstimation = () => {
+    void doGetCostEstimation().catch((err: unknown) => {
+      setManualCostEstimationError(
+        err instanceof Error
+          ? err
+          : new Error("Failed to calculate cost estimation"),
+      );
+    });
+  };
+
   const ensureEstimationForMenu = useCallback(
     (menuItem: string | null) => {
+      if (menuItem === "cost-estimation") {
+        if (!costEstimation && !costEstimationState.error) {
+          void doGetCostEstimation();
+        }
+      }
       if (menuItem === "complexity") {
         if (
           !complexityEstimation &&
@@ -340,6 +392,9 @@ export const useClusterSizingWizardViewModel = (
       }
     },
     [
+      costEstimation,
+      costEstimationState.error,
+      doGetCostEstimation,
       complexityEstimation,
       complexityState.loading,
       manualComplexityError,
@@ -358,6 +413,8 @@ export const useClusterSizingWizardViewModel = (
     setMigrationEstimation(initialValues.migrationEstimation);
     setComplexityEstimation(initialValues.complexityEstimation);
     setEstimationByComplexity(initialValues.estimationByComplexity);
+    setCostEstimation(null);
+    setManualCostEstimationError(undefined);
     setManualCalculateError(undefined);
     setManualEstimationError(undefined);
     setManualComplexityError(undefined);
@@ -411,5 +468,10 @@ export const useClusterSizingWizardViewModel = (
     isFormValid,
     ensureEstimationForMenu,
     reset,
+    isCostEstimationTabVisible: identity?.kind === "partner",
+    getCostEstimation,
+    costEstimation,
+    isLoadingCostEstimation: costEstimationState.loading,
+    costEstimationError: manualCostEstimationError ?? costEstimationState.error,
   };
 };

--- a/src/ui/report/view-models/useReportPageViewModel.ts
+++ b/src/ui/report/view-models/useReportPageViewModel.ts
@@ -41,13 +41,13 @@ import {
   type ClusterViewModel,
   compareClustersByVmCount,
 } from "../helpers/clusterViewModel";
+import type { SizingFormValues } from "../views/cluster-sizer/types";
 import {
   formatNumber,
   formatRatio,
   getCpuOvercommitLabel,
   getMemoryOvercommitLabel,
 } from "./ClusterSizingHelpers";
-import type { SizingFormValues } from "../views/cluster-sizer/types";
 
 // ---------------------------------------------------------------------------
 // Sizing → PDF page builder

--- a/src/ui/report/views/cluster-sizer/ClusterSizingWizard.tsx
+++ b/src/ui/report/views/cluster-sizer/ClusterSizingWizard.tsx
@@ -18,6 +18,11 @@ import {
   useClusterSizingWizardViewModel,
 } from "../../view-models/useClusterSizingWizardViewModel";
 import { ComplexityResult } from "./ComplexityResult";
+import {
+  CostEstimationResult,
+  CostEstimationResultSkeleton,
+} from "./CostEstimationResult";
+import RecommendationTabContent from "./RecommendationTabContent";
 import { RecommendationTemplate } from "./RecommendationTemplate";
 import { SizingInputForm } from "./SizingInputForm";
 import { SizingResult } from "./SizingResult";
@@ -46,12 +51,17 @@ interface ClusterSizingWizardProps {
   isReadOnly?: boolean;
 }
 
-type MenuItem = "architecture" | "time-estimation" | "complexity" | "plan";
+type MenuItem =
+  | "architecture"
+  | "cost-estimation"
+  | "time-estimation"
+  | "complexity"
+  | "plan";
 
 const modalBodyStyle = css`
   display: flex;
   flex-direction: column;
-  height: 680px;
+  min-height: 60vh;
 `;
 
 const tabsContainerStyle = css`
@@ -98,7 +108,6 @@ const tabsContainerStyle = css`
 const contentContainerStyle = css`
   flex: 1;
   overflow: auto;
-  padding: var(--pf-t--global--spacer--300);
 `;
 
 export const ClusterSizingWizard: React.FC<ClusterSizingWizardProps> = ({
@@ -214,6 +223,20 @@ export const ClusterSizingWizard: React.FC<ClusterSizingWizardProps> = ({
             }
           />
         );
+      case "cost-estimation":
+        if (!vm.isCostEstimationTabVisible) return null;
+        return (
+          <RecommendationTabContent
+            id="cost-estimation"
+            title="Cost estimation"
+            content={
+              <CostEstimationResult costEstimation={vm.costEstimation} />
+            }
+            isLoading={vm.isLoadingCostEstimation}
+            loadingComponent={<CostEstimationResultSkeleton />}
+            errorMessage={vm.costEstimationError}
+          />
+        );
       case "time-estimation":
         return (
           <RecommendationTemplate
@@ -314,6 +337,12 @@ export const ClusterSizingWizard: React.FC<ClusterSizingWizardProps> = ({
                 <TabTitleText>OpenShift Cluster Architecture</TabTitleText>
               }
             />
+            {vm.isCostEstimationTabVisible && (
+              <Tab
+                eventKey="cost-estimation"
+                title={<TabTitleText>Cost Estimation</TabTitleText>}
+              />
+            )}
             <Tab
               eventKey="time-estimation"
               title={<TabTitleText>Migration Time Estimation</TabTitleText>}

--- a/src/ui/report/views/cluster-sizer/CostEstimationResult.tsx
+++ b/src/ui/report/views/cluster-sizer/CostEstimationResult.tsx
@@ -1,0 +1,372 @@
+import { css } from "@emotion/css";
+import {
+  Card,
+  CardBody,
+  Flex,
+  FlexItem,
+  Gallery,
+  Label,
+  Skeleton,
+  Stack,
+  StackItem,
+  Title,
+} from "@patternfly/react-core";
+import React from "react";
+
+import type { CostEstimationResponse } from "../../../../models/AssessmentModel";
+
+interface CostEstimationResultProps {
+  costEstimation: CostEstimationResponse | null;
+}
+
+const heroCardStyle = css`
+  background: var(--pf-t--global--background--color--primary--default);
+  border: 1px solid var(--pf-t--global--border--color--default);
+  text-align: center;
+  padding: var(--pf-t--global--spacer--md);
+`;
+
+const heroTitleStyle = css`
+  text-transform: uppercase;
+  color: var(--pf-t--global--color--brand--default);
+  margin-bottom: var(--pf-t--global--spacer--md);
+`;
+
+const heroPriceSkeletonStyle = css`
+  display: flex;
+  justify-content: center;
+  height: 84px;
+`;
+
+const heroPriceStyle = css`
+  font-size: 3.5rem;
+  font-weight: var(--pf-t--global--font--weight--heading--default);
+  color: var(--pf-t--global--color--brand--default);
+`;
+
+const breakdownPriceSkeletonStyle = css`
+  display: flex;
+  justify-content: center;
+`;
+
+const breakdownCardStyle = css`
+  text-align: center;
+  min-height: 120px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`;
+
+const breakdownLabelStyle = css`
+  font-size: var(--pf-t--global--font--size--body--sm);
+  color: var(--pf-t--global--text--color--subtle);
+  margin-bottom: var(--pf-t--global--spacer--sm);
+`;
+
+const breakdownValueStyle = css`
+  font-size: var(--pf-t--global--font--size--2xl);
+  font-weight: var(--pf-t--global--font--weight--heading--default);
+  color: var(--pf-t--global--text--color--regular);
+`;
+
+const savingsCardStyle = css`
+  background: var(--pf-t--global--background--color--status--success--default);
+  border: 1px solid var(--pf-t--global--border--color--status--success--default);
+`;
+
+const savingsTitleStyle = css`
+  font-size: var(--pf-t--global--font--size--body--default);
+  color: var(--pf-t--global--color--status--success--default);
+  font-weight: var(--pf-t--global--font--weight--body--bold);
+  margin-bottom: var(--pf-t--global--spacer--sm);
+`;
+
+const savingsAmountStyle = css`
+  font-size: var(--pf-t--global--font--size--2xl);
+  font-weight: var(--pf-t--global--font--weight--heading--default);
+  color: var(--pf-t--global--color--status--success--default);
+`;
+
+const sectionTitleStyle = css`
+  margin-top: var(--pf-t--global--spacer--xl);
+  margin-bottom: var(--pf-t--global--spacer--md);
+`;
+
+const formatCurrency = (value: number): string => {
+  const sign = value < 0 ? "-" : "";
+  const abs = Math.abs(value);
+  if (abs >= 1_000_000) return `${sign}$${(abs / 1_000_000).toFixed(1)}M`;
+  if (abs >= 1_000) return `${sign}$${(abs / 1_000).toFixed(1)}K`;
+  return `${sign}$${abs.toFixed(0)}`;
+};
+
+export const CostEstimationResult: React.FC<CostEstimationResultProps> = ({
+  costEstimation,
+}) => {
+  if (!costEstimation) {
+    return null;
+  }
+
+  const { results, savings } = costEstimation;
+  const ovTotal = results.openshiftVirtualization.totalThreeYearCostEstimation;
+  const breakdown = results.openshiftVirtualization.breakdown;
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <Title headingLevel="h2">Cost Estimation</Title>
+      </StackItem>
+
+      <StackItem>
+        <Card className={heroCardStyle}>
+          <CardBody>
+            <Title headingLevel="h3" className={heroTitleStyle}>
+              Total OpenShift 3-Year cost estimation
+            </Title>
+            <div className={heroPriceStyle}>{formatCurrency(ovTotal)}</div>
+          </CardBody>
+        </Card>
+      </StackItem>
+
+      <StackItem>
+        <Title headingLevel="h3" className={sectionTitleStyle}>
+          Breakdown
+        </Title>
+        <Gallery hasGutter minWidths={{ default: "300px" }}>
+          <Card className={breakdownCardStyle}>
+            <CardBody>
+              <div className={breakdownLabelStyle}>Software Subscriptions</div>
+              <div className={breakdownValueStyle}>
+                {formatCurrency(breakdown.softwareSubscriptions)}
+              </div>
+            </CardBody>
+          </Card>
+          <Card className={breakdownCardStyle}>
+            <CardBody>
+              <div className={breakdownLabelStyle}>
+                Ansible Automation Platform
+              </div>
+              <div className={breakdownValueStyle}>
+                {formatCurrency(breakdown.ansibleAutomationPlatform)}
+              </div>
+            </CardBody>
+          </Card>
+          <Card className={breakdownCardStyle}>
+            <CardBody>
+              <div className={breakdownLabelStyle}>
+                Migration Consulting Services
+              </div>
+              <div className={breakdownValueStyle}>
+                {formatCurrency(breakdown.migrationConsultingServices)}
+              </div>
+            </CardBody>
+          </Card>
+          <Card className={breakdownCardStyle}>
+            <CardBody>
+              <div className={breakdownLabelStyle}>Swing Hardware Upgrades</div>
+              <div className={breakdownValueStyle}>
+                {formatCurrency(breakdown.swingHardwareUpgrades)}
+              </div>
+            </CardBody>
+          </Card>
+          <Card className={breakdownCardStyle}>
+            <CardBody>
+              <div className={breakdownLabelStyle}>
+                Additional Storage Costs
+              </div>
+              <div className={breakdownValueStyle}>
+                {formatCurrency(breakdown.additionalStorageCosts)}
+              </div>
+            </CardBody>
+          </Card>
+          <Card className={breakdownCardStyle}>
+            <CardBody>
+              <div className={breakdownLabelStyle}>Third Party ISV Costs</div>
+              <div className={breakdownValueStyle}>
+                {formatCurrency(breakdown.thirdPartyIsvCosts)}
+              </div>
+            </CardBody>
+          </Card>
+        </Gallery>
+      </StackItem>
+
+      {(savings.vsVcf || savings.vsVvf) && (
+        <StackItem>
+          <Title headingLevel="h3" className={sectionTitleStyle}>
+            Savings summary
+          </Title>
+          <Gallery hasGutter minWidths={{ default: "400px" }}>
+            {savings.vsVcf && (
+              <Card className={savingsCardStyle}>
+                <CardBody>
+                  <Flex
+                    justifyContent={{ default: "justifyContentSpaceBetween" }}
+                    alignItems={{ default: "alignItemsCenter" }}
+                  >
+                    <FlexItem>
+                      <div className={savingsAmountStyle}>
+                        {formatCurrency(savings.vsVcf.absoluteThreeYearUsd)}
+                      </div>
+                      <Label color="green">
+                        {savings.vsVcf.percentage.toFixed(1)}% Saved
+                      </Label>
+                    </FlexItem>
+                    <FlexItem>
+                      <div className={savingsTitleStyle}>
+                        Savings vs VMware VCF
+                      </div>
+                    </FlexItem>
+                  </Flex>
+                </CardBody>
+              </Card>
+            )}
+            {savings.vsVvf && (
+              <Card className={savingsCardStyle}>
+                <CardBody>
+                  <Flex
+                    justifyContent={{ default: "justifyContentSpaceBetween" }}
+                    alignItems={{ default: "alignItemsCenter" }}
+                  >
+                    <FlexItem>
+                      <div className={savingsAmountStyle}>
+                        {formatCurrency(savings.vsVvf.absoluteThreeYearUsd)}
+                      </div>
+                      <Label color="green">
+                        {savings.vsVvf.percentage.toFixed(1)}% Saved
+                      </Label>
+                    </FlexItem>
+                    <FlexItem>
+                      <div className={savingsTitleStyle}>
+                        Savings vs VMware VVF
+                      </div>
+                    </FlexItem>
+                  </Flex>
+                </CardBody>
+              </Card>
+            )}
+          </Gallery>
+        </StackItem>
+      )}
+    </Stack>
+  );
+};
+
+CostEstimationResult.displayName = "CostEstimationResult";
+
+export const CostEstimationResultSkeleton: React.FC = () => {
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <Title headingLevel="h2">Cost Estimation</Title>
+      </StackItem>
+
+      <StackItem>
+        <Card className={heroCardStyle}>
+          <CardBody>
+            <Title headingLevel="h3" className={heroTitleStyle}>
+              Total OpenShift 3-Year cost estimation
+            </Title>
+            <div className={heroPriceSkeletonStyle}>
+              <Skeleton
+                fontSize="4xl"
+                width="30%"
+                height="100%"
+                screenreaderText="Loading total cost value"
+              />
+            </div>
+          </CardBody>
+        </Card>
+      </StackItem>
+
+      <StackItem>
+        <Title headingLevel="h3" className={sectionTitleStyle}>
+          Breakdown
+        </Title>
+        <Gallery hasGutter minWidths={{ default: "300px" }}>
+          <Card className={breakdownCardStyle}>
+            <CardBody>
+              <div className={breakdownLabelStyle}>Software Subscriptions</div>
+              <div className={breakdownPriceSkeletonStyle}>
+                <Skeleton
+                  fontSize="2xl"
+                  width="30%"
+                  screenreaderText="Loading Software Subscriptions"
+                />
+              </div>
+            </CardBody>
+          </Card>
+          <Card className={breakdownCardStyle}>
+            <CardBody>
+              <div className={breakdownLabelStyle}>
+                Ansible Automation Platform
+              </div>
+              <div className={breakdownPriceSkeletonStyle}>
+                <Skeleton
+                  fontSize="2xl"
+                  width="30%"
+                  screenreaderText="Loading Ansible Automation Platform"
+                />
+              </div>
+            </CardBody>
+          </Card>
+          <Card className={breakdownCardStyle}>
+            <CardBody>
+              <div className={breakdownLabelStyle}>
+                Migration Consulting Services
+              </div>
+              <div className={breakdownPriceSkeletonStyle}>
+                <Skeleton
+                  fontSize="2xl"
+                  width="30%"
+                  screenreaderText="Loading Migration Consulting Services"
+                />
+              </div>
+            </CardBody>
+          </Card>
+          <Card className={breakdownCardStyle}>
+            <CardBody>
+              <div className={breakdownLabelStyle}>Swing Hardware Upgrades</div>
+              <div className={breakdownPriceSkeletonStyle}>
+                <Skeleton
+                  fontSize="2xl"
+                  width="30%"
+                  screenreaderText="Loading Swing Hardware Upgrades"
+                />
+              </div>
+            </CardBody>
+          </Card>
+          <Card className={breakdownCardStyle}>
+            <CardBody>
+              <div className={breakdownLabelStyle}>
+                Additional Storage Costs
+              </div>
+              <div className={breakdownPriceSkeletonStyle}>
+                <Skeleton
+                  fontSize="2xl"
+                  width="30%"
+                  screenreaderText="Loading Additional Storage Costs"
+                />
+              </div>
+            </CardBody>
+          </Card>
+          <Card className={breakdownCardStyle}>
+            <CardBody>
+              <div className={breakdownLabelStyle}>Third Party ISV Costs</div>
+              <div className={breakdownPriceSkeletonStyle}>
+                <Skeleton
+                  fontSize="2xl"
+                  width="30%"
+                  screenreaderText="Loading Third Party ISV Costs"
+                />
+              </div>
+            </CardBody>
+          </Card>
+        </Gallery>
+      </StackItem>
+    </Stack>
+  );
+};
+
+CostEstimationResultSkeleton.displayName = "CostEstimationResultSkeleton";
+
+export default CostEstimationResult;

--- a/src/ui/report/views/cluster-sizer/RecommendationTabContent.tsx
+++ b/src/ui/report/views/cluster-sizer/RecommendationTabContent.tsx
@@ -1,0 +1,55 @@
+import { Alert, TabContent, TabContentBody } from "@patternfly/react-core";
+import type { ReactNode } from "react";
+import React from "react";
+
+import { LoadingSpinner } from "../../../core/components/LoadingSpinner";
+
+interface RecommendationTabContentProps {
+  /** id for the TabContent **/
+  id: string;
+  /** Title for a11y */
+  title: string;
+  /** React component or element to render */
+  content: ReactNode;
+  /** Optional isLoading to display loading spinner */
+  isLoading?: boolean;
+  /** Optional loadingComponent to replace loading spinner */
+  loadingComponent?: ReactNode;
+  /** Error message **/
+  errorMessage: Error | undefined;
+}
+
+export const RecommendationTabContent: React.FC<
+  RecommendationTabContentProps
+> = ({
+  id,
+  title,
+  content,
+  isLoading = false,
+  loadingComponent,
+  errorMessage,
+}) => {
+  return (
+    <TabContent id={id}>
+      <TabContentBody hasPadding>
+        {isLoading ? (
+          loadingComponent === undefined ? (
+            <LoadingSpinner />
+          ) : (
+            loadingComponent
+          )
+        ) : errorMessage ? (
+          <Alert isInline variant="danger" title={`${title} error`}>
+            {errorMessage.message}
+          </Alert>
+        ) : (
+          <div>{content}</div>
+        )}
+      </TabContentBody>
+    </TabContent>
+  );
+};
+
+RecommendationTabContent.displayName = "RecommendationTabContent";
+
+export default RecommendationTabContent;


### PR DESCRIPTION
If user is a partner, the cost estimation tab is visible and query the cost-estimation endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cost estimation tab to the cluster sizing wizard, visible for partner accounts.
  * Cost estimation displays total 3-year OpenShift costs with detailed breakdown by component.
  * Added optional savings comparison showing cost savings versus alternative platforms.
  * Cost calculation includes loading and error states with appropriate user feedback.

* **Chores**
  * Adjusted wizard modal layout from fixed to flexible sizing.
  * Added development proxy configuration for cost estimation API endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->