### PR TITLE
NO-JIRA | fix: reverting url changes to avoid redirects from migration-advisor-dev to migration-advisor

### DIFF
--- a/dev/vite.config.ts
+++ b/dev/vite.config.ts
@@ -37,10 +37,6 @@ export default defineConfig(({ mode }) => {
       "process.env.MIGRATION_PLANNER_UI_VERSION": JSON.stringify(
         env.MIGRATION_PLANNER_UI_VERSION,
       ),
-      // Standalone dev mode — app is served at "/", no mount-path prefix.
-      // The microfrontend (Webpack) build sets this to "/openshift/migration-advisor"
-      // via fec.config.js DefinePlugin. See src/routing/Routes.ts.
-      "process.env.MIGRATION_PLANNER_APP_BASENAME": JSON.stringify(""),
     },
     resolve: {
       alias: {

--- a/fec.config.js
+++ b/fec.config.js
@@ -26,12 +26,6 @@ module.exports = {
       "process.env.MIGRATION_PLANNER_UI_VERSION": JSON.stringify(
         process.env.MIGRATION_PLANNER_UI_VERSION,
       ),
-      // Static mount-path prefix — consumed by src/routing/Routes.ts.
-      // Must match appUrl in this file. In standalone (Vite) mode this is
-      // defined as "" in dev/vite.config.ts.
-      "process.env.MIGRATION_PLANNER_APP_BASENAME": JSON.stringify(
-        "/openshift/migration-advisor",
-      ),
     }),
     // Prevent EMFILE (too many open files) by excluding node_modules from
     // webpack's file-system watcher.  The FEC-generated config sets no

--- a/src/routing/Routes.ts
+++ b/src/routing/Routes.ts
@@ -1,70 +1,95 @@
 /**
- * Known app slugs used by the Console Chrome to mount this microfrontend.
- * Both serve the same RootApp module (see deploy/frontend.yaml).
+ * The current app slug used by the Insights Chrome to mount this microfrontend.
+ * Matches `appUrl` in `fec.config.js`.
  */
 const APP_SLUG = "/openshift/migration-advisor";
-const LEGACY_APP_SLUG = "/openshift/migration-assessment";
 
 /**
- * Compute the mount-path prefix once and cache it.
- *
- * Resolution order (first defined value wins):
- *
- * 1. **Build-time injection** — Webpack's DefinePlugin (fec.config.js) sets
- *    `process.env.MIGRATION_PLANNER_APP_BASENAME` to `"/openshift/migration-advisor"`.
- *    Vite (dev/vite.config.ts) sets it to `""` for standalone mode.
- *
- * 2. **Lazy runtime detection** — if the build pipeline did not inject the
- *    constant, we read window.location.pathname the first time a routes.*
- *    getter is accessed. This is safe because routes.* is only accessed inside
- *    React renders, and the Chrome shell only renders this federated module
- *    after navigating to its URL — so pathname is already correct at that point.
- *
- * The result is cached permanently after the first call. Subsequent calls
- * return the cached value without touching window.location again, so Chrome's
- * synchronous window.location update during Back/Forward navigation (which
- * occurs before React's render cycle) cannot corrupt the value.
- *
- * This is intentionally NOT computed at module-load time. Webpack Module
- * Federation pre-loads federated modules in the background while the user is
- * still on a different page (e.g. the Console home or search). At pre-load
- * time window.location.pathname is not the app's URL, so a module-level
- * constant would be set to "" and all routes would lose their prefix.
+ * The legacy app slug kept alive for backward compatibility.
+ * Both slugs serve the same RootApp module (see deploy/frontend.yaml).
  */
-let _cachedBasename: string | null = null;
+const LEGACY_APP_SLUG = "/openshift/migration-assessment";
 
-function getAppBasename(): string {
-  if (_cachedBasename !== null) return _cachedBasename;
+let lastLoggedBasename: string | null = null;
 
-  // Build-time injection (primary path)
-  const buildTime = process.env.MIGRATION_PLANNER_APP_BASENAME;
-  if (buildTime !== undefined) {
-    return (_cachedBasename = buildTime);
-  }
-
-  // Runtime detection fallback
+/**
+ * Resolve the app's base path at runtime.
+ *
+ * - **Standalone (dev) mode** — `BrowserRouter` has `basename="/"` and the
+ *   app is mounted at the root. Returns `""` so every route is root-relative.
+ *
+ * - **Microfrontend (stage) mode** — The Chrome's `BrowserRouter` has
+ *   `basename="/"` and mounts the app inside a nested `<Route>` at
+ *   `APP_SLUG`. Absolute `navigate()` / `<Link to>` calls must therefore
+ *   include the full mount path, otherwise React Router resolves them from
+ *   the router root and the URL ends up outside the app.
+ *
+ * Detection: if the current URL contains the app slug, we're in stage mode.
+ * This is called dynamically each time routes are accessed to avoid module-load
+ * timing issues with federated modules.
+ */
+function resolveAppBasename(): string {
   try {
+    // Strip known Chrome preview/beta prefixes before matching
     const pathname = window.location.pathname.replace(/^\/(preview|beta)/, "");
-    if (pathname.startsWith(APP_SLUG)) return (_cachedBasename = APP_SLUG);
-    if (pathname.startsWith(LEGACY_APP_SLUG))
-      return (_cachedBasename = LEGACY_APP_SLUG);
-  } catch {
-    // SSR / test environment without window
-  }
+    const basename = pathname.startsWith(APP_SLUG)
+      ? APP_SLUG
+      : pathname.startsWith(LEGACY_APP_SLUG)
+        ? LEGACY_APP_SLUG
+        : "";
 
-  return (_cachedBasename = "");
+    // Log only when basename changes or on first detection (to track production issues)
+    if (process.env.NODE_ENV !== "test" && lastLoggedBasename !== basename) {
+      console.info("[Routes] Basename detected:", {
+        mode: basename ? "microfrontend" : "standalone",
+        basename: basename || "(root)",
+        currentPathname: window.location.pathname,
+        timestamp: new Date().toISOString(),
+      });
+      lastLoggedBasename = basename;
+    }
+
+    return basename;
+  } catch {
+    return ""; // SSR / test environment without DOM
+  }
 }
 
 /**
- * Centralized route map.
+ * Get the app's mount-path prefix dynamically.
+ * - `""` in standalone (dev) mode
+ * - `"/openshift/migration-advisor"` in stage mode (current slug)
+ * - `"/openshift/migration-assessment"` in stage mode (legacy slug)
  *
- * Every path includes the mount-path prefix so that navigate() and <Link to>
- * calls work correctly in both standalone and microfrontend mode.
- * All getters call getAppBasename() which caches on first access.
+ * This is computed on each access to avoid caching stale values during
+ * module hot-reloading or federated module initialization.
+ */
+function getAppBasename(): string {
+  return resolveAppBasename();
+}
+
+/**
+ * The app's mount-path prefix.
+ * - `""` in standalone (dev) mode
+ * - `"/openshift/migration-advisor"` in stage mode (current slug)
+ * - `"/openshift/migration-assessment"` in stage mode (legacy slug)
+ *
+ * @deprecated This is a snapshot at module-load time and may be stale.
+ * Prefer using the `routes` object which dynamically resolves the basename.
+ */
+export const APP_BASENAME = getAppBasename();
+
+/**
+ * Centralized route map with dynamic basename resolution.
+ *
+ * Each route property is a getter that computes the full path at access time,
+ * ensuring the basename is always current even during HMR or federated module
+ * initialization.
  */
 export const routes = {
   get root() {
-    return getAppBasename() || "/";
+    const base = getAppBasename();
+    return base || "/";
   },
   get assessments() {
     return `${getAppBasename()}/assessments`;

--- a/src/routing/__tests__/Routes.test.ts
+++ b/src/routing/__tests__/Routes.test.ts
@@ -1,225 +1,348 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Re-import Routes with a specific MIGRATION_PLANNER_APP_BASENAME value.
- *
- * Because the basename is lazily cached on the first routes.* access, we must
- * reset the module registry so that the cache (_cachedBasename) starts as null
- * again, then stub the env var before the first access.
- */
-async function importRoutesWithBasename(basename: string) {
-  vi.resetModules();
-  vi.stubEnv("MIGRATION_PLANNER_APP_BASENAME", basename);
-  return import("../Routes");
-}
+import { APP_BASENAME, routes } from "../Routes";
 
 // ---------------------------------------------------------------------------
-// Setup / teardown
+// Setup
 // ---------------------------------------------------------------------------
 
-afterEach(() => {
-  vi.unstubAllEnvs();
-  vi.resetModules();
-});
+describe("Routes", () => {
+  const originalLocation = window.location;
 
-// ---------------------------------------------------------------------------
-// Standalone mode (dev) — env var is "" (Vite sets it to empty string)
-// ---------------------------------------------------------------------------
-
-describe("Standalone mode (dev) — APP_BASENAME is empty", () => {
-  let routes: Awaited<ReturnType<typeof importRoutesWithBasename>>["routes"];
-
-  beforeEach(async () => {
-    ({ routes } = await importRoutesWithBasename(""));
+  beforeEach(() => {
+    // Mock window.location with Object.defineProperty for safe reassignment
+    Object.defineProperty(window, "location", {
+      value: { ...originalLocation, pathname: "/" },
+      writable: true,
+      configurable: true,
+    });
   });
 
-  it("routes.root returns /", () => {
-    expect(routes.root).toBe("/");
-  });
-
-  it("routes.assessments returns /assessments", () => {
-    expect(routes.assessments).toBe("/assessments");
-  });
-
-  it("routes.assessmentById returns /assessments/:id", () => {
-    expect(routes.assessmentById("test-123")).toBe("/assessments/test-123");
-  });
-
-  it("routes.assessmentReport returns /assessments/:id/report", () => {
-    expect(routes.assessmentReport("test-123")).toBe(
-      "/assessments/test-123/report",
-    );
-  });
-
-  it("routes.assessmentCreate returns /assessments/create", () => {
-    expect(routes.assessmentCreate).toBe("/assessments/create");
-  });
-
-  it("routes.exampleReport returns /assessments/example-report", () => {
-    expect(routes.exampleReport).toBe("/assessments/example-report");
-  });
-
-  it("routes.environments returns /environments", () => {
-    expect(routes.environments).toBe("/environments");
-  });
-
-  it("routes.partners returns /partners", () => {
-    expect(routes.partners).toBe("/partners");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Microfrontend mode (stage/prod) — Webpack injects the full slug
-// ---------------------------------------------------------------------------
-
-describe("Microfrontend mode (stage/prod) — APP_BASENAME is /openshift/migration-advisor", () => {
-  const BASE = "/openshift/migration-advisor";
-
-  let routes: Awaited<ReturnType<typeof importRoutesWithBasename>>["routes"];
-
-  beforeEach(async () => {
-    ({ routes } = await importRoutesWithBasename(BASE));
-  });
-
-  it("routes.root returns the basename", () => {
-    expect(routes.root).toBe(BASE);
-  });
-
-  it("routes.assessments includes basename", () => {
-    expect(routes.assessments).toBe(`${BASE}/assessments`);
-  });
-
-  it("routes.assessmentById includes basename", () => {
-    expect(routes.assessmentById("test-123")).toBe(
-      `${BASE}/assessments/test-123`,
-    );
-  });
-
-  it("routes.assessmentReport includes basename", () => {
-    expect(routes.assessmentReport("test-123")).toBe(
-      `${BASE}/assessments/test-123/report`,
-    );
-  });
-
-  it("routes.assessmentCreate includes basename", () => {
-    expect(routes.assessmentCreate).toBe(`${BASE}/assessments/create`);
-  });
-
-  it("routes.exampleReport includes basename", () => {
-    expect(routes.exampleReport).toBe(`${BASE}/assessments/example-report`);
-  });
-
-  it("routes.environments includes basename", () => {
-    expect(routes.environments).toBe(`${BASE}/environments`);
-  });
-
-  it("routes.partners includes basename", () => {
-    expect(routes.partners).toBe(`${BASE}/partners`);
-  });
-
-  it("routes.myPartner includes basename", () => {
-    expect(routes.myPartner).toBe(`${BASE}/partners/my`);
-  });
-
-  it("routes.adminGroupById includes basename", () => {
-    expect(routes.adminGroupById("g-1")).toBe(`${BASE}/partners/groups/g-1`);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Fallback — env var not injected by DefinePlugin (e.g. misconfigured build)
-// ---------------------------------------------------------------------------
-
-describe("Fallback — env var absent, basename detected lazily from window.location", () => {
   afterEach(() => {
-    vi.unstubAllEnvs();
-    vi.resetModules();
+    // Restore original location
     Object.defineProperty(window, "location", {
-      value: { ...window.location, pathname: "/" },
+      value: originalLocation,
       writable: true,
       configurable: true,
     });
+    vi.clearAllMocks();
   });
 
-  it("detects /openshift/migration-advisor when routes are first accessed", async () => {
+  // ---------------------------------------------------------------------------
+  // Standalone mode (dev) tests
+  // ---------------------------------------------------------------------------
+
+  describe("Standalone mode (dev)", () => {
+    beforeEach(() => {
+      Object.defineProperty(window, "location", {
+        value: { ...window.location, pathname: "/assessments" },
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it("routes.root returns / when in standalone mode", () => {
+      expect(routes.root).toBe("/");
+    });
+
+    it("routes.assessments returns /assessments when in standalone mode", () => {
+      expect(routes.assessments).toBe("/assessments");
+    });
+
+    it("routes.assessmentById returns /assessments/:id when in standalone mode", () => {
+      expect(routes.assessmentById("test-123")).toBe("/assessments/test-123");
+    });
+
+    it("routes.assessmentReport returns /assessments/:id/report when in standalone mode", () => {
+      expect(routes.assessmentReport("test-123")).toBe(
+        "/assessments/test-123/report",
+      );
+    });
+
+    it("routes.assessmentCreate returns /assessments/create when in standalone mode", () => {
+      expect(routes.assessmentCreate).toBe("/assessments/create");
+    });
+
+    it("routes.exampleReport returns /assessments/example-report when in standalone mode", () => {
+      expect(routes.exampleReport).toBe("/assessments/example-report");
+    });
+
+    it("routes.environments returns /environments when in standalone mode", () => {
+      expect(routes.environments).toBe("/environments");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Microfrontend mode (stage/prod) tests
+  // ---------------------------------------------------------------------------
+
+  describe("Microfrontend mode (stage/prod)", () => {
     const BASE = "/openshift/migration-advisor";
 
-    // Set the URL to simulate Chrome shell having already navigated here
-    Object.defineProperty(window, "location", {
-      value: { ...window.location, pathname: `${BASE}/assessments` },
-      writable: true,
-      configurable: true,
+    beforeEach(() => {
+      Object.defineProperty(window, "location", {
+        value: { ...window.location, pathname: `${BASE}/assessments` },
+        writable: true,
+        configurable: true,
+      });
     });
 
-    // Do NOT stub env var — simulate DefinePlugin not having injected it
-    vi.resetModules();
-    vi.unstubAllEnvs();
-    const { routes } = await import("../Routes");
+    it("routes.root returns basename when in microfrontend mode", () => {
+      expect(routes.root).toBe(BASE);
+    });
 
-    // First routes.* access triggers lazy detection
-    expect(routes.assessments).toBe(`${BASE}/assessments`);
-    expect(routes.root).toBe(BASE);
+    it("routes.assessments includes basename when in microfrontend mode", () => {
+      expect(routes.assessments).toBe(`${BASE}/assessments`);
+    });
+
+    it("routes.assessmentById includes basename when in microfrontend mode", () => {
+      expect(routes.assessmentById("test-123")).toBe(
+        `${BASE}/assessments/test-123`,
+      );
+    });
+
+    it("routes.assessmentReport includes basename when in microfrontend mode", () => {
+      expect(routes.assessmentReport("test-123")).toBe(
+        `${BASE}/assessments/test-123/report`,
+      );
+    });
+
+    it("routes.assessmentCreate includes basename when in microfrontend mode", () => {
+      expect(routes.assessmentCreate).toBe(`${BASE}/assessments/create`);
+    });
+
+    it("routes.exampleReport includes basename when in microfrontend mode", () => {
+      expect(routes.exampleReport).toBe(`${BASE}/assessments/example-report`);
+    });
+
+    it("routes.environments includes basename when in microfrontend mode", () => {
+      expect(routes.environments).toBe(`${BASE}/environments`);
+    });
   });
 
-  it("strips /preview prefix before detecting the slug", async () => {
-    const BASE = "/openshift/migration-advisor";
-    Object.defineProperty(window, "location", {
-      value: {
-        ...window.location,
-        pathname: `/preview${BASE}/assessments`,
-      },
-      writable: true,
-      configurable: true,
+  // ---------------------------------------------------------------------------
+  // Dynamic resolution tests
+  // ---------------------------------------------------------------------------
+
+  describe("Dynamic basename resolution", () => {
+    it("routes update when window.location changes from standalone to microfrontend", () => {
+      // Start in standalone mode
+      Object.defineProperty(window, "location", {
+        value: { ...window.location, pathname: "/assessments" },
+        writable: true,
+        configurable: true,
+      });
+      expect(routes.assessments).toBe("/assessments");
+
+      // Simulate navigation to microfrontend mode
+      Object.defineProperty(window, "location", {
+        value: {
+          ...window.location,
+          pathname: "/openshift/migration-advisor/assessments",
+        },
+        writable: true,
+        configurable: true,
+      });
+      expect(routes.assessments).toBe(
+        "/openshift/migration-advisor/assessments",
+      );
     });
 
-    vi.resetModules();
-    vi.unstubAllEnvs();
-    const { routes } = await import("../Routes");
+    it("routes update when window.location changes from microfrontend to standalone", () => {
+      // Start in microfrontend mode
+      Object.defineProperty(window, "location", {
+        value: {
+          ...window.location,
+          pathname: "/openshift/migration-advisor/assessments",
+        },
+        writable: true,
+        configurable: true,
+      });
+      expect(routes.assessments).toBe(
+        "/openshift/migration-advisor/assessments",
+      );
 
-    expect(routes.assessments).toBe(`${BASE}/assessments`);
+      // Simulate navigation to standalone mode
+      Object.defineProperty(window, "location", {
+        value: { ...window.location, pathname: "/assessments" },
+        writable: true,
+        configurable: true,
+      });
+      expect(routes.assessments).toBe("/assessments");
+    });
+
+    it("handles /preview prefix correctly in microfrontend mode", () => {
+      Object.defineProperty(window, "location", {
+        value: {
+          ...window.location,
+          pathname: "/preview/openshift/migration-advisor/assessments",
+        },
+        writable: true,
+        configurable: true,
+      });
+      expect(routes.assessments).toBe(
+        "/openshift/migration-advisor/assessments",
+      );
+    });
+
+    it("handles /beta prefix correctly in microfrontend mode", () => {
+      Object.defineProperty(window, "location", {
+        value: {
+          ...window.location,
+          pathname: "/beta/openshift/migration-advisor/assessments",
+        },
+        writable: true,
+        configurable: true,
+      });
+      expect(routes.assessments).toBe(
+        "/openshift/migration-advisor/assessments",
+      );
+    });
+
+    it("handles /preview prefix correctly in standalone mode", () => {
+      Object.defineProperty(window, "location", {
+        value: { ...window.location, pathname: "/preview/assessments" },
+        writable: true,
+        configurable: true,
+      });
+      expect(routes.assessments).toBe("/assessments");
+    });
   });
 
-  it("returns root-relative paths when pathname does not match any known slug", async () => {
-    Object.defineProperty(window, "location", {
-      value: { ...window.location, pathname: "/" },
-      writable: true,
-      configurable: true,
+  // ---------------------------------------------------------------------------
+  // APP_BASENAME export (legacy)
+  // ---------------------------------------------------------------------------
+
+  describe("APP_BASENAME export", () => {
+    it("APP_BASENAME is a string", () => {
+      expect(typeof APP_BASENAME).toBe("string");
     });
 
-    vi.resetModules();
-    vi.unstubAllEnvs();
-    const { routes } = await import("../Routes");
-
-    expect(routes.assessments).toBe("/assessments");
-    expect(routes.root).toBe("/");
+    it("APP_BASENAME matches the current resolved basename", () => {
+      // Note: APP_BASENAME is computed once at module-load, so it may be stale.
+      // This test just verifies it's exported and is a string.
+      expect(APP_BASENAME).toMatch(/^(|\/openshift\/migration-assessment)$/);
+    });
   });
-});
 
-// ---------------------------------------------------------------------------
-// Stability — once cached the value never changes regardless of URL changes
-// ---------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
+  // Production bug reproduction test
+  // ---------------------------------------------------------------------------
 
-describe("Stability — basename is cached after first access", () => {
-  it("routes stay stable when window.location changes after first access", async () => {
-    const BASE = "/openshift/migration-advisor";
-    const { routes } = await importRoutesWithBasename(BASE);
+  describe("Production bug: inconsistent URL generation after login/logout", () => {
+    it("reproduces the 'See an example report' navigation bug where basename is missing", () => {
+      // SCENARIO: User logs in, module loads before Chrome routing is ready
+      // Simulate: Module loads with incorrect pathname (root or incomplete)
+      Object.defineProperty(window, "location", {
+        value: { ...window.location, pathname: "/" },
+        writable: true,
+        configurable: true,
+      });
 
-    // First access — cache is populated
-    expect(routes.assessments).toBe(`${BASE}/assessments`);
+      // At this point, if routes were static (old behavior), they would cache
+      // the wrong basename and return "/assessments/example-report"
 
-    // Simulate Chrome updating window.location before React finishes rendering
-    // (back-button race condition). With lazy caching this has no effect.
-    Object.defineProperty(window, "location", {
-      value: { ...window.location, pathname: "/openshift/" },
-      writable: true,
-      configurable: true,
+      // User navigates to the app after Chrome routing initializes
+      Object.defineProperty(window, "location", {
+        value: {
+          ...window.location,
+          pathname: "/openshift/migration-advisor/assessments",
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      // User clicks "See an example report" button
+      const exampleReportUrl = routes.exampleReport;
+
+      // EXPECTED: Should return correct URL with basename
+      expect(exampleReportUrl).toBe(
+        "/openshift/migration-advisor/assessments/example-report",
+      );
+
+      // BEFORE FIX: Would return "/assessments/example-report"
+      // AFTER FIX: Returns "/openshift/migration-advisor/assessments/example-report"
     });
 
-    // Cached value must be unchanged
-    expect(routes.assessments).toBe(`${BASE}/assessments`);
+    it("reproduces the RVTools upload navigation bug where basename is missing", () => {
+      // SCENARIO: User uploads RVTools file, job completes, navigates to report
+      // Simulate: Module loaded at wrong time, pathname changes during session
+
+      // Initial load with incomplete pathname
+      Object.defineProperty(window, "location", {
+        value: { ...window.location, pathname: "/assessments" },
+        writable: true,
+        configurable: true,
+      });
+
+      // User is actually in the microfrontend context
+      Object.defineProperty(window, "location", {
+        value: {
+          ...window.location,
+          pathname: "/openshift/migration-advisor/assessments",
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      // Job completes, navigate to report
+      const assessmentId = "d8d38f15-d3f6-49a6-9a8b-2f7efc21aae9";
+      const reportUrl = routes.assessmentReport(assessmentId);
+
+      // EXPECTED: Should return correct URL with basename
+      expect(reportUrl).toBe(
+        `/openshift/migration-advisor/assessments/${assessmentId}/report`,
+      );
+
+      // BEFORE FIX: Would return "/assessments/d8d38f15-.../report"
+      // AFTER FIX: Returns "/openshift/migration-advisor/assessments/d8d38f15-.../report"
+    });
+
+    it("verifies all route getters adapt to pathname changes during the session", () => {
+      // Simulate module load at root
+      Object.defineProperty(window, "location", {
+        value: { ...window.location, pathname: "/" },
+        writable: true,
+        configurable: true,
+      });
+
+      // Routes should work in standalone mode initially
+      expect(routes.assessments).toBe("/assessments");
+      expect(routes.environments).toBe("/environments");
+
+      // User navigates to microfrontend context (Chrome loads)
+      Object.defineProperty(window, "location", {
+        value: {
+          ...window.location,
+          pathname: "/openshift/migration-advisor/assessments",
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      // ALL routes should now include the basename
+      expect(routes.root).toBe("/openshift/migration-advisor");
+      expect(routes.assessments).toBe(
+        "/openshift/migration-advisor/assessments",
+      );
+      expect(routes.assessmentCreate).toBe(
+        "/openshift/migration-advisor/assessments/create",
+      );
+      expect(routes.exampleReport).toBe(
+        "/openshift/migration-advisor/assessments/example-report",
+      );
+      expect(routes.environments).toBe(
+        "/openshift/migration-advisor/environments",
+      );
+
+      // And they should work correctly for navigation
+      const testId = "test-123";
+      expect(routes.assessmentById(testId)).toBe(
+        `/openshift/migration-advisor/assessments/${testId}`,
+      );
+      expect(routes.assessmentReport(testId)).toBe(
+        `/openshift/migration-advisor/assessments/${testId}/report`,
+      );
+    });
   });
 });


### PR DESCRIPTION
Reverting url changes to avoid redirects from migration-advisor-dev to migration-advisor.
- Commits reverted: 978b0e786e6597bf5deeb5079f107b168779fe89, f79cb3888430cd59af63795734a9dd43997e32e3, db6ebaad85be54aa7cefd87f56e538ecd9d29680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated routing logic to dynamically resolve mount paths at runtime instead of build-time, improving support for different deployment contexts and environment prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->