### PR TITLE
ECOPROJECT-4491 | fix: solving URL issues - add runtime basename fallback for misconfigured builds

### DIFF
--- a/src/routing/Routes.ts
+++ b/src/routing/Routes.ts
@@ -1,23 +1,55 @@
 /**
- * The app's mount-path prefix, injected at build time.
- *
- * - **Standalone (dev) mode** — Vite defines this as `""` so every route is
- *   root-relative (the app is served directly at `/`).
- *
- * - **Microfrontend (stage/prod) mode** — Webpack's DefinePlugin (fec.config.js)
- *   sets this to `"/openshift/migration-advisor"`. The Chrome's BrowserRouter
- *   has `basename="/"` and mounts the app at this slug, so all navigate() and
- *   <Link to> calls must include the full mount path as a prefix — exactly the
- *   same pattern used by the uhc-portal's `withBasename` / `ocmBaseName`.
- *
- * Using a static build-time constant (rather than reading window.location at
- * call-time) avoids a Chrome-specific race condition where the browser updates
- * window.location synchronously when the back/forward button is pressed, before
- * React finishes its current render cycle. That stale read caused routes.*
- * getters to return root-relative paths like /assessments instead of
- * /openshift/migration-advisor/assessments, crashing the Console.
+ * Known app slugs used by the Console Chrome to mount this microfrontend.
+ * Both serve the same RootApp module (see deploy/frontend.yaml).
  */
-const APP_BASENAME: string = process.env.MIGRATION_PLANNER_APP_BASENAME ?? "";
+const APP_SLUG = "/openshift/migration-advisor";
+const LEGACY_APP_SLUG = "/openshift/migration-assessment";
+
+/**
+ * Detect the mount-path prefix from window.location.pathname at module-load
+ * time. This is safe because the federated module is first imported only after
+ * the Chrome shell has already navigated to the app's URL, so pathname is
+ * reliably set to the correct value.
+ *
+ * This is intentionally called ONCE and cached — unlike the old approach that
+ * re-read window.location on every routes.* access, this cannot be affected by
+ * subsequent URL changes (e.g. Chrome's synchronous update during Back navigation).
+ */
+function detectBasenameOnLoad(): string {
+  try {
+    const pathname = window.location.pathname.replace(/^\/(preview|beta)/, "");
+    if (pathname.startsWith(APP_SLUG)) return APP_SLUG;
+    if (pathname.startsWith(LEGACY_APP_SLUG)) return LEGACY_APP_SLUG;
+    return "";
+  } catch {
+    return ""; // SSR / test environment
+  }
+}
+
+/**
+ * The app's mount-path prefix.
+ *
+ * Resolution order (first defined value wins):
+ *
+ * 1. **Build-time injection** — Webpack's DefinePlugin (fec.config.js) sets
+ *    `process.env.MIGRATION_PLANNER_APP_BASENAME` to `"/openshift/migration-advisor"`.
+ *    Vite (dev/vite.config.ts) sets it to `""` for standalone mode.
+ *    This is the primary mechanism and matches the pattern used by the
+ *    uhc-portal's `withBasename` / `ocmBaseName`.
+ *
+ * 2. **Module-load detection fallback** — if the build pipeline did not inject
+ *    the constant (e.g. a misconfigured or cached build), we read
+ *    window.location.pathname once when the module is first imported. Because
+ *    the Chrome shell only imports the federated module after navigating to its
+ *    URL, the pathname is correct at this point and will not be affected by any
+ *    later navigation events.
+ *
+ * Either way the result is a stable string constant — never re-computed on
+ * subsequent calls — so Chrome's synchronous window.location update during
+ * Back/Forward navigation cannot cause routes.* getters to return stale paths.
+ */
+const APP_BASENAME: string =
+  process.env.MIGRATION_PLANNER_APP_BASENAME ?? detectBasenameOnLoad();
 
 /**
  * The app's mount-path prefix at module-load time.

--- a/src/routing/__tests__/Routes.test.ts
+++ b/src/routing/__tests__/Routes.test.ts
@@ -140,6 +140,72 @@ describe("Microfrontend mode (stage/prod) — APP_BASENAME is /openshift/migrati
 });
 
 // ---------------------------------------------------------------------------
+// Fallback — env var not injected by DefinePlugin (e.g. misconfigured build)
+// ---------------------------------------------------------------------------
+
+describe("Fallback — env var absent, basename detected from window.location", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    // Restore jsdom's default location (avoids cross-test pollution)
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, pathname: "/" },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("detects /openshift/migration-advisor from window.location.pathname", async () => {
+    const BASE = "/openshift/migration-advisor";
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, pathname: `${BASE}/assessments` },
+      writable: true,
+      configurable: true,
+    });
+
+    // Do NOT stub env var — simulate DefinePlugin not having injected it
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    const { APP_BASENAME, routes } = await import("../Routes");
+
+    expect(APP_BASENAME).toBe(BASE);
+    expect(routes.assessments).toBe(`${BASE}/assessments`);
+  });
+
+  it("strips /preview prefix before detecting the slug", async () => {
+    const BASE = "/openshift/migration-advisor";
+    Object.defineProperty(window, "location", {
+      value: {
+        ...window.location,
+        pathname: `/preview${BASE}/assessments`,
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    const { APP_BASENAME } = await import("../Routes");
+
+    expect(APP_BASENAME).toBe(BASE);
+  });
+
+  it("returns empty string when pathname does not match any known slug", async () => {
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, pathname: "/" },
+      writable: true,
+      configurable: true,
+    });
+
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    const { APP_BASENAME } = await import("../Routes");
+
+    expect(APP_BASENAME).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Stability — routes never change mid-session (no window.location dependency)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
If Webpack's DefinePlugin fails to inject MIGRATION_PLANNER_APP_BASENAME, fall back to reading window.location.pathname once at module-load time instead of silently using an empty string that breaks all routes.