### PR TITLE
ECOPROJECT-4515 | feat: Display sharing assessment information for customers or partners

### DIFF
--- a/src/ui/assessment/view-models/useAssessmentPageViewModel.ts
+++ b/src/ui/assessment/view-models/useAssessmentPageViewModel.ts
@@ -181,9 +181,11 @@ export const useAssessmentPageViewModel = (): AssessmentPageViewModel => {
   // ---- Column visibility and sorting --------------------------------------
 
   const [isColumnSelectOpen, setIsColumnSelectOpen] = useState(false);
+
+  const userSelectedColumnsVersion = 2;
   const [userSelectedColumns, setUserSelectedColumns] = useLocalStorage<
     ColumnKey[]
-  >(VISIBLE_COLUMNS_KEY, DEFAULT_VISIBLE_COLUMNS);
+  >(VISIBLE_COLUMNS_KEY, DEFAULT_VISIBLE_COLUMNS, userSelectedColumnsVersion);
 
   const [sortBy, setSortBy] = useState<
     { columnKey: SortableColumn; direction: "asc" | "desc" } | undefined

--- a/src/ui/assessment/views/AssessmentsTable.tsx
+++ b/src/ui/assessment/views/AssessmentsTable.tsx
@@ -75,13 +75,17 @@ export const Columns = {
   Networks: "Networks",
   Datastores: "Datastores",
   AssessmentReport: "Assessment report",
+  SharingStatus: "Sharing status",
   Actions: "",
 } as const;
 
 export type ColumnKey = keyof typeof Columns;
 export const DEFAULT_VISIBLE_COLUMNS = Object.keys(Columns) as ColumnKey[];
 export const MANDATORY_COLUMNS: ColumnKey[] = ["Name", "Actions"];
-export type SortableColumn = Exclude<ColumnKey, "AssessmentReport" | "Actions">;
+export type SortableColumn = Exclude<
+  ColumnKey,
+  "AssessmentReport" | "SharingStatus" | "Actions"
+>;
 export const SORTABLE_COLUMNS: SortableColumn[] = [
   "Name",
   "SourceType",
@@ -136,6 +140,7 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
       const permissions = Array.isArray(assessment.permissions)
         ? assessment.permissions
         : [];
+      const isShared = assessment.sharing?.isShared || false;
 
       // Use pre-computed model properties
       const snapshotData = assessment.latestSnapshot;
@@ -169,6 +174,7 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
         snapshots,
         hasData,
         permissions,
+        isShared,
       };
     });
 
@@ -423,6 +429,9 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
           {isColumnVisible("AssessmentReport") && (
             <Th modifier="nowrap">{Columns.AssessmentReport}</Th>
           )}
+          {isColumnVisible("SharingStatus") && (
+            <Th modifier="nowrap">{Columns.SharingStatus}</Th>
+          )}
           {isColumnVisible("Actions") && (
             <Th modifier="fitContent" screenReaderText="Actions">
               {Columns.Actions}
@@ -560,6 +569,11 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
                 </TableText>
               </Td>
             )}
+            {isColumnVisible("SharingStatus") && (
+              <Td dataLabel={Columns.SharingStatus}>
+                {row.isShared ? "Shared with partner" : "Not shared"}
+              </Td>
+            )}
             {isColumnVisible("Actions") && (
               <Td dataLabel={Columns.Actions} modifier="fitContent">
                 <Dropdown
@@ -592,20 +606,16 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
                         !row.hasData || !row.permissions.includes("read")
                       }
                     >
-                      Show assessment report
-                    </DropdownItem>
-                    <DropdownItem
-                      onClick={() => alert("Edit functionality coming soon!")}
-                      isDisabled={true}
-                    >
-                      Edit assessment
+                      View assessment report
                     </DropdownItem>
                     <DropdownItem
                       onClick={() => {
                         toggleDropdown(row.id);
                         return onShareAssessment(row.id);
                       }}
-                      isDisabled={!row.permissions.includes("share")}
+                      isDisabled={
+                        !row.permissions.includes("share") || row.isShared
+                      }
                     >
                       Share assessment
                     </DropdownItem>


### PR DESCRIPTION

<img width="647" height="296" alt="image" src="https://github.com/user-attachments/assets/75ddc9ef-61be-4f7a-98e9-5f27a9dd5091" />


<img width="668" height="429" alt="image" src="https://github.com/user-attachments/assets/bbb9fb84-00ff-43db-a086-f051d892cdff" />

<img width="649" height="449" alt="image" src="https://github.com/user-attachments/assets/74d8750a-7c08-460d-87f0-c8cf3027b6e5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Sharing Status" column to the assessments table to display whether assessments are shared.

* **Improvements**
  * Enhanced "Share assessment" action to only appear when the assessment has share permissions and isn't already shared.
  * Renamed "Show assessment report" to "View assessment report."
  * Removed the disabled "Edit assessment" option from the row menu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->