### PR TITLE
NO-JIRA | fix: Add enableProxy to handleSubmit dependencies to fix stale closure

### DIFF
--- a/src/ui/environment/views/DiscoverySourceSetupModal.tsx
+++ b/src/ui/environment/views/DiscoverySourceSetupModal.tsx
@@ -369,6 +369,7 @@ export const DiscoverySourceSetupModal: React.FC<
       httpProxy,
       httpsProxy,
       noProxy,
+      enableProxy,
       vm,
       sourceName,
       onStartDownload,


### PR DESCRIPTION
The enableProxy state variable was missing from the useCallback dependencies array, causing a stale closure issue where rapid changes to the proxy toggle followed by form submission would use the old enableProxy value instead of the current state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy configuration handling in the Discovery Source Setup to ensure correct validation and application of proxy settings when the proxy configuration status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->