### PR TITLE
ECOPROJECT-4574 | fix: incorrect 'Read more' URL in discovery agent instructions

### DIFF
--- a/src/ui/core/components/VCenterSetupInstructions.tsx
+++ b/src/ui/core/components/VCenterSetupInstructions.tsx
@@ -64,7 +64,7 @@ export const VCenterSetupInstructions: React.FC = () => {
               Select your preference for sharing aggregated data with
               console.redhat.com (read more{" "}
               <a
-                href="https://kubev2v.github.io/openshift-migration-advisor-docs/docs/tutorial/#discovery-agent-flow"
+                href="https://kubev2v.github.io/openshift-migration-advisor-docs/docs/aggregated-data-report/"
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
<img width="1237" height="908" alt="Captura desde 2026-05-05 13-41-54" src="https://github.com/user-attachments/assets/510f6875-9fc4-45c7-8371-8ed56c94f72d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated hyperlink in setup instructions to reference aggregated data report documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->