### PR TITLE
NO-JIRA | fix: Display Shared by or Shared with in assessment sharing status

### DIFF
--- a/src/data/stores/AssessmentsStore.ts
+++ b/src/data/stores/AssessmentsStore.ts
@@ -202,8 +202,23 @@ export class AssessmentsStore
     return deletedAssessment;
   }
 
-  async share(id: string) {
-    await this.api.shareAssessment({ id });
+  async share(
+    id: string,
+    initOverrides?: RequestInit | InitOverrideFunction,
+  ): Promise<AssessmentModel> {
+    try {
+      await this.api.shareAssessment({ id }, initOverrides);
+    } catch (err) {
+      throw await parseApiError(err, "Failed to share assessment");
+    }
+    // Fetch the updated assessment to get the sharedBy information
+    const updated = await this.api.getAssessment({ id }, initOverrides);
+    const model = createAssessmentModel(updated);
+    this.assessments = this.assessments.map((assessment) =>
+      assessment.id === model.id ? model : assessment,
+    );
+    this.notify();
+    return model;
   }
 
   calculateAssessmentClusterRequirements(

--- a/src/data/stores/interfaces/IAssessmentsStore.ts
+++ b/src/data/stores/interfaces/IAssessmentsStore.ts
@@ -47,7 +47,10 @@ export interface IAssessmentsStore extends ExternalStore<AssessmentModel[]> {
     id: string,
     initOverrides?: RequestInit | InitOverrideFunction,
   ): Promise<AssessmentModel>;
-  share(id: string): Promise<void>;
+  share(
+    id: string,
+    initOverrides?: RequestInit | InitOverrideFunction,
+  ): Promise<AssessmentModel>;
   calculateAssessmentClusterRequirements(
     requestParameters: CalculateAssessmentClusterRequirementsRequest,
     initOverrides?: RequestInit | InitOverrideFunction,

--- a/src/ui/assessment/views/AssessmentsTable.tsx
+++ b/src/ui/assessment/views/AssessmentsTable.tsx
@@ -141,6 +141,7 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
         ? assessment.permissions
         : [];
       const isShared = assessment.sharing?.isShared || false;
+      const sharedBy = assessment.sharing?.sharedBy || null;
 
       // Use pre-computed model properties
       const snapshotData = assessment.latestSnapshot;
@@ -175,6 +176,7 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
         hasData,
         permissions,
         isShared,
+        sharedBy,
       };
     });
 
@@ -571,7 +573,11 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
             )}
             {isColumnVisible("SharingStatus") && (
               <Td dataLabel={Columns.SharingStatus}>
-                {row.isShared ? "Shared with partner" : "Not shared"}
+                {row.isShared
+                  ? row.sharedBy
+                    ? "Shared by customer"
+                    : "Shared with partner"
+                  : "Not shared"}
               </Td>
             )}
             {isColumnVisible("Actions") && (


### PR DESCRIPTION
Depending on user role, the API return a sharedBy or sharedWith object. We use this in the assessment table to display better information.

Also update the list after sharing to display the sharing status directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Updated sharing status display in the assessments table to distinguish between assessments shared by the customer and those shared with a partner, providing clearer visibility into sharing origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->