### PR TITLE
ECOPROJECT-4525 | fix: prevent PDF export container from appearing as white box on scroll

### DIFF
--- a/src/ui/core/components/OffScreenRenderer.tsx
+++ b/src/ui/core/components/OffScreenRenderer.tsx
@@ -14,6 +14,14 @@ import { createPortal } from "react-dom";
 // Styles
 // ---------------------------------------------------------------------------
 
+const offScreenHost = css`
+  position: fixed;
+  left: -9999px;
+  top: 0;
+  z-index: -1;
+  pointer-events: none;
+`;
+
 const offScreenContainer = css`
   position: absolute;
   left: -9999px;
@@ -72,6 +80,7 @@ export const OffScreenRenderer = forwardRef<
   const [host] = useState(() => {
     const el = document.createElement("div");
     el.id = "pdf-hidden-container";
+    el.className = offScreenHost;
     return el;
   });
 


### PR DESCRIPTION
The off-screen PDF export container (#pdf-hidden-container) was appearing as a large white box when scrolling on assessment report pages in production.

Root cause: The host div created in OffScreenRenderer had no positioning styles, causing it to remain in document flow with inherited dimensions.

Fix: Added inline styles to position the host div off-screen and remove it from document flow (position: fixed, left: -9999px, z-index: -1).

Tested in production console - confirmed the white box no longer appears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved off-screen rendering to prevent unintended interactions with interface elements and ensure they remain hidden from view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->