### PR TITLE
ECOPROJECT-4491 | fix: solving errors with url

### DIFF
--- a/src/routing/Routes.ts
+++ b/src/routing/Routes.ts
@@ -6,94 +6,92 @@ const APP_SLUG = "/openshift/migration-advisor";
 const LEGACY_APP_SLUG = "/openshift/migration-assessment";
 
 /**
- * Detect the mount-path prefix from window.location.pathname at module-load
- * time. This is safe because the federated module is first imported only after
- * the Chrome shell has already navigated to the app's URL, so pathname is
- * reliably set to the correct value.
- *
- * This is intentionally called ONCE and cached — unlike the old approach that
- * re-read window.location on every routes.* access, this cannot be affected by
- * subsequent URL changes (e.g. Chrome's synchronous update during Back navigation).
- */
-function detectBasenameOnLoad(): string {
-  try {
-    const pathname = window.location.pathname.replace(/^\/(preview|beta)/, "");
-    if (pathname.startsWith(APP_SLUG)) return APP_SLUG;
-    if (pathname.startsWith(LEGACY_APP_SLUG)) return LEGACY_APP_SLUG;
-    return "";
-  } catch {
-    return ""; // SSR / test environment
-  }
-}
-
-/**
- * The app's mount-path prefix.
+ * Compute the mount-path prefix once and cache it.
  *
  * Resolution order (first defined value wins):
  *
  * 1. **Build-time injection** — Webpack's DefinePlugin (fec.config.js) sets
  *    `process.env.MIGRATION_PLANNER_APP_BASENAME` to `"/openshift/migration-advisor"`.
  *    Vite (dev/vite.config.ts) sets it to `""` for standalone mode.
- *    This is the primary mechanism and matches the pattern used by the
- *    uhc-portal's `withBasename` / `ocmBaseName`.
  *
- * 2. **Module-load detection fallback** — if the build pipeline did not inject
- *    the constant (e.g. a misconfigured or cached build), we read
- *    window.location.pathname once when the module is first imported. Because
- *    the Chrome shell only imports the federated module after navigating to its
- *    URL, the pathname is correct at this point and will not be affected by any
- *    later navigation events.
+ * 2. **Lazy runtime detection** — if the build pipeline did not inject the
+ *    constant, we read window.location.pathname the first time a routes.*
+ *    getter is accessed. This is safe because routes.* is only accessed inside
+ *    React renders, and the Chrome shell only renders this federated module
+ *    after navigating to its URL — so pathname is already correct at that point.
  *
- * Either way the result is a stable string constant — never re-computed on
- * subsequent calls — so Chrome's synchronous window.location update during
- * Back/Forward navigation cannot cause routes.* getters to return stale paths.
+ * The result is cached permanently after the first call. Subsequent calls
+ * return the cached value without touching window.location again, so Chrome's
+ * synchronous window.location update during Back/Forward navigation (which
+ * occurs before React's render cycle) cannot corrupt the value.
+ *
+ * This is intentionally NOT computed at module-load time. Webpack Module
+ * Federation pre-loads federated modules in the background while the user is
+ * still on a different page (e.g. the Console home or search). At pre-load
+ * time window.location.pathname is not the app's URL, so a module-level
+ * constant would be set to "" and all routes would lose their prefix.
  */
-const APP_BASENAME: string =
-  process.env.MIGRATION_PLANNER_APP_BASENAME ?? detectBasenameOnLoad();
+let _cachedBasename: string | null = null;
 
