### PR TITLE
ECOPROJECT-4491 | fix: revert the remove process.env dependency from basename resolution

### DIFF
--- a/dev/vite.config.ts
+++ b/dev/vite.config.ts
@@ -37,6 +37,10 @@ export default defineConfig(({ mode }) => {
       "process.env.MIGRATION_PLANNER_UI_VERSION": JSON.stringify(
         env.MIGRATION_PLANNER_UI_VERSION,
       ),
+      // Standalone dev mode — app is served at "/", no mount-path prefix.
+      // The microfrontend (Webpack) build sets this to "/openshift/migration-advisor"
+      // via fec.config.js DefinePlugin. See src/routing/Routes.ts.
+      "process.env.MIGRATION_PLANNER_APP_BASENAME": JSON.stringify(""),
     },
     resolve: {
       alias: {

--- a/fec.config.js
+++ b/fec.config.js
@@ -26,6 +26,12 @@ module.exports = {
       "process.env.MIGRATION_PLANNER_UI_VERSION": JSON.stringify(
         process.env.MIGRATION_PLANNER_UI_VERSION,
       ),
+      // Static mount-path prefix — consumed by src/routing/Routes.ts.
+      // Must match appUrl in this file. In standalone (Vite) mode this is
+      // defined as "" in dev/vite.config.ts.
+      "process.env.MIGRATION_PLANNER_APP_BASENAME": JSON.stringify(
+        "/openshift/migration-advisor",
+      ),
     }),
     // Prevent EMFILE (too many open files) by excluding node_modules from
     // webpack's file-system watcher.  The FEC-generated config sets no

--- a/src/routing/Routes.ts
+++ b/src/routing/Routes.ts
@@ -6,37 +6,43 @@ const APP_SLUG = "/openshift/migration-advisor";
 const LEGACY_APP_SLUG = "/openshift/migration-assessment";
 
 /**
- * Lazily cached mount-path prefix.
+ * Compute the mount-path prefix once and cache it.
  *
- * Design rationale
- * ----------------
- * We intentionally do NOT rely on a Webpack DefinePlugin / Vite `define`
- * constant. The FEC (frontend-components-config) build tool owns the
- * `process.env.*` namespace and may substitute an empty string for any env var
- * that is absent from the real process environment — including our constant.
- * If that override fires first, the cache would be seeded with "" and every
- * route would lose its prefix.
+ * Resolution order (first defined value wins):
  *
- * We also intentionally do NOT read window.location at module-load time.
- * Webpack Module Federation pre-loads federated modules in the background
- * while the user is on a different page (Console home, search, etc.). At that
- * point window.location.pathname is not the app's URL and would return "".
+ * 1. **Build-time injection** — Webpack's DefinePlugin (fec.config.js) sets
+ *    `process.env.MIGRATION_PLANNER_APP_BASENAME` to `"/openshift/migration-advisor"`.
+ *    Vite (dev/vite.config.ts) sets it to `""` for standalone mode.
  *
- * Instead, the value is read and cached the first time any `routes.*` getter
- * is accessed. That first access always happens inside a React render, and the
- * Chrome shell only renders the migration-advisor component after it has
- * already navigated to the app's URL — so pathname is guaranteed to be correct.
+ * 2. **Lazy runtime detection** — if the build pipeline did not inject the
+ *    constant, we read window.location.pathname the first time a routes.*
+ *    getter is accessed. This is safe because routes.* is only accessed inside
+ *    React renders, and the Chrome shell only renders this federated module
+ *    after navigating to its URL — so pathname is already correct at that point.
  *
- * The cache is permanent: `_cachedBasename` is set exactly once and never
- * re-evaluated. This makes it immune to Chrome's synchronous window.location
- * update that occurs before React's render cycle during Back/Forward
- * navigation (the original race-condition bug).
+ * The result is cached permanently after the first call. Subsequent calls
+ * return the cached value without touching window.location again, so Chrome's
+ * synchronous window.location update during Back/Forward navigation (which
+ * occurs before React's render cycle) cannot corrupt the value.
+ *
+ * This is intentionally NOT computed at module-load time. Webpack Module
+ * Federation pre-loads federated modules in the background while the user is
+ * still on a different page (e.g. the Console home or search). At pre-load
+ * time window.location.pathname is not the app's URL, so a module-level
+ * constant would be set to "" and all routes would lose their prefix.
  */
 let _cachedBasename: string | null = null;
 
 function getAppBasename(): string {
   if (_cachedBasename !== null) return _cachedBasename;
 
+  // Build-time injection (primary path)
+  const buildTime = process.env.MIGRATION_PLANNER_APP_BASENAME;
+  if (buildTime !== undefined) {
+    return (_cachedBasename = buildTime);
+  }
+
+  // Runtime detection fallback
   try {
     const pathname = window.location.pathname.replace(/^\/(preview|beta)/, "");
     if (pathname.startsWith(APP_SLUG)) return (_cachedBasename = APP_SLUG);

--- a/src/routing/__tests__/Routes.test.ts
+++ b/src/routing/__tests__/Routes.test.ts
@@ -5,40 +5,36 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // ---------------------------------------------------------------------------
 
 /**
- * Set window.location.pathname, reset the module registry so that the lazy
- * cache (_cachedBasename) starts as null, then re-import Routes.
+ * Re-import Routes with a specific MIGRATION_PLANNER_APP_BASENAME value.
  *
- * The pathname must be set BEFORE import so that the first routes.* access
- * (which triggers lazy detection) reads the correct value.
+ * Because the basename is lazily cached on the first routes.* access, we must
+ * reset the module registry so that the cache (_cachedBasename) starts as null
+ * again, then stub the env var before the first access.
  */
-async function importRoutesAtPathname(pathname: string) {
-  Object.defineProperty(window, "location", {
-    value: { ...window.location, pathname },
-    writable: true,
-    configurable: true,
-  });
+async function importRoutesWithBasename(basename: string) {
   vi.resetModules();
+  vi.stubEnv("MIGRATION_PLANNER_APP_BASENAME", basename);
   return import("../Routes");
 }
 
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
 afterEach(() => {
-  Object.defineProperty(window, "location", {
-    value: { ...window.location, pathname: "/" },
-    writable: true,
-    configurable: true,
-  });
+  vi.unstubAllEnvs();
   vi.resetModules();
 });
 
 // ---------------------------------------------------------------------------
-// Standalone mode — URL is "/" (no Console Chrome prefix)
+// Standalone mode (dev) — env var is "" (Vite sets it to empty string)
 // ---------------------------------------------------------------------------
 
-describe("Standalone mode — pathname is /", () => {
-  let routes: Awaited<ReturnType<typeof importRoutesAtPathname>>["routes"];
+describe("Standalone mode (dev) — APP_BASENAME is empty", () => {
+  let routes: Awaited<ReturnType<typeof importRoutesWithBasename>>["routes"];
 
   beforeEach(async () => {
-    ({ routes } = await importRoutesAtPathname("/"));
+    ({ routes } = await importRoutesWithBasename(""));
   });
 
   it("routes.root returns /", () => {
@@ -77,16 +73,16 @@ describe("Standalone mode — pathname is /", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Microfrontend mode — URL starts with /openshift/migration-advisor
+// Microfrontend mode (stage/prod) — Webpack injects the full slug
 // ---------------------------------------------------------------------------
 
-describe("Microfrontend mode — pathname starts with /openshift/migration-advisor", () => {
+describe("Microfrontend mode (stage/prod) — APP_BASENAME is /openshift/migration-advisor", () => {
   const BASE = "/openshift/migration-advisor";
 
-  let routes: Awaited<ReturnType<typeof importRoutesAtPathname>>["routes"];
+  let routes: Awaited<ReturnType<typeof importRoutesWithBasename>>["routes"];
 
   beforeEach(async () => {
-    ({ routes } = await importRoutesAtPathname(`${BASE}/assessments`));
+    ({ routes } = await importRoutesWithBasename(BASE));
   });
 
   it("routes.root returns the basename", () => {
@@ -135,48 +131,88 @@ describe("Microfrontend mode — pathname starts with /openshift/migration-advis
 });
 
 // ---------------------------------------------------------------------------
-// Legacy slug — /openshift/migration-assessment
+// Fallback — env var not injected by DefinePlugin (e.g. misconfigured build)
 // ---------------------------------------------------------------------------
 
-describe("Legacy slug — pathname starts with /openshift/migration-assessment", () => {
-  it("routes.assessments uses the legacy basename", async () => {
-    const { routes } = await importRoutesAtPathname(
-      "/openshift/migration-assessment/assessments",
-    );
-    expect(routes.assessments).toBe(
-      "/openshift/migration-assessment/assessments",
-    );
+describe("Fallback — env var absent, basename detected lazily from window.location", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, pathname: "/" },
+      writable: true,
+      configurable: true,
+    });
   });
-});
 
-// ---------------------------------------------------------------------------
-// /preview prefix — stage environments use /preview/openshift/...
-// ---------------------------------------------------------------------------
-
-describe("/preview prefix — stage pathname includes /preview", () => {
-  it("strips /preview and detects the correct basename", async () => {
+  it("detects /openshift/migration-advisor when routes are first accessed", async () => {
     const BASE = "/openshift/migration-advisor";
-    const { routes } = await importRoutesAtPathname(
-      `/preview${BASE}/assessments`,
-    );
+
+    // Set the URL to simulate Chrome shell having already navigated here
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, pathname: `${BASE}/assessments` },
+      writable: true,
+      configurable: true,
+    });
+
+    // Do NOT stub env var — simulate DefinePlugin not having injected it
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    const { routes } = await import("../Routes");
+
+    // First routes.* access triggers lazy detection
     expect(routes.assessments).toBe(`${BASE}/assessments`);
     expect(routes.root).toBe(BASE);
   });
+
+  it("strips /preview prefix before detecting the slug", async () => {
+    const BASE = "/openshift/migration-advisor";
+    Object.defineProperty(window, "location", {
+      value: {
+        ...window.location,
+        pathname: `/preview${BASE}/assessments`,
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    const { routes } = await import("../Routes");
+
+    expect(routes.assessments).toBe(`${BASE}/assessments`);
+  });
+
+  it("returns root-relative paths when pathname does not match any known slug", async () => {
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, pathname: "/" },
+      writable: true,
+      configurable: true,
+    });
+
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    const { routes } = await import("../Routes");
+
+    expect(routes.assessments).toBe("/assessments");
+    expect(routes.root).toBe("/");
+  });
 });
 
 // ---------------------------------------------------------------------------
-// Stability — cached value never recomputed after first access
+// Stability — once cached the value never changes regardless of URL changes
 // ---------------------------------------------------------------------------
 
-describe("Stability — basename is cached after the first routes.* access", () => {
-  it("routes remain stable when window.location changes after first access", async () => {
+describe("Stability — basename is cached after first access", () => {
+  it("routes stay stable when window.location changes after first access", async () => {
     const BASE = "/openshift/migration-advisor";
-    const { routes } = await importRoutesAtPathname(`${BASE}/assessments`);
+    const { routes } = await importRoutesWithBasename(BASE);
 
+    // First access — cache is populated
     expect(routes.assessments).toBe(`${BASE}/assessments`);
 
-    // Simulate Chrome synchronously updating window.location before React
-    // finishes rendering (the Back-button race condition).
+    // Simulate Chrome updating window.location before React finishes rendering
+    // (back-button race condition). With lazy caching this has no effect.
     Object.defineProperty(window, "location", {
       value: { ...window.location, pathname: "/openshift/" },
       writable: true,
@@ -185,6 +221,5 @@ describe("Stability — basename is cached after the first routes.* access", () 
 
     // Cached value must be unchanged
     expect(routes.assessments).toBe(`${BASE}/assessments`);
-    expect(routes.root).toBe(BASE);
   });
 });


### PR DESCRIPTION
This reverts commit 591fecd8894fbc713915ecd489615fc244c46cf3.