### PR TITLE
ECOPROJECT-4531 | fix: Add contact form input validation

### DIFF
--- a/src/ui/partner/regularUser/components/ContactForm.tsx
+++ b/src/ui/partner/regularUser/components/ContactForm.tsx
@@ -15,18 +15,31 @@ interface ContactFormProps {
 const validationSchema: yup.ObjectSchema<PartnerRequestCreate> = yup
   .object()
   .shape({
-    name: yup.string().trim().required("Your company name is required"),
+    name: yup
+      .string()
+      .trim()
+      .required("Your company name is required")
+      .max(100, "Company name must be 100 characters or less"),
     contactName: yup
       .string()
       .trim()
-      .required("Primary contact name is required"),
-    contactPhone: yup.string().trim().default(""),
+      .required("Primary contact name is required")
+      .max(100, "Contact name must be 100 characters or less"),
+    contactPhone: yup
+      .string()
+      .trim()
+      .default("")
+      .max(20, "Phone number must be 20 characters or less"),
     email: yup
       .string()
       .trim()
       .required("Email is required")
       .email("Please enter a valid email address"),
-    location: yup.string().trim().default(""),
+    location: yup
+      .string()
+      .trim()
+      .default("")
+      .max(100, "Location must be 100 characters or less"),
   });
 
 export const ContactForm: React.FC<ContactFormProps> = ({ id, onSubmit }) => {

--- a/src/ui/partner/regularUser/components/__tests__/ContactForm.test.tsx
+++ b/src/ui/partner/regularUser/components/__tests__/ContactForm.test.tsx
@@ -182,4 +182,30 @@ describe("ContactForm", () => {
       expect(getByText("Your company name is required")).toBeInTheDocument();
     });
   });
+
+  it("validates company name maximum length", async () => {
+    const mockOnSubmit = vi.fn();
+    const user = userEvent.setup();
+    const { getByRole, getByText } = render(
+      <>
+        <ContactForm id="contact-form" onSubmit={mockOnSubmit} />
+        <Button variant="primary" type="submit" form="contact-form">
+          Contact
+        </Button>
+      </>,
+    );
+
+    const name = getByRole("textbox", { name: /Your company name/i });
+    // Create a string with 101 characters
+    const longName = "A".repeat(101);
+    await user.type(name, longName);
+
+    const contactButton = getByRole("button", { name: /Contact/i });
+    await user.click(contactButton);
+
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+    expect(
+      getByText("Company name must be 100 characters or less"),
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
The company name and primary name fields in the “Request a Partner” form accept any type and length of input without validation. This allows users to submit excessively long or potentially invalid data. Proper input validation (e.g., maximum length, allowed characters) may prevent invalid submissions and improve overall form reliability.