-/**
- * The app's mount-path prefix at module-load time.
- *
- * @deprecated Use the `routes` object instead. This export exists only for
- * legacy callers; it has the same value as the internal APP_BASENAME constant.
- */
-export { APP_BASENAME };
+function getAppBasename(): string {
+  if (_cachedBasename !== null) return _cachedBasename;
+
+  // Build-time injection (primary path)
+  const buildTime = process.env.MIGRATION_PLANNER_APP_BASENAME;
+  if (buildTime !== undefined) {
+    return (_cachedBasename = buildTime);
+  }
+
+  // Runtime detection fallback
+  try {
+    const pathname = window.location.pathname.replace(/^\/(preview|beta)/, "");
+    if (pathname.startsWith(APP_SLUG)) return (_cachedBasename = APP_SLUG);
+    if (pathname.startsWith(LEGACY_APP_SLUG))
+      return (_cachedBasename = LEGACY_APP_SLUG);
+  } catch {
+    // SSR / test environment without window
+  }
+
+  return (_cachedBasename = "");
+}
 
 /**
  * Centralized route map.
  *
- * Every path includes the build-time basename prefix so that navigate() and
- * <Link to> calls work correctly in both standalone and microfrontend mode.
+ * Every path includes the mount-path prefix so that navigate() and <Link to>
+ * calls work correctly in both standalone and microfrontend mode.
+ * All getters call getAppBasename() which caches on first access.
  */
 export const routes = {
   get root() {
-    return APP_BASENAME || "/";
+    return getAppBasename() || "/";
   },
   get assessments() {
-    return `${APP_BASENAME}/assessments`;
+    return `${getAppBasename()}/assessments`;
   },
-  assessmentById: (id: string) => `${APP_BASENAME}/assessments/${id}`,
-  assessmentReport: (id: string) => `${APP_BASENAME}/assessments/${id}/report`,
+  assessmentById: (id: string) => `${getAppBasename()}/assessments/${id}`,
+  assessmentReport: (id: string) =>
+    `${getAppBasename()}/assessments/${id}/report`,
   get assessmentCreate() {
-    return `${APP_BASENAME}/assessments/create`;
+    return `${getAppBasename()}/assessments/create`;
   },
   get exampleReport() {
-    return `${APP_BASENAME}/assessments/example-report`;
+    return `${getAppBasename()}/assessments/example-report`;
   },
   get environments() {
-    return `${APP_BASENAME}/environments`;
+    return `${getAppBasename()}/environments`;
   },
   get partners() {
-    return `${APP_BASENAME}/partners`;
+    return `${getAppBasename()}/partners`;
   },
   get myPartner() {
-    return `${APP_BASENAME}/partners/my`;
+    return `${getAppBasename()}/partners/my`;
   },
   get customers() {
-    return `${APP_BASENAME}/partners/customers`;
+    return `${getAppBasename()}/partners/customers`;
   },
   get adminGroups() {
-    return `${APP_BASENAME}/partners/groups`;
+    return `${getAppBasename()}/partners/groups`;
   },
-  adminGroupById: (id: string) => `${APP_BASENAME}/partners/groups/${id}`,
+  adminGroupById: (id: string) => `${getAppBasename()}/partners/groups/${id}`,
 } as const;

