### PR TITLE
ECOPROJECT-4491 | fix: remove process.env dependency from basename resolution

### DIFF
--- a/dev/vite.config.ts
+++ b/dev/vite.config.ts
@@ -37,10 +37,6 @@ export default defineConfig(({ mode }) => {
       "process.env.MIGRATION_PLANNER_UI_VERSION": JSON.stringify(
         env.MIGRATION_PLANNER_UI_VERSION,
       ),
-      // Standalone dev mode — app is served at "/", no mount-path prefix.
-      // The microfrontend (Webpack) build sets this to "/openshift/migration-advisor"
-      // via fec.config.js DefinePlugin. See src/routing/Routes.ts.
-      "process.env.MIGRATION_PLANNER_APP_BASENAME": JSON.stringify(""),
     },
     resolve: {
       alias: {

--- a/fec.config.js
+++ b/fec.config.js
@@ -26,12 +26,6 @@ module.exports = {
       "process.env.MIGRATION_PLANNER_UI_VERSION": JSON.stringify(
         process.env.MIGRATION_PLANNER_UI_VERSION,
       ),
-      // Static mount-path prefix — consumed by src/routing/Routes.ts.
-      // Must match appUrl in this file. In standalone (Vite) mode this is
-      // defined as "" in dev/vite.config.ts.
-      "process.env.MIGRATION_PLANNER_APP_BASENAME": JSON.stringify(
-        "/openshift/migration-advisor",
-      ),
     }),
     // Prevent EMFILE (too many open files) by excluding node_modules from
     // webpack's file-system watcher.  The FEC-generated config sets no

--- a/src/routing/Routes.ts
+++ b/src/routing/Routes.ts
@@ -6,43 +6,37 @@ const APP_SLUG = "/openshift/migration-advisor";
 const LEGACY_APP_SLUG = "/openshift/migration-assessment";
 
 /**
- * Compute the mount-path prefix once and cache it.
+ * Lazily cached mount-path prefix.
  *
- * Resolution order (first defined value wins):
+ * Design rationale
+ * ----------------
+ * We intentionally do NOT rely on a Webpack DefinePlugin / Vite `define`
+ * constant. The FEC (frontend-components-config) build tool owns the
+ * `process.env.*` namespace and may substitute an empty string for any env var
+ * that is absent from the real process environment — including our constant.
+ * If that override fires first, the cache would be seeded with "" and every
+ * route would lose its prefix.
  *
- * 1. **Build-time injection** — Webpack's DefinePlugin (fec.config.js) sets
- *    `process.env.MIGRATION_PLANNER_APP_BASENAME` to `"/openshift/migration-advisor"`.
- *    Vite (dev/vite.config.ts) sets it to `""` for standalone mode.
+ * We also intentionally do NOT read window.location at module-load time.
+ * Webpack Module Federation pre-loads federated modules in the background
+ * while the user is on a different page (Console home, search, etc.). At that
+ * point window.location.pathname is not the app's URL and would return "".
  *
- * 2. **Lazy runtime detection** — if the build pipeline did not inject the
- *    constant, we read window.location.pathname the first time a routes.*
- *    getter is accessed. This is safe because routes.* is only accessed inside
- *    React renders, and the Chrome shell only renders this federated module
- *    after navigating to its URL — so pathname is already correct at that point.
+ * Instead, the value is read and cached the first time any `routes.*` getter
+ * is accessed. That first access always happens inside a React render, and the
+ * Chrome shell only renders the migration-advisor component after it has
+ * already navigated to the app's URL — so pathname is guaranteed to be correct.
  *
- * The result is cached permanently after the first call. Subsequent calls
- * return the cached value without touching window.location again, so Chrome's
- * synchronous window.location update during Back/Forward navigation (which
- * occurs before React's render cycle) cannot corrupt the value.
- *
- * This is intentionally NOT computed at module-load time. Webpack Module
- * Federation pre-loads federated modules in the background while the user is
- * still on a different page (e.g. the Console home or search). At pre-load
- * time window.location.pathname is not the app's URL, so a module-level
- * constant would be set to "" and all routes would lose their prefix.
+ * The cache is permanent: `_cachedBasename` is set exactly once and never
+ * re-evaluated. This makes it immune to Chrome's synchronous window.location
+ * update that occurs before React's render cycle during Back/Forward
+ * navigation (the original race-condition bug).
  */
 let _cachedBasename: string | null = null;
 
 function getAppBasename(): string {
   if (_cachedBasename !== null) return _cachedBasename;
 
-  // Build-time injection (primary path)
-  const buildTime = process.env.MIGRATION_PLANNER_APP_BASENAME;
-  if (buildTime !== undefined) {
-    return (_cachedBasename = buildTime);
-  }
-
-  // Runtime detection fallback
   try {
     const pathname = window.location.pathname.replace(/^\/(preview|beta)/, "");
     if (pathname.startsWith(APP_SLUG)) return (_cachedBasename = APP_SLUG);

--- a/src/routing/__tests__/Routes.test.ts
+++ b/src/routing/__tests__/Routes.test.ts
@@ -5,36 +5,40 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // ---------------------------------------------------------------------------
 
 /**
- * Re-import Routes with a specific MIGRATION_PLANNER_APP_BASENAME value.
+ * Set window.location.pathname, reset the module registry so that the lazy
+ * cache (_cachedBasename) starts as null, then re-import Routes.
  *
- * Because the basename is lazily cached on the first routes.* access, we must
- * reset the module registry so that the cache (_cachedBasename) starts as null
- * again, then stub the env var before the first access.
+ * The pathname must be set BEFORE import so that the first routes.* access
+ * (which triggers lazy detection) reads the correct value.
  */
-async function importRoutesWithBasename(basename: string) {
+async function importRoutesAtPathname(pathname: string) {
+  Object.defineProperty(window, "location", {
+    value: { ...window.location, pathname },
+    writable: true,
+    configurable: true,
+  });
   vi.resetModules();
-  vi.stubEnv("MIGRATION_PLANNER_APP_BASENAME", basename);
   return import("../Routes");
 }
 
-// ---------------------------------------------------------------------------
-// Setup / teardown
-// ---------------------------------------------------------------------------
-
 afterEach(() => {
-  vi.unstubAllEnvs();
+  Object.defineProperty(window, "location", {
+    value: { ...window.location, pathname: "/" },
+    writable: true,
+    configurable: true,
+  });
   vi.resetModules();
 });
 
 // ---------------------------------------------------------------------------
-// Standalone mode (dev) — env var is "" (Vite sets it to empty string)
+// Standalone mode — URL is "/" (no Console Chrome prefix)
 // ---------------------------------------------------------------------------
 
-describe("Standalone mode (dev) — APP_BASENAME is empty", () => {
-  let routes: Awaited<ReturnType<typeof importRoutesWithBasename>>["routes"];
+describe("Standalone mode — pathname is /", () => {
+  let routes: Awaited<ReturnType<typeof importRoutesAtPathname>>["routes"];
 
   beforeEach(async () => {
-    ({ routes } = await importRoutesWithBasename(""));
+    ({ routes } = await importRoutesAtPathname("/"));
   });
 
   it("routes.root returns /", () => {
@@ -73,16 +77,16 @@ describe("Standalone mode (dev) — APP_BASENAME is empty", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Microfrontend mode (stage/prod) — Webpack injects the full slug
+// Microfrontend mode — URL starts with /openshift/migration-advisor
 // ---------------------------------------------------------------------------
 
-describe("Microfrontend mode (stage/prod) — APP_BASENAME is /openshift/migration-advisor", () => {
+describe("Microfrontend mode — pathname starts with /openshift/migration-advisor", () => {
   const BASE = "/openshift/migration-advisor";
 
-  let routes: Awaited<ReturnType<typeof importRoutesWithBasename>>["routes"];
+  let routes: Awaited<ReturnType<typeof importRoutesAtPathname>>["routes"];
 
   beforeEach(async () => {
-    ({ routes } = await importRoutesWithBasename(BASE));
+    ({ routes } = await importRoutesAtPathname(`${BASE}/assessments`));
   });
 
   it("routes.root returns the basename", () => {
@@ -131,88 +135,48 @@ describe("Microfrontend mode (stage/prod) — APP_BASENAME is /openshift/migrati
 });
 
 // ---------------------------------------------------------------------------
-// Fallback — env var not injected by DefinePlugin (e.g. misconfigured build)
+// Legacy slug — /openshift/migration-assessment
 // ---------------------------------------------------------------------------
 
-describe("Fallback — env var absent, basename detected lazily from window.location", () => {
-  afterEach(() => {
-    vi.unstubAllEnvs();
-    vi.resetModules();
-    Object.defineProperty(window, "location", {
-      value: { ...window.location, pathname: "/" },
-      writable: true,
-      configurable: true,
-    });
-  });
-
-  it("detects /openshift/migration-advisor when routes are first accessed", async () => {
-    const BASE = "/openshift/migration-advisor";
-
-    // Set the URL to simulate Chrome shell having already navigated here
-    Object.defineProperty(window, "location", {
-      value: { ...window.location, pathname: `${BASE}/assessments` },
-      writable: true,
-      configurable: true,
-    });
-
-    // Do NOT stub env var — simulate DefinePlugin not having injected it
-    vi.resetModules();
-    vi.unstubAllEnvs();
-    const { routes } = await import("../Routes");
-
-    // First routes.* access triggers lazy detection
-    expect(routes.assessments).toBe(`${BASE}/assessments`);
-    expect(routes.root).toBe(BASE);
-  });
-
-  it("strips /preview prefix before detecting the slug", async () => {
-    const BASE = "/openshift/migration-advisor";
-    Object.defineProperty(window, "location", {
-      value: {
-        ...window.location,
-        pathname: `/preview${BASE}/assessments`,
-      },
-      writable: true,
-      configurable: true,
-    });
-
-    vi.resetModules();
-    vi.unstubAllEnvs();
-    const { routes } = await import("../Routes");
-
-    expect(routes.assessments).toBe(`${BASE}/assessments`);
-  });
-
-  it("returns root-relative paths when pathname does not match any known slug", async () => {
-    Object.defineProperty(window, "location", {
-      value: { ...window.location, pathname: "/" },
-      writable: true,
-      configurable: true,
-    });
-
-    vi.resetModules();
-    vi.unstubAllEnvs();
-    const { routes } = await import("../Routes");
-
-    expect(routes.assessments).toBe("/assessments");
-    expect(routes.root).toBe("/");
+describe("Legacy slug — pathname starts with /openshift/migration-assessment", () => {
+  it("routes.assessments uses the legacy basename", async () => {
+    const { routes } = await importRoutesAtPathname(
+      "/openshift/migration-assessment/assessments",
+    );
+    expect(routes.assessments).toBe(
+      "/openshift/migration-assessment/assessments",
+    );
   });
 });
 
 // ---------------------------------------------------------------------------
-// Stability — once cached the value never changes regardless of URL changes
+// /preview prefix — stage environments use /preview/openshift/...
 // ---------------------------------------------------------------------------
 
-describe("Stability — basename is cached after first access", () => {
-  it("routes stay stable when window.location changes after first access", async () => {
+describe("/preview prefix — stage pathname includes /preview", () => {
+  it("strips /preview and detects the correct basename", async () => {
     const BASE = "/openshift/migration-advisor";
-    const { routes } = await importRoutesWithBasename(BASE);
+    const { routes } = await importRoutesAtPathname(
+      `/preview${BASE}/assessments`,
+    );
+    expect(routes.assessments).toBe(`${BASE}/assessments`);
+    expect(routes.root).toBe(BASE);
+  });
+});
 
-    // First access — cache is populated
+// ---------------------------------------------------------------------------
+// Stability — cached value never recomputed after first access
+// ---------------------------------------------------------------------------
+
+describe("Stability — basename is cached after the first routes.* access", () => {
+  it("routes remain stable when window.location changes after first access", async () => {
+    const BASE = "/openshift/migration-advisor";
+    const { routes } = await importRoutesAtPathname(`${BASE}/assessments`);
+
     expect(routes.assessments).toBe(`${BASE}/assessments`);
 
-    // Simulate Chrome updating window.location before React finishes rendering
-    // (back-button race condition). With lazy caching this has no effect.
+    // Simulate Chrome synchronously updating window.location before React
+    // finishes rendering (the Back-button race condition).
     Object.defineProperty(window, "location", {
       value: { ...window.location, pathname: "/openshift/" },
       writable: true,
@@ -221,5 +185,6 @@ describe("Stability — basename is cached after first access", () => {
 
     // Cached value must be unchanged
     expect(routes.assessments).toBe(`${BASE}/assessments`);
+    expect(routes.root).toBe(BASE);
   });
 });


### PR DESCRIPTION
The FEC build tool can override process.env.MIGRATION_PLANNER_APP_BASENAME with an empty string for env vars absent from the real build environment, causing the basename cache to be seeded with \"\" before the runtime fallback could run. Remove the process.env check entirely so getAppBasename() relies solely on lazy window.location detection, which is safe because it is called on first routes.* access inside a React render — at which point the Chrome shell has already navigated to the app's URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated the routing system to determine the application's mount path at runtime rather than at build time, improving deployment flexibility across different hosting environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->