### PR TITLE
ECOPROJECT-4527 | fix: Clear backend error when selecting valid file in CreateAssessmentModal

### DIFF
--- a/src/ui/assessment/views/CreateAssessmentModal.tsx
+++ b/src/ui/assessment/views/CreateAssessmentModal.tsx
@@ -201,6 +201,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
     setFileValidationError("");
     setSelectedFile(file);
     setFilename(file.name);
+    onClearError?.();
   };
 
   const handleFileClear = (): void => {


### PR DESCRIPTION
After uploading an invalid RVTools file, the error message persisted even when selecting a valid file afterward, keeping the Create Assessment button disabled. Now calling onClearError when a valid file is selected to match the behavior of the assessment name field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File selection in assessment creation now automatically clears previous error messages when a valid file is accepted, improving the user experience during the file upload process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->