--- a/src/routing/__tests__/Routes.test.ts
+++ b/src/routing/__tests__/Routes.test.ts
@@ -7,8 +7,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 /**
  * Re-import Routes with a specific MIGRATION_PLANNER_APP_BASENAME value.
  *
- * Because APP_BASENAME is a module-level constant (computed once on import),
- * we must reset the module registry and re-import after stubbing the env var.
+ * Because the basename is lazily cached on the first routes.* access, we must
+ * reset the module registry so that the cache (_cachedBasename) starts as null
+ * again, then stub the env var before the first access.
  */
 async function importRoutesWithBasename(basename: string) {
   vi.resetModules();
@@ -31,14 +32,9 @@ afterEach(() => {
 
 describe("Standalone mode (dev) — APP_BASENAME is empty", () => {
   let routes: Awaited<ReturnType<typeof importRoutesWithBasename>>["routes"];
-  let APP_BASENAME: string;
 
   beforeEach(async () => {
-    ({ routes, APP_BASENAME } = await importRoutesWithBasename(""));
-  });
-
-  it("APP_BASENAME is empty", () => {
-    expect(APP_BASENAME).toBe("");
+    ({ routes } = await importRoutesWithBasename(""));
   });
 
   it("routes.root returns /", () => {
@@ -84,14 +80,9 @@ describe("Microfrontend mode (stage/prod) — APP_BASENAME is /openshift/migrati
   const BASE = "/openshift/migration-advisor";
 
   let routes: Awaited<ReturnType<typeof importRoutesWithBasename>>["routes"];
-  let APP_BASENAME: string;
 
   beforeEach(async () => {
-    ({ routes, APP_BASENAME } = await importRoutesWithBasename(BASE));
-  });
-
-  it("APP_BASENAME matches the app slug", () => {
-    expect(APP_BASENAME).toBe(BASE);
+    ({ routes } = await importRoutesWithBasename(BASE));
   });
 
   it("routes.root returns the basename", () => {
@@ -143,11 +134,10 @@ describe("Microfrontend mode (stage/prod) — APP_BASENAME is /openshift/migrati
 // Fallback — env var not injected by DefinePlugin (e.g. misconfigured build)
 // ---------------------------------------------------------------------------
 
-describe("Fallback — env var absent, basename detected from window.location", () => {
+describe("Fallback — env var absent, basename detected lazily from window.location", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.resetModules();
-    // Restore jsdom's default location (avoids cross-test pollution)
     Object.defineProperty(window, "location", {
       value: { ...window.location, pathname: "/" },
       writable: true,
@@ -155,8 +145,10 @@ describe("Fallback — env var absent, basename detected from window.location", 
     });
   });
 
-  it("detects /openshift/migration-advisor from window.location.pathname", async () => {
+  it("detects /openshift/migration-advisor when routes are first accessed", async () => {
     const BASE = "/openshift/migration-advisor";
+
+    // Set the URL to simulate Chrome shell having already navigated here
     Object.defineProperty(window, "location", {
       value: { ...window.location, pathname: `${BASE}/assessments` },
       writable: true,
@@ -166,10 +158,11 @@ describe("Fallback — env var absent, basename detected from window.location", 
     // Do NOT stub env var — simulate DefinePlugin not having injected it
     vi.resetModules();
     vi.unstubAllEnvs();
-    const { APP_BASENAME, routes } = await import("../Routes");
+    const { routes } = await import("../Routes");
 
-    expect(APP_BASENAME).toBe(BASE);
+    // First routes.* access triggers lazy detection
     expect(routes.assessments).toBe(`${BASE}/assessments`);
+    expect(routes.root).toBe(BASE);
   });
 
   it("strips /preview prefix before detecting the slug", async () => {
@@ -185,12 +178,12 @@ describe("Fallback — env var absent, basename detected from window.location", 
 
     vi.resetModules();
     vi.unstubAllEnvs();
-    const { APP_BASENAME } = await import("../Routes");
+    const { routes } = await import("../Routes");
 
-    expect(APP_BASENAME).toBe(BASE);
+    expect(routes.assessments).toBe(`${BASE}/assessments`);
   });
 
-  it("returns empty string when pathname does not match any known slug", async () => {
+  it("returns root-relative paths when pathname does not match any known slug", async () => {
     Object.defineProperty(window, "location", {
       value: { ...window.location, pathname: "/" },
       writable: true,
@@ -199,33 +192,34 @@ describe("Fallback — env var absent, basename detected from window.location", 
 
     vi.resetModules();
     vi.unstubAllEnvs();
-    const { APP_BASENAME } = await import("../Routes");
+    const { routes } = await import("../Routes");
 
-    expect(APP_BASENAME).toBe("");
+    expect(routes.assessments).toBe("/assessments");
+    expect(routes.root).toBe("/");
   });
 });
 
 // ---------------------------------------------------------------------------
-// Stability — routes never change mid-session (no window.location dependency)
+// Stability — once cached the value never changes regardless of URL changes
 // ---------------------------------------------------------------------------
 
-describe("Stability — APP_BASENAME is a static constant", () => {
-  it("routes stay stable regardless of window.location changes", async () => {
+describe("Stability — basename is cached after first access", () => {
+  it("routes stay stable when window.location changes after first access", async () => {
     const BASE = "/openshift/migration-advisor";
     const { routes } = await importRoutesWithBasename(BASE);
 
-    // Routes are correct when the app is active.
+    // First access — cache is populated
     expect(routes.assessments).toBe(`${BASE}/assessments`);
 
     // Simulate Chrome updating window.location before React finishes rendering
-    // (back-button race condition). With a static constant this has no effect.
+    // (back-button race condition). With lazy caching this has no effect.
     Object.defineProperty(window, "location", {
       value: { ...window.location, pathname: "/openshift/" },
       writable: true,
       configurable: true,
     });
 
-    // Routes must be unchanged — they do not read window.location.
+    // Cached value must be unchanged
     expect(routes.assessments).toBe(`${BASE}/assessments`);
   });
 });


### PR DESCRIPTION
- getAppBasename() is now lazily evaluated — it only runs on the first routes.* access. That first access always happens inside a React render, and the Chrome shell only renders the migration-advisor component after it has already navigated to the app's URL. So the detection is guaranteed to read the correct pathname. The result is then permanently cached, so no subsequent URL change (e.g. Chrome's Back-button race condition) can corrupt it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal routing initialization logic for improved lazy-loading performance. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->