### PR TITLE
ECOPROJECT-4532 | fix: Unclear error message returned for long input in 'Request a Partner' form

### DIFF
--- a/src/ui/partner/regularUser/components/ContactFormModal.tsx
+++ b/src/ui/partner/regularUser/components/ContactFormModal.tsx
@@ -1,5 +1,7 @@
+import { css } from "@emotion/css";
 import type { PartnerRequestCreate } from "@openshift-migration-advisor/planner-sdk";
 import {
+  Alert,
   Button,
   Modal,
   ModalBody,
@@ -11,20 +13,25 @@ import React from "react";
 
 import { ContactForm } from "./ContactForm";
 
+const errorDivStyle = css`
+  padding-top: 1em;
+`;
+
 interface ContactFormModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSubmit: (values: PartnerRequestCreate) => void | Promise<void>;
+  error?: Error;
 }
 
 export const ContactFormModal: React.FC<ContactFormModalProps> = ({
   isOpen,
   onClose,
   onSubmit,
+  error,
 }) => {
   const handleSubmit = async (values: PartnerRequestCreate) => {
     await onSubmit(values);
-    onClose();
   };
 
   return (
@@ -37,6 +44,13 @@ export const ContactFormModal: React.FC<ContactFormModalProps> = ({
             void handleSubmit(values);
           }}
         />
+        {error && (
+          <div className={errorDivStyle}>
+            <Alert isInline variant="danger" title="Request a partner failed">
+              {error.message}
+            </Alert>
+          </div>
+        )}
       </ModalBody>
       <ModalFooter>
         <Button variant="primary" type="submit" form="contact-partner-form">

--- a/src/ui/partner/regularUser/view-models/__tests__/usePartnersViewModel.test.ts
+++ b/src/ui/partner/regularUser/view-models/__tests__/usePartnersViewModel.test.ts
@@ -2,6 +2,7 @@ import type { PartnerRequestCreate } from "@openshift-migration-advisor/planner-
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { Partner } from "../../../../../models/PartnerModel";
 import { usePartnersViewModel } from "../usePartnersViewModel";
 
 // ---------------------------------------------------------------------------
@@ -65,11 +66,14 @@ describe("usePartnersViewModel - createPartnerRequest", () => {
       await Promise.resolve();
     });
 
+    // Open the contact form modal to select the partner
+    act(() => {
+      result.current.openContactFormModal({ id: partnerId } as Partner);
+    });
+
+    // Create the partner request
     await act(async () => {
-      await result.current.createPartnerRequest(
-        partnerId,
-        mockPartnerRequestCreate,
-      );
+      await result.current.createPartnerRequest(mockPartnerRequestCreate);
     });
 
     expect(mockPartnerRequestsStore.create).toHaveBeenCalledWith(

--- a/src/ui/partner/regularUser/view-models/usePartnersViewModel.ts
+++ b/src/ui/partner/regularUser/view-models/usePartnersViewModel.ts
@@ -3,22 +3,24 @@ import type {
   PartnerRequestCreate,
 } from "@openshift-migration-advisor/planner-sdk";
 import { useInjection } from "@y0n1/react-ioc";
-import { useSyncExternalStore } from "react";
+import { useState, useSyncExternalStore } from "react";
 import { useAsync, useAsyncFn } from "react-use";
 
 import { Symbols } from "../../../../config/Dependencies";
 import type { IPartnerRequestsStore } from "../../../../data/stores/interfaces/IPartnerRequestsStore";
 import type { IPartnersStore } from "../../../../data/stores/interfaces/IPartnersStore";
+import { parseApiError } from "../../../../lib/common/ErrorParser";
 import type { Partner } from "../../../../models/PartnerModel";
 
 export interface PartnersViewModel {
   partners: Partner[];
   isLoading: boolean;
   error?: Error;
-  createPartnerRequest: (
-    partnerId: string,
-    data: PartnerRequestCreate,
-  ) => Promise<PartnerRequest>;
+  createError?: Error;
+  openContactFormModal: (partner: Partner | null) => void;
+  closeContactFormModal: () => void;
+  createPartnerRequest: (data: PartnerRequestCreate) => Promise<PartnerRequest>;
+  isContactFormModalOpen: boolean;
 }
 
 export const usePartnersViewModel = (): PartnersViewModel => {
@@ -27,6 +29,9 @@ export const usePartnersViewModel = (): PartnersViewModel => {
     Symbols.PartnerRequestsStore,
   );
 
+  const [selectedPartner, setSelectedPartner] = useState<Partner | null>(null);
+  const [createError, setCreateError] = useState<Error | undefined>();
+
   const partners = useSyncExternalStore<Partner[]>(
     partnersStore.subscribe.bind(partnersStore),
     partnersStore.getSnapshot.bind(partnersStore),
@@ -34,17 +39,47 @@ export const usePartnersViewModel = (): PartnersViewModel => {
 
   const { loading, error } = useAsync(() => partnersStore.list(), []);
 
+  const closeContactFormModal = () => {
+    setSelectedPartner(null);
+    setCreateError(undefined);
+  };
+
   const [createState, doCreatePartnerRequest] = useAsyncFn(
     async (partnerId: string, data: PartnerRequestCreate) => {
-      return await partnerRequestsStore.create(partnerId, data);
+      try {
+        const result = await partnerRequestsStore.create(partnerId, data);
+        setCreateError(undefined);
+        closeContactFormModal();
+        return result;
+      } catch (err) {
+        const parsedError = await parseApiError(
+          err,
+          "Failed to create an assignment request",
+        );
+        setCreateError(parsedError);
+        throw parsedError;
+      }
     },
     [partnerRequestsStore],
   );
 
+  const createPartnerRequest = async (
+    data: PartnerRequestCreate,
+  ): Promise<PartnerRequest> => {
+    if (!selectedPartner) {
+      throw new Error("No partner selected");
+    }
+    return doCreatePartnerRequest(selectedPartner.id, data);
+  };
+
   return {
     partners,
     isLoading: loading || createState.loading,
-    error: error || createState.error,
-    createPartnerRequest: doCreatePartnerRequest,
+    error,
+    createError,
+    openContactFormModal: setSelectedPartner,
+    closeContactFormModal,
+    isContactFormModalOpen: selectedPartner !== null,
+    createPartnerRequest,
   };
 };

--- a/src/ui/partner/regularUser/views/PartnersListSection.tsx
+++ b/src/ui/partner/regularUser/views/PartnersListSection.tsx
@@ -15,9 +15,8 @@ import {
   Title,
 } from "@patternfly/react-core";
 import { SearchIcon } from "@patternfly/react-icons";
-import React, { useState } from "react";
+import React from "react";
 
-import type { Partner } from "../../../../models/PartnerModel";
 import { LoadingSpinner } from "../../../core/components/LoadingSpinner";
 import { ContactFormModal } from "../components/ContactFormModal";
 import { usePartnersViewModel } from "../view-models/usePartnersViewModel";
@@ -28,15 +27,6 @@ const introStyle = css`
 
 export const PartnersListSection: React.FC = () => {
   const vm = usePartnersViewModel();
-  const [selectedPartner, setSelectedPartner] = useState<Partner | null>(null);
-
-  const handleSubmitRequest = async (values: PartnerRequestCreate) => {
-    if (!selectedPartner) {
-      return;
-    }
-    await vm.createPartnerRequest(selectedPartner.id, values);
-    setSelectedPartner(null);
-  };
 
   return (
     <PageSection>
@@ -86,7 +76,7 @@ export const PartnersListSection: React.FC = () => {
                 <Button
                   variant="primary"
                   isBlock
-                  onClick={() => setSelectedPartner(partner)}
+                  onClick={() => vm.openContactFormModal(partner)}
                 >
                   Request assignment
                 </Button>
@@ -96,11 +86,14 @@ export const PartnersListSection: React.FC = () => {
         </Gallery>
       )}
 
-      {selectedPartner !== null && (
+      {vm.isContactFormModalOpen && (
         <ContactFormModal
           isOpen
-          onClose={() => setSelectedPartner(null)}
-          onSubmit={(values) => void handleSubmitRequest(values)}
+          onClose={vm.closeContactFormModal}
+          onSubmit={(values: PartnerRequestCreate) =>
+            void vm.createPartnerRequest(values)
+          }
+          error={vm.createError}
         />
       )}
     </PageSection>


### PR DESCRIPTION
When a very long company name or primary name is entered in the “Request a Partner” form, the system returns a generic Partners API error (“Response returned an error code”). This message does not provide enough context for the user to understand what went wrong. The error handling should display a clear and user-friendly message indicating that the input exceeds allowed limits or is invalid.

<img width="840" height="695" alt="localhost_3000_partners (1)" src="https://github.com/user-attachments/assets/f90e77c7-2900-435b-8053-c559ac5c63ef" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Contact form modal now displays submission errors inline, keeping the modal open for users to address issues and retry without losing form context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->