### PR TITLE
ECOPROJECT-4535 | fix: Disable/Enable assessment actions depending on user's permissions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "@emotion/css": "^11.13.5",
         "@hookform/resolvers": "^5.2.2",
-        "@openshift-migration-advisor/planner-sdk": "^0.12.0-390afc4a9dfe",
+        "@openshift-migration-advisor/planner-sdk": "^0.12.0-7e11634ba97d",
         "@patternfly/react-charts": "7.4.9",
         "@patternfly/react-core": "^6.4.1",
         "@patternfly/react-icons": "^6.4.0",
@@ -2721,9 +2721,9 @@
       }
     },
     "node_modules/@openshift-migration-advisor/planner-sdk": {
-      "version": "0.12.0-390afc4a9dfe",
-      "resolved": "https://registry.npmjs.org/@openshift-migration-advisor/planner-sdk/-/planner-sdk-0.12.0-390afc4a9dfe.tgz",
-      "integrity": "sha512-KFv6M2RGsXds8V2PxDPIadxDCeLoZk8vfmc9yVX68renFzCL2ZxQlV7J/qdUdlKsLJ0pTl6A7wRBDD6fESfk/A==",
+      "version": "0.12.0-7e11634ba97d",
+      "resolved": "https://registry.npmjs.org/@openshift-migration-advisor/planner-sdk/-/planner-sdk-0.12.0-7e11634ba97d.tgz",
+      "integrity": "sha512-Xs8WyJtOc1YRDR3NNoySTThPSN6W+RNE9fafrhXHNUX9vmO6a22v1BwiisLJUdaIdisH1VEy1cRl0aNxDo82Ow==",
       "license": "Apache-2.0"
     },
     "node_modules/@openshift/dynamic-plugin-sdk": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@emotion/css": "^11.13.5",
     "@hookform/resolvers": "^5.2.2",
-    "@openshift-migration-advisor/planner-sdk": "^0.12.0-390afc4a9dfe",
+    "@openshift-migration-advisor/planner-sdk": "^0.12.0-7e11634ba97d",
     "@patternfly/react-charts": "7.4.9",
     "@patternfly/react-core": "^6.4.1",
     "@patternfly/react-icons": "^6.4.0",

--- a/src/ui/assessment/views/AssessmentsPage.tsx
+++ b/src/ui/assessment/views/AssessmentsPage.tsx
@@ -85,7 +85,6 @@ export const AssessmentsPage: React.FC<AssessmentsPageProps> = ({
   rvtoolsOpenToken,
 }) => {
   const {
-    identity,
     isCreatingJob,
     jobCreateError,
     isJobProcessing,
@@ -508,7 +507,6 @@ export const AssessmentsPage: React.FC<AssessmentsPageProps> = ({
             selectedSourceTypes={selectedSourceTypes}
             selectedOwners={selectedOwners}
             visibleColumns={visibleColumns}
-            canShareAssessment={identity?.kind === "customer"}
           />
         </div>
       )}

--- a/src/ui/assessment/views/AssessmentsTable.tsx
+++ b/src/ui/assessment/views/AssessmentsTable.tsx
@@ -62,7 +62,6 @@ type AssessmentsTableProps = {
   onDelete?: (assessmentId: string) => void;
   onUpdate?: (assessmentId: string) => void;
   visibleColumns?: ColumnKey[];
-  canShareAssessment: boolean;
   onShareAssessment: (assessmentId: string) => void;
 };
 
@@ -105,7 +104,6 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
   onSort,
   onDelete,
   visibleColumns = Object.keys(Columns) as ColumnKey[],
-  canShareAssessment,
   onShareAssessment,
 }) => {
   const navigate = useNavigate();
@@ -135,6 +133,9 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
       const id = String(assessment.id ?? "");
       const sourceType = assessment.sourceType || "Unknown";
       const snapshots = assessment.snapshots ?? [];
+      const permissions = Array.isArray(assessment.permissions)
+        ? assessment.permissions
+        : [];
 
       // Use pre-computed model properties
       const snapshotData = assessment.latestSnapshot;
@@ -167,6 +168,7 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
         datastores: snapshotData.datastores,
         snapshots,
         hasData,
+        permissions,
       };
     });
 
@@ -539,8 +541,15 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
                   >
                     <Button
                       variant="link"
-                      isAriaDisabled={!row.hasData}
-                      onClick={() => navigate(routes.assessmentReport(row.id))}
+                      isAriaDisabled={
+                        !row.hasData || !row.permissions.includes("read")
+                      }
+                      onClick={
+                        row.hasData && row.permissions.includes("read")
+                          ? (): void =>
+                              navigate(routes.assessmentReport(row.id))
+                          : undefined
+                      }
                       icon={<MonitoringIcon />}
                       aria-label="View assessment report"
                       style={{ padding: 0 }}
@@ -579,7 +588,9 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
                   <DropdownList>
                     <DropdownItem
                       onClick={() => navigate(routes.assessmentReport(row.id))}
-                      isDisabled={!row.hasData}
+                      isDisabled={
+                        !row.hasData || !row.permissions.includes("read")
+                      }
                     >
                       Show assessment report
                     </DropdownItem>
@@ -589,16 +600,15 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
                     >
                       Edit assessment
                     </DropdownItem>
-                    {canShareAssessment && (
-                      <DropdownItem
-                        onClick={() => {
-                          toggleDropdown(row.id);
-                          return onShareAssessment(row.id);
-                        }}
-                      >
-                        Share with partner
-                      </DropdownItem>
-                    )}
+                    <DropdownItem
+                      onClick={() => {
+                        toggleDropdown(row.id);
+                        return onShareAssessment(row.id);
+                      }}
+                      isDisabled={!row.permissions.includes("share")}
+                    >
+                      Share assessment
+                    </DropdownItem>
                     <DropdownItem
                       onClick={openAssistedInstaller}
                       isDisabled={!row.hasData}
@@ -610,6 +620,9 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
                         toggleDropdown(row.id);
                         return handleDelete(row.id);
                       }}
+                      isDisabled={
+                        !onDelete || !row.permissions.includes("delete")
+                      }
                     >
                       Delete assessment
                     </DropdownItem>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed assessment sharing action to properly respect user permissions; action now displays as disabled when lacking share permission instead of being conditionally hidden.
  * Updated view/read assessment report button to enforce read permissions and prevent navigation without proper access.
  * Corrected delete action to respect delete permissions per assessment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->