### PR TITLE
ECOPROJECT-4536 | feat: create different examples for OVA and RVTools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2440,19 +2440,6 @@
         "eslint-scope": "5.1.1"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@nuxt/opencollective": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.4.1.tgz",
@@ -2763,9 +2750,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2787,9 +2771,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2811,9 +2792,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2835,9 +2813,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2859,9 +2834,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2883,9 +2855,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3918,9 +3887,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3935,9 +3901,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3952,9 +3915,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3969,9 +3929,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3986,9 +3943,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4003,9 +3957,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4020,9 +3971,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4037,9 +3985,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4054,9 +3999,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4071,9 +4013,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4088,9 +4027,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4105,9 +4041,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4122,9 +4055,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4746,9 +4676,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4766,9 +4693,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4786,9 +4710,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4806,9 +4727,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4826,9 +4744,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4846,9 +4761,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -19816,22 +19728,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
-      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/src/routing/AppRoutes.tsx
+++ b/src/routing/AppRoutes.tsx
@@ -24,6 +24,13 @@ const ExampleReport = lazy(
     ),
 );
 
+const DiscoveryOvaExampleReport = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "DiscoveryOvaExampleReport" */ "../ui/report/views/DiscoveryOvaExampleReport"
+    ),
+);
+
 const CreateFromOva = lazy(
   () =>
     import(
@@ -86,6 +93,10 @@ export const AppRoutes: React.FC = () => (
       {/* Independent routes — they have their own page layout */}
       <Route path="assessments/:id/report" element={<Report />} />
       <Route path="assessments/example-report" element={<ExampleReport />} />
+      <Route
+        path="assessments/discovery-ova-example-report"
+        element={<DiscoveryOvaExampleReport />}
+      />
       <Route path="assessments/create" element={<CreateFromOva />} />
       <Route path="assessments/:id" element={<AssessmentDetails />} />
     </Route>

--- a/src/routing/Routes.ts
+++ b/src/routing/Routes.ts
@@ -78,6 +78,9 @@ export const routes = {
   get exampleReport() {
     return `${getAppBasename()}/assessments/example-report`;
   },
+  get discoveryOvaExampleReport() {
+    return `${getAppBasename()}/assessments/discovery-ova-example-report`;
+  },
   get environments() {
     return `${getAppBasename()}/environments`;
   },

--- a/src/ui/home/views/HowDoesItWork.tsx
+++ b/src/ui/home/views/HowDoesItWork.tsx
@@ -120,7 +120,7 @@ export const HowDoesItWork: React.FC = () => {
                   onClick={() => navigate(routes.discoveryOvaExampleReport)}
                   className={linkButtonStyle}
                 >
-                  Discovery OVA example report
+                  See Discovery OVA example report
                 </Button>
               </Content>
             </FlexItem>

--- a/src/ui/home/views/HowDoesItWork.tsx
+++ b/src/ui/home/views/HowDoesItWork.tsx
@@ -111,7 +111,16 @@ export const HowDoesItWork: React.FC = () => {
                   onClick={() => navigate(routes.exampleReport)}
                   className={linkButtonStyle}
                 >
-                  See example report
+                  See RVtools example report
+                </Button>{" "}
+                or{" "}
+                <Button
+                  isInline
+                  variant="link"
+                  onClick={() => navigate(routes.discoveryOvaExampleReport)}
+                  className={linkButtonStyle}
+                >
+                  Discovery OVA example report
                 </Button>
               </Content>
             </FlexItem>

--- a/src/ui/report/view-models/useDiscoveryOvaExampleReportViewModel.ts
+++ b/src/ui/report/view-models/useDiscoveryOvaExampleReportViewModel.ts
@@ -1,0 +1,122 @@
+import type {
+  Infra,
+  Inventory,
+  InventoryData,
+  VMs,
+} from "@openshift-migration-advisor/planner-sdk";
+import React, { useMemo, useState } from "react";
+
+import {
+  buildClusterViewModel,
+  type ClusterViewModel,
+} from "../views/assessment-report/ClusterView";
+import type { ExampleClusterData } from "../views/example-data/clusterSizingFixture";
+import { EXAMPLE_SIZING_MAP } from "../views/example-data/clusterSizingFixture";
+import { getExampleInventory } from "../views/example-data/inventoryFixture";
+import type { MockVirtualMachine } from "../views/example-data/ovaVmFixture";
+import { EXAMPLE_OVA_VMS } from "../views/example-data/ovaVmFixture";
+
+export interface DiscoveryOvaExampleReportVM {
+  infra: Infra | undefined;
+  vms: VMs | undefined;
+  clusters: { [key: string]: InventoryData } | undefined;
+  clusterCount: number;
+  clusterSelectDisabled: boolean;
+
+  selectedClusterId: string;
+  clusterView: ClusterViewModel;
+
+  isClusterSelectOpen: boolean;
+  setIsClusterSelectOpen: (open: boolean) => void;
+
+  activeTab: string | number;
+  handleTabSelect: (
+    event: React.MouseEvent<HTMLElement, MouseEvent>,
+    tabIndex: string | number,
+  ) => void;
+
+  handleClusterSelect: (
+    event: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined,
+  ) => void;
+
+  isSizingWizardOpen: boolean;
+  setIsSizingWizardOpen: (open: boolean) => void;
+  exampleSizing: ExampleClusterData | null;
+
+  filteredVMs: MockVirtualMachine[];
+}
+
+export function useDiscoveryOvaExampleReportViewModel(): DiscoveryOvaExampleReportVM {
+  const inventory: Inventory = getExampleInventory();
+  const infra = inventory.vcenter?.infra;
+  const vms = inventory.vcenter?.vms;
+  const clusters = inventory.clusters;
+
+  const [userSelectedClusterId, setUserSelectedClusterId] = useState<
+    string | null
+  >(null);
+  const [isClusterSelectOpen, setIsClusterSelectOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState<string | number>(0);
+  const [isSizingWizardOpen, setIsSizingWizardOpen] = useState(false);
+
+  const selectedClusterId = useMemo(
+    () => userSelectedClusterId ?? "all",
+    [userSelectedClusterId],
+  );
+
+  const clusterView = useMemo(
+    () => buildClusterViewModel({ infra, vms, clusters, selectedClusterId }),
+    [infra, vms, clusters, selectedClusterId],
+  );
+
+  const clusterCount = clusters ? Object.keys(clusters).length : 0;
+  const clusterSelectDisabled = clusterCount <= 0;
+
+  const exampleSizing =
+    selectedClusterId !== "all"
+      ? (EXAMPLE_SIZING_MAP[selectedClusterId] ?? null)
+      : null;
+
+  const filteredVMs = useMemo(() => {
+    if (selectedClusterId === "all") return EXAMPLE_OVA_VMS;
+    return EXAMPLE_OVA_VMS.filter((vm) => vm.cluster === selectedClusterId);
+  }, [selectedClusterId]);
+
+  const handleClusterSelect = (
+    _event: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined,
+  ) => {
+    if (typeof value === "string") {
+      setUserSelectedClusterId(value);
+      setIsClusterSelectOpen(false);
+      setActiveTab(0);
+    }
+  };
+
+  const handleTabSelect = (
+    _event: React.MouseEvent<HTMLElement, MouseEvent>,
+    tabIndex: string | number,
+  ) => {
+    setActiveTab(tabIndex);
+  };
+
+  return {
+    infra,
+    vms,
+    clusters,
+    clusterCount,
+    clusterSelectDisabled,
+    selectedClusterId,
+    clusterView,
+    isClusterSelectOpen,
+    setIsClusterSelectOpen,
+    activeTab,
+    handleTabSelect,
+    handleClusterSelect,
+    isSizingWizardOpen,
+    setIsSizingWizardOpen,
+    exampleSizing,
+    filteredVMs,
+  };
+}

--- a/src/ui/report/view-models/useDiscoveryOvaExampleReportViewModel.ts
+++ b/src/ui/report/view-models/useDiscoveryOvaExampleReportViewModel.ts
@@ -87,11 +87,10 @@ export function useDiscoveryOvaExampleReportViewModel(): DiscoveryOvaExampleRepo
     _event: React.MouseEvent<Element, MouseEvent> | undefined,
     value: string | number | undefined,
   ) => {
-    if (typeof value === "string") {
-      setUserSelectedClusterId(value);
-      setIsClusterSelectOpen(false);
-      setActiveTab(0);
-    }
+    if (value == null) return;
+    setUserSelectedClusterId(String(value));
+    setIsClusterSelectOpen(false);
+    setActiveTab(0);
   };
 
   const handleTabSelect = (

--- a/src/ui/report/view-models/useExampleReportViewModel.ts
+++ b/src/ui/report/view-models/useExampleReportViewModel.ts
@@ -1,0 +1,95 @@
+import type {
+  Infra,
+  Inventory,
+  InventoryData,
+  VMs,
+} from "@openshift-migration-advisor/planner-sdk";
+import React, { useMemo, useState } from "react";
+
+import {
+  buildClusterViewModel,
+  type ClusterViewModel,
+} from "../views/assessment-report/ClusterView";
+import type { ExampleClusterData } from "../views/example-data/clusterSizingFixture";
+import { EXAMPLE_SIZING_MAP } from "../views/example-data/clusterSizingFixture";
+import { getExampleInventory } from "../views/example-data/inventoryFixture";
+
+export interface ExampleReportVM {
+  infra: Infra | undefined;
+  vms: VMs | undefined;
+  clusters: { [key: string]: InventoryData } | undefined;
+  clusterCount: number;
+  clusterSelectDisabled: boolean;
+
+  selectedClusterId: string;
+  clusterView: ClusterViewModel;
+
+  isClusterSelectOpen: boolean;
+  setIsClusterSelectOpen: (open: boolean) => void;
+
+  handleClusterSelect: (
+    event: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined,
+  ) => void;
+
+  isSizingWizardOpen: boolean;
+  setIsSizingWizardOpen: (open: boolean) => void;
+  exampleSizing: ExampleClusterData | null;
+}
+
+export function useExampleReportViewModel(): ExampleReportVM {
+  const inventory: Inventory = getExampleInventory();
+  const infra = inventory.vcenter?.infra;
+  const vms = inventory.vcenter?.vms;
+  const clusters = inventory.clusters;
+
+  const [userSelectedClusterId, setUserSelectedClusterId] = useState<
+    string | null
+  >(null);
+  const [isClusterSelectOpen, setIsClusterSelectOpen] = useState(false);
+  const [isSizingWizardOpen, setIsSizingWizardOpen] = useState(false);
+
+  const selectedClusterId = useMemo(
+    () => userSelectedClusterId ?? "all",
+    [userSelectedClusterId],
+  );
+
+  const clusterView = useMemo(
+    () => buildClusterViewModel({ infra, vms, clusters, selectedClusterId }),
+    [infra, vms, clusters, selectedClusterId],
+  );
+
+  const clusterCount = clusters ? Object.keys(clusters).length : 0;
+  const clusterSelectDisabled = clusterCount <= 0;
+
+  const exampleSizing =
+    selectedClusterId !== "all"
+      ? (EXAMPLE_SIZING_MAP[selectedClusterId] ?? null)
+      : null;
+
+  const handleClusterSelect = (
+    _event: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined,
+  ) => {
+    if (typeof value === "string") {
+      setUserSelectedClusterId(value);
+      setIsClusterSelectOpen(false);
+    }
+  };
+
+  return {
+    infra,
+    vms,
+    clusters,
+    clusterCount,
+    clusterSelectDisabled,
+    selectedClusterId,
+    clusterView,
+    isClusterSelectOpen,
+    setIsClusterSelectOpen,
+    handleClusterSelect,
+    isSizingWizardOpen,
+    setIsSizingWizardOpen,
+    exampleSizing,
+  };
+}

--- a/src/ui/report/view-models/useExampleReportViewModel.ts
+++ b/src/ui/report/view-models/useExampleReportViewModel.ts
@@ -20,6 +20,7 @@ export interface ExampleReportVM {
   clusters: { [key: string]: InventoryData } | undefined;
   clusterCount: number;
   clusterSelectDisabled: boolean;
+  detectedSummaryText: string;
 
   selectedClusterId: string;
   clusterView: ClusterViewModel;
@@ -67,14 +68,23 @@ export function useExampleReportViewModel(): ExampleReportVM {
       ? (EXAMPLE_SIZING_MAP[selectedClusterId] ?? null)
       : null;
 
+  const detectedSummaryText = useMemo(() => {
+    if (clusterCount <= 0) return "No clusters detected";
+    const clusterLabel = clusterCount === 1 ? "cluster" : "clusters";
+    const totalVMs = vms?.total;
+    if (typeof totalVMs === "number") {
+      return `Detected ${totalVMs} VMs in ${clusterCount} ${clusterLabel}`;
+    }
+    return `Detected ${clusterCount} ${clusterLabel}`;
+  }, [vms?.total, clusterCount]);
+
   const handleClusterSelect = (
     _event: React.MouseEvent<Element, MouseEvent> | undefined,
     value: string | number | undefined,
   ) => {
-    if (typeof value === "string") {
-      setUserSelectedClusterId(value);
-      setIsClusterSelectOpen(false);
-    }
+    if (value == null) return;
+    setUserSelectedClusterId(String(value));
+    setIsClusterSelectOpen(false);
   };
 
   return {
@@ -83,6 +93,7 @@ export function useExampleReportViewModel(): ExampleReportVM {
     clusters,
     clusterCount,
     clusterSelectDisabled,
+    detectedSummaryText,
     selectedClusterId,
     clusterView,
     isClusterSelectOpen,

--- a/src/ui/report/view-models/useExampleVMTable.ts
+++ b/src/ui/report/view-models/useExampleVMTable.ts
@@ -1,0 +1,49 @@
+import { useMemo, useState } from "react";
+
+import type { MockVirtualMachine } from "../views/example-data/ovaVmFixture";
+
+interface UseExampleVMTableResult {
+  page: number;
+  setPage: (page: number) => void;
+  pageSize: number;
+  setPageSize: (size: number) => void;
+  searchTerm: string;
+  setSearchTerm: (term: string) => void;
+  filteredVMs: MockVirtualMachine[];
+  paginatedVMs: MockVirtualMachine[];
+}
+
+export function useExampleVMTable(
+  vms: MockVirtualMachine[],
+  initialPageSize = 20,
+): UseExampleVMTableResult {
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(initialPageSize);
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const filteredVMs = useMemo(() => {
+    if (!searchTerm.trim()) return vms;
+    const lowerSearch = searchTerm.toLowerCase();
+    return vms.filter(
+      (vm) =>
+        vm.name.toLowerCase().includes(lowerSearch) ||
+        vm.id.toLowerCase().includes(lowerSearch),
+    );
+  }, [vms, searchTerm]);
+
+  const paginatedVMs = useMemo(() => {
+    const start = (page - 1) * pageSize;
+    return filteredVMs.slice(start, start + pageSize);
+  }, [filteredVMs, page, pageSize]);
+
+  return {
+    page,
+    setPage,
+    pageSize,
+    setPageSize,
+    searchTerm,
+    setSearchTerm,
+    filteredVMs,
+    paginatedVMs,
+  };
+}

--- a/src/ui/report/view-models/useExampleVMTable.ts
+++ b/src/ui/report/view-models/useExampleVMTable.ts
@@ -31,13 +31,16 @@ export function useExampleVMTable(
     );
   }, [vms, searchTerm]);
 
+  const lastPage = Math.max(1, Math.ceil(filteredVMs.length / pageSize));
+  const effectivePage = Math.min(page, lastPage);
+
   const paginatedVMs = useMemo(() => {
-    const start = (page - 1) * pageSize;
+    const start = (effectivePage - 1) * pageSize;
     return filteredVMs.slice(start, start + pageSize);
-  }, [filteredVMs, page, pageSize]);
+  }, [filteredVMs, effectivePage, pageSize]);
 
   return {
-    page,
+    page: effectivePage,
     setPage,
     pageSize,
     setPageSize,

--- a/src/ui/report/views/DiscoveryOvaExampleReport.tsx
+++ b/src/ui/report/views/DiscoveryOvaExampleReport.tsx
@@ -1,4 +1,3 @@
-import { type Infra, type VMs } from "@openshift-migration-advisor/planner-sdk";
 import {
   Button,
   Content,
@@ -20,87 +19,20 @@ import {
   Title,
 } from "@patternfly/react-core";
 import { CheckCircleIcon } from "@patternfly/react-icons";
-import React, { useMemo, useState } from "react";
+import React from "react";
 
 import { routes } from "../../../routing/Routes";
 import { AppPage } from "../../core/components/AppPage";
-import {
-  buildClusterViewModel,
-  type ClusterOption,
-} from "./assessment-report/ClusterView";
+import { useDiscoveryOvaExampleReportViewModel } from "../view-models/useDiscoveryOvaExampleReportViewModel";
+import type { ClusterOption } from "./assessment-report/ClusterView";
 import { Dashboard } from "./assessment-report/Dashboard";
 import { ClusterSizingWizard } from "./cluster-sizer/ClusterSizingWizard";
 import { ExampleStorageOffloadTab } from "./discovery-ova-example/ExampleStorageOffloadTab";
 import { ExampleVMTable } from "./discovery-ova-example/ExampleVMTable";
-import {
-  EXAMPLE_FORM_VALUES,
-  EXAMPLE_SIZING_MAP,
-} from "./example-data/clusterSizingFixture";
-import { getExampleInventory } from "./example-data/inventoryFixture";
-import { EXAMPLE_OVA_VMS } from "./example-data/ovaVmFixture";
+import { EXAMPLE_FORM_VALUES } from "./example-data/clusterSizingFixture";
 
 const DiscoveryOvaExampleReport: React.FC = () => {
-  const inventory = getExampleInventory();
-  const infra = inventory.vcenter?.infra as Infra;
-  const vms = inventory.vcenter?.vms as VMs;
-  const clusters = inventory.clusters;
-
-  const [userSelectedClusterId, setUserSelectedClusterId] = useState<
-    string | null
-  >(null);
-  const [isClusterSelectOpen, setIsClusterSelectOpen] = useState(false);
-  const [activeTab, setActiveTab] = useState<string | number>(0);
-
-  const selectedClusterId = useMemo(() => {
-    if (userSelectedClusterId !== null) {
-      return userSelectedClusterId;
-    }
-    return "all";
-  }, [userSelectedClusterId]);
-
-  const clusterView = useMemo(
-    () =>
-      buildClusterViewModel({
-        infra,
-        vms,
-        clusters,
-        selectedClusterId,
-      }),
-    [infra, vms, clusters, selectedClusterId],
-  );
-
-  const handleClusterSelect = (
-    _event: React.MouseEvent<Element, MouseEvent> | undefined,
-    value: string | number | undefined,
-  ) => {
-    if (typeof value === "string") {
-      setUserSelectedClusterId(value);
-      setIsClusterSelectOpen(false);
-      setActiveTab(0);
-    }
-  };
-
-  const handleTabSelect = (
-    _event: React.MouseEvent<HTMLElement, MouseEvent>,
-    tabIndex: string | number,
-  ) => {
-    setActiveTab(tabIndex);
-  };
-
-  const clusterCount = clusters ? Object.keys(clusters).length : 0;
-  const clusterSelectDisabled = clusterCount <= 0;
-
-  const [isSizingWizardOpen, setIsSizingWizardOpen] = useState(false);
-
-  const exampleSizing =
-    selectedClusterId !== "all"
-      ? (EXAMPLE_SIZING_MAP[selectedClusterId] ?? null)
-      : null;
-
-  const filteredVMs = useMemo(() => {
-    if (selectedClusterId === "all") return EXAMPLE_OVA_VMS;
-    return EXAMPLE_OVA_VMS.filter((vm) => vm.cluster === selectedClusterId);
-  }, [selectedClusterId]);
+  const vm = useDiscoveryOvaExampleReportViewModel();
 
   return (
     <AppPage
@@ -122,14 +54,14 @@ const DiscoveryOvaExampleReport: React.FC = () => {
       ]}
       title=""
       headerActions={
-        exampleSizing ? (
+        vm.exampleSizing ? (
           <Split hasGutter>
             <SplitItem>
               <Button
                 variant="primary"
-                onClick={() => setIsSizingWizardOpen(true)}
+                onClick={() => vm.setIsSizingWizardOpen(true)}
               >
-                View recommendation for {exampleSizing.clusterName}
+                View recommendation for {vm.exampleSizing.clusterName}
               </Button>
             </SplitItem>
           </Split>
@@ -137,7 +69,6 @@ const DiscoveryOvaExampleReport: React.FC = () => {
       }
       caption={
         <Stack hasGutter>
-          {/* Header matching agent-UI Header component */}
           <StackItem>
             <Flex direction={{ default: "column" }} gap={{ default: "gapSm" }}>
               <FlexItem>
@@ -186,43 +117,44 @@ const DiscoveryOvaExampleReport: React.FC = () => {
 
               <FlexItem>
                 <Content component="p">
-                  Detected <strong>{vms?.total ?? 0} VMs</strong> in{" "}
+                  Detected <strong>{vm.vms?.total ?? 0} VMs</strong> in{" "}
                   <strong>
-                    {clusterCount} {clusterCount === 1 ? "cluster" : "clusters"}
+                    {vm.clusterCount}{" "}
+                    {vm.clusterCount === 1 ? "cluster" : "clusters"}
                   </strong>
                 </Content>
               </FlexItem>
             </Flex>
           </StackItem>
 
-          {/* Cluster selector */}
           <StackItem>
             <Select
               isScrollable
-              isOpen={isClusterSelectOpen}
-              selected={clusterView.selectionId}
-              onSelect={handleClusterSelect}
+              isOpen={vm.isClusterSelectOpen}
+              selected={vm.clusterView.selectionId}
+              onSelect={vm.handleClusterSelect}
               onOpenChange={(isOpen: boolean) => {
-                if (!clusterSelectDisabled) setIsClusterSelectOpen(isOpen);
+                if (!vm.clusterSelectDisabled)
+                  vm.setIsClusterSelectOpen(isOpen);
               }}
               toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
                 <MenuToggle
                   ref={toggleRef}
-                  isExpanded={isClusterSelectOpen}
+                  isExpanded={vm.isClusterSelectOpen}
                   onClick={() => {
-                    if (!clusterSelectDisabled) {
-                      setIsClusterSelectOpen((prev) => !prev);
+                    if (!vm.clusterSelectDisabled) {
+                      vm.setIsClusterSelectOpen(!vm.isClusterSelectOpen);
                     }
                   }}
-                  isDisabled={clusterSelectDisabled}
+                  isDisabled={vm.clusterSelectDisabled}
                   style={{ minWidth: "422px" }}
                 >
-                  {clusterView.selectionLabel}
+                  {vm.clusterView.selectionLabel}
                 </MenuToggle>
               )}
             >
               <SelectList>
-                {clusterView.clusterOptions.map((option: ClusterOption) => (
+                {vm.clusterView.clusterOptions.map((option: ClusterOption) => (
                   <SelectOption key={option.id} value={option.id}>
                     {option.label}
                   </SelectOption>
@@ -233,25 +165,33 @@ const DiscoveryOvaExampleReport: React.FC = () => {
         </Stack>
       }
     >
-      {/* Tabbed layout matching agent-UI ReportContainer */}
-      <Tabs activeKey={activeTab} onSelect={handleTabSelect}>
+      <Tabs activeKey={vm.activeTab} onSelect={vm.handleTabSelect}>
         <Tab eventKey={0} title={<TabTitleText>Overview</TabTitleText>}>
           <div style={{ marginTop: "24px" }}>
-            <Dashboard
-              infra={clusterView.viewInfra as Infra}
-              cpuCores={clusterView.cpuCores!}
-              ramGB={clusterView.ramGB!}
-              vms={clusterView.viewVms as VMs}
-              clusters={clusterView.viewClusters}
-              isAggregateView={clusterView.isAggregateView}
-              clusterFound={clusterView.clusterFound}
-            />
+            {vm.clusterView.viewInfra &&
+            vm.clusterView.viewVms &&
+            vm.clusterView.cpuCores &&
+            vm.clusterView.ramGB ? (
+              <Dashboard
+                infra={vm.clusterView.viewInfra}
+                cpuCores={vm.clusterView.cpuCores}
+                ramGB={vm.clusterView.ramGB}
+                vms={vm.clusterView.viewVms}
+                clusters={vm.clusterView.viewClusters}
+                isAggregateView={vm.clusterView.isAggregateView}
+                clusterFound={vm.clusterView.clusterFound}
+              />
+            ) : (
+              <Content component="p">
+                No data is available for the selected cluster.
+              </Content>
+            )}
           </div>
         </Tab>
 
         <Tab eventKey={1} title={<TabTitleText>Virtual Machines</TabTitleText>}>
           <div style={{ marginTop: "24px" }}>
-            <ExampleVMTable vms={filteredVMs} />
+            <ExampleVMTable vms={vm.filteredVMs} />
           </div>
         </Tab>
 
@@ -263,20 +203,21 @@ const DiscoveryOvaExampleReport: React.FC = () => {
         </Tab>
       </Tabs>
 
-      {exampleSizing && (
+      {vm.exampleSizing && (
         <ClusterSizingWizard
-          key={selectedClusterId}
-          isOpen={isSizingWizardOpen}
-          onClose={() => setIsSizingWizardOpen(false)}
-          clusterName={exampleSizing.clusterName}
-          clusterId={selectedClusterId}
+          key={vm.selectedClusterId}
+          isOpen={vm.isSizingWizardOpen}
+          onClose={() => vm.setIsSizingWizardOpen(false)}
+          clusterName={vm.exampleSizing.clusterName}
+          clusterId={vm.selectedClusterId}
           assessmentId="example"
           options={{
-            initialSizerOutput: exampleSizing.result,
+            initialSizerOutput: vm.exampleSizing.result,
             initialFormValues: EXAMPLE_FORM_VALUES,
-            initialMigrationEstimation: exampleSizing.migrationEstimation,
-            initialComplexityEstimation: exampleSizing.complexityEstimation,
-            initialEstimationByComplexity: exampleSizing.estimationByComplexity,
+            initialMigrationEstimation: vm.exampleSizing.migrationEstimation,
+            initialComplexityEstimation: vm.exampleSizing.complexityEstimation,
+            initialEstimationByComplexity:
+              vm.exampleSizing.estimationByComplexity,
           }}
           isReadOnly
         />

--- a/src/ui/report/views/DiscoveryOvaExampleReport.tsx
+++ b/src/ui/report/views/DiscoveryOvaExampleReport.tsx
@@ -1,3 +1,4 @@
+import { css } from "@emotion/css";
 import {
   Button,
   Content,
@@ -20,6 +21,10 @@ import {
 } from "@patternfly/react-core";
 import { CheckCircleIcon } from "@patternfly/react-icons";
 import React from "react";
+
+const clusterToggleStyle = css`
+  min-width: 422px;
+`;
 
 import { routes } from "../../../routing/Routes";
 import { AppPage } from "../../core/components/AppPage";
@@ -147,7 +152,7 @@ const DiscoveryOvaExampleReport: React.FC = () => {
                     }
                   }}
                   isDisabled={vm.clusterSelectDisabled}
-                  style={{ minWidth: "422px" }}
+                  className={clusterToggleStyle}
                 >
                   {vm.clusterView.selectionLabel}
                 </MenuToggle>

--- a/src/ui/report/views/DiscoveryOvaExampleReport.tsx
+++ b/src/ui/report/views/DiscoveryOvaExampleReport.tsx
@@ -1,6 +1,9 @@
 import { type Infra, type VMs } from "@openshift-migration-advisor/planner-sdk";
 import {
   Button,
+  Content,
+  Flex,
+  FlexItem,
   Icon,
   MenuToggle,
   type MenuToggleElement,
@@ -11,9 +14,12 @@ import {
   SplitItem,
   Stack,
   StackItem,
+  Tab,
+  Tabs,
+  TabTitleText,
+  Title,
 } from "@patternfly/react-core";
 import { CheckCircleIcon } from "@patternfly/react-icons";
-import { t_global_color_status_success_default as globalSuccessColor100 } from "@patternfly/react-tokens/dist/js/t_global_color_status_success_default";
 import React, { useMemo, useState } from "react";
 
 import { routes } from "../../../routing/Routes";
@@ -24,25 +30,27 @@ import {
 } from "./assessment-report/ClusterView";
 import { Dashboard } from "./assessment-report/Dashboard";
 import { ClusterSizingWizard } from "./cluster-sizer/ClusterSizingWizard";
+import { ExampleStorageOffloadTab } from "./discovery-ova-example/ExampleStorageOffloadTab";
+import { ExampleVMTable } from "./discovery-ova-example/ExampleVMTable";
 import {
   EXAMPLE_FORM_VALUES,
   EXAMPLE_SIZING_MAP,
 } from "./example-data/clusterSizingFixture";
 import { getExampleInventory } from "./example-data/inventoryFixture";
+import { EXAMPLE_OVA_VMS } from "./example-data/ovaVmFixture";
 
-const ExampleReport: React.FC = () => {
+const DiscoveryOvaExampleReport: React.FC = () => {
   const inventory = getExampleInventory();
   const infra = inventory.vcenter?.infra as Infra;
   const vms = inventory.vcenter?.vms as VMs;
   const clusters = inventory.clusters;
 
-  // State for cluster selection
   const [userSelectedClusterId, setUserSelectedClusterId] = useState<
     string | null
   >(null);
   const [isClusterSelectOpen, setIsClusterSelectOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState<string | number>(0);
 
-  // Compute effective selection - default to "all"
   const selectedClusterId = useMemo(() => {
     if (userSelectedClusterId !== null) {
       return userSelectedClusterId;
@@ -50,7 +58,6 @@ const ExampleReport: React.FC = () => {
     return "all";
   }, [userSelectedClusterId]);
 
-  // Build cluster view model
   const clusterView = useMemo(
     () =>
       buildClusterViewModel({
@@ -69,20 +76,31 @@ const ExampleReport: React.FC = () => {
     if (typeof value === "string") {
       setUserSelectedClusterId(value);
       setIsClusterSelectOpen(false);
+      setActiveTab(0);
     }
+  };
+
+  const handleTabSelect = (
+    _event: React.MouseEvent<HTMLElement, MouseEvent>,
+    tabIndex: string | number,
+  ) => {
+    setActiveTab(tabIndex);
   };
 
   const clusterCount = clusters ? Object.keys(clusters).length : 0;
   const clusterSelectDisabled = clusterCount <= 0;
 
-  // Sizing wizard state
   const [isSizingWizardOpen, setIsSizingWizardOpen] = useState(false);
 
-  // Example sizing data for the currently selected cluster (if any)
   const exampleSizing =
     selectedClusterId !== "all"
       ? (EXAMPLE_SIZING_MAP[selectedClusterId] ?? null)
       : null;
+
+  const filteredVMs = useMemo(() => {
+    if (selectedClusterId === "all") return EXAMPLE_OVA_VMS;
+    return EXAMPLE_OVA_VMS.filter((vm) => vm.cluster === selectedClusterId);
+  }, [selectedClusterId]);
 
   return (
     <AppPage
@@ -98,11 +116,11 @@ const ExampleReport: React.FC = () => {
         },
         {
           key: 3,
-          children: "RVtools example report",
+          children: "Discovery OVA example report",
           isActive: true,
         },
       ]}
-      title="Rvtools example report"
+      title=""
       headerActions={
         exampleSizing ? (
           <Split hasGutter>
@@ -119,37 +137,65 @@ const ExampleReport: React.FC = () => {
       }
       caption={
         <Stack hasGutter>
+          {/* Header matching agent-UI Header component */}
           <StackItem>
-            Discovery VM status :{" "}
-            <Icon size="md" isInline>
-              <CheckCircleIcon color={globalSuccessColor100.var} />
-            </Icon>{" "}
-            Ready
-            <br />
-            This is an example report showcasing the migration advisor dashboard
-            for RVtools file upload.
-          </StackItem>
-          <StackItem>
-            {clusterCount > 0 ? (
-              typeof vms?.total === "number" ? (
-                <>
-                  Detected <strong>{vms?.total} VMs</strong> in{" "}
+            <Flex direction={{ default: "column" }} gap={{ default: "gapSm" }}>
+              <FlexItem>
+                <Title headingLevel="h1" size="2xl">
+                  Migration Advisor Report
+                </Title>
+              </FlexItem>
+
+              <FlexItem>
+                <Flex
+                  gap={{ default: "gapSm" }}
+                  alignItems={{ default: "alignItemsCenter" }}
+                >
+                  <FlexItem>
+                    <Content component="small">
+                      <strong>Discovery VM status:</strong>
+                    </Content>
+                  </FlexItem>
+                  <FlexItem>
+                    <Flex
+                      gap={{ default: "gapXs" }}
+                      alignItems={{ default: "alignItemsCenter" }}
+                    >
+                      <Icon status="success">
+                        <CheckCircleIcon />
+                      </Icon>
+                      <Content component="small">Connected</Content>
+                    </Flex>
+                  </FlexItem>
+                </Flex>
+              </FlexItem>
+
+              <FlexItem>
+                <Content component="p">
+                  Presenting the information we were able to fetch from the
+                  discovery process
+                </Content>
+              </FlexItem>
+
+              <FlexItem>
+                <Content component="small">
+                  This is an example report showcasing the migration advisor
+                  dashboard for discovery OVA deployment.
+                </Content>
+              </FlexItem>
+
+              <FlexItem>
+                <Content component="p">
+                  Detected <strong>{vms?.total ?? 0} VMs</strong> in{" "}
                   <strong>
                     {clusterCount} {clusterCount === 1 ? "cluster" : "clusters"}
                   </strong>
-                </>
-              ) : (
-                <>
-                  Detected{" "}
-                  <strong>
-                    {clusterCount} {clusterCount === 1 ? "cluster" : "clusters"}
-                  </strong>
-                </>
-              )
-            ) : (
-              "No clusters detected"
-            )}
+                </Content>
+              </FlexItem>
+            </Flex>
           </StackItem>
+
+          {/* Cluster selector */}
           <StackItem>
             <Select
               isScrollable
@@ -187,15 +233,35 @@ const ExampleReport: React.FC = () => {
         </Stack>
       }
     >
-      <Dashboard
-        infra={clusterView.viewInfra as Infra}
-        cpuCores={clusterView.cpuCores!}
-        ramGB={clusterView.ramGB!}
-        vms={clusterView.viewVms as VMs}
-        clusters={clusterView.viewClusters}
-        isAggregateView={clusterView.isAggregateView}
-        clusterFound={clusterView.clusterFound}
-      />
+      {/* Tabbed layout matching agent-UI ReportContainer */}
+      <Tabs activeKey={activeTab} onSelect={handleTabSelect}>
+        <Tab eventKey={0} title={<TabTitleText>Overview</TabTitleText>}>
+          <div style={{ marginTop: "24px" }}>
+            <Dashboard
+              infra={clusterView.viewInfra as Infra}
+              cpuCores={clusterView.cpuCores!}
+              ramGB={clusterView.ramGB!}
+              vms={clusterView.viewVms as VMs}
+              clusters={clusterView.viewClusters}
+              isAggregateView={clusterView.isAggregateView}
+              clusterFound={clusterView.clusterFound}
+            />
+          </div>
+        </Tab>
+
+        <Tab eventKey={1} title={<TabTitleText>Virtual Machines</TabTitleText>}>
+          <div style={{ marginTop: "24px" }}>
+            <ExampleVMTable vms={filteredVMs} />
+          </div>
+        </Tab>
+
+        <Tab
+          eventKey={2}
+          title={<TabTitleText>Storage offload estimator</TabTitleText>}
+        >
+          <ExampleStorageOffloadTab />
+        </Tab>
+      </Tabs>
 
       {exampleSizing && (
         <ClusterSizingWizard
@@ -219,6 +285,6 @@ const ExampleReport: React.FC = () => {
   );
 };
 
-ExampleReport.displayName = "ExampleReport";
+DiscoveryOvaExampleReport.displayName = "DiscoveryOvaExampleReport";
 
-export default ExampleReport;
+export default DiscoveryOvaExampleReport;

--- a/src/ui/report/views/ExampleReport.tsx
+++ b/src/ui/report/views/ExampleReport.tsx
@@ -1,3 +1,4 @@
+import { css } from "@emotion/css";
 import {
   Button,
   Content,
@@ -23,6 +24,10 @@ import type { ClusterOption } from "./assessment-report/ClusterView";
 import { Dashboard } from "./assessment-report/Dashboard";
 import { ClusterSizingWizard } from "./cluster-sizer/ClusterSizingWizard";
 import { EXAMPLE_FORM_VALUES } from "./example-data/clusterSizingFixture";
+
+const clusterToggleStyle = css`
+  min-width: 422px;
+`;
 
 const ExampleReport: React.FC = () => {
   const vm = useExampleReportViewModel();
@@ -72,29 +77,7 @@ const ExampleReport: React.FC = () => {
             This is an example report showcasing the migration advisor dashboard
             for RVTools file upload.
           </StackItem>
-          <StackItem>
-            {vm.clusterCount > 0 ? (
-              typeof vm.vms?.total === "number" ? (
-                <>
-                  Detected <strong>{vm.vms.total} VMs</strong> in{" "}
-                  <strong>
-                    {vm.clusterCount}{" "}
-                    {vm.clusterCount === 1 ? "cluster" : "clusters"}
-                  </strong>
-                </>
-              ) : (
-                <>
-                  Detected{" "}
-                  <strong>
-                    {vm.clusterCount}{" "}
-                    {vm.clusterCount === 1 ? "cluster" : "clusters"}
-                  </strong>
-                </>
-              )
-            ) : (
-              "No clusters detected"
-            )}
-          </StackItem>
+          <StackItem>{vm.detectedSummaryText}</StackItem>
           <StackItem>
             <Select
               isScrollable
@@ -115,7 +98,7 @@ const ExampleReport: React.FC = () => {
                     }
                   }}
                   isDisabled={vm.clusterSelectDisabled}
-                  style={{ minWidth: "422px" }}
+                  className={clusterToggleStyle}
                 >
                   {vm.clusterView.selectionLabel}
                 </MenuToggle>

--- a/src/ui/report/views/ExampleReport.tsx
+++ b/src/ui/report/views/ExampleReport.tsx
@@ -1,6 +1,6 @@
-import { type Infra, type VMs } from "@openshift-migration-advisor/planner-sdk";
 import {
   Button,
+  Content,
   Icon,
   MenuToggle,
   type MenuToggleElement,
@@ -14,75 +14,18 @@ import {
 } from "@patternfly/react-core";
 import { CheckCircleIcon } from "@patternfly/react-icons";
 import { t_global_color_status_success_default as globalSuccessColor100 } from "@patternfly/react-tokens/dist/js/t_global_color_status_success_default";
-import React, { useMemo, useState } from "react";
+import React from "react";
 
 import { routes } from "../../../routing/Routes";
 import { AppPage } from "../../core/components/AppPage";
-import {
-  buildClusterViewModel,
-  type ClusterOption,
-} from "./assessment-report/ClusterView";
+import { useExampleReportViewModel } from "../view-models/useExampleReportViewModel";
+import type { ClusterOption } from "./assessment-report/ClusterView";
 import { Dashboard } from "./assessment-report/Dashboard";
 import { ClusterSizingWizard } from "./cluster-sizer/ClusterSizingWizard";
-import {
-  EXAMPLE_FORM_VALUES,
-  EXAMPLE_SIZING_MAP,
-} from "./example-data/clusterSizingFixture";
-import { getExampleInventory } from "./example-data/inventoryFixture";
+import { EXAMPLE_FORM_VALUES } from "./example-data/clusterSizingFixture";
 
 const ExampleReport: React.FC = () => {
-  const inventory = getExampleInventory();
-  const infra = inventory.vcenter?.infra as Infra;
-  const vms = inventory.vcenter?.vms as VMs;
-  const clusters = inventory.clusters;
-
-  // State for cluster selection
-  const [userSelectedClusterId, setUserSelectedClusterId] = useState<
-    string | null
-  >(null);
-  const [isClusterSelectOpen, setIsClusterSelectOpen] = useState(false);
-
-  // Compute effective selection - default to "all"
-  const selectedClusterId = useMemo(() => {
-    if (userSelectedClusterId !== null) {
-      return userSelectedClusterId;
-    }
-    return "all";
-  }, [userSelectedClusterId]);
-
-  // Build cluster view model
-  const clusterView = useMemo(
-    () =>
-      buildClusterViewModel({
-        infra,
-        vms,
-        clusters,
-        selectedClusterId,
-      }),
-    [infra, vms, clusters, selectedClusterId],
-  );
-
-  const handleClusterSelect = (
-    _event: React.MouseEvent<Element, MouseEvent> | undefined,
-    value: string | number | undefined,
-  ) => {
-    if (typeof value === "string") {
-      setUserSelectedClusterId(value);
-      setIsClusterSelectOpen(false);
-    }
-  };
-
-  const clusterCount = clusters ? Object.keys(clusters).length : 0;
-  const clusterSelectDisabled = clusterCount <= 0;
-
-  // Sizing wizard state
-  const [isSizingWizardOpen, setIsSizingWizardOpen] = useState(false);
-
-  // Example sizing data for the currently selected cluster (if any)
-  const exampleSizing =
-    selectedClusterId !== "all"
-      ? (EXAMPLE_SIZING_MAP[selectedClusterId] ?? null)
-      : null;
+  const vm = useExampleReportViewModel();
 
   return (
     <AppPage
@@ -98,20 +41,20 @@ const ExampleReport: React.FC = () => {
         },
         {
           key: 3,
-          children: "RVtools example report",
+          children: "RVTools example report",
           isActive: true,
         },
       ]}
-      title="Rvtools example report"
+      title="RVTools example report"
       headerActions={
-        exampleSizing ? (
+        vm.exampleSizing ? (
           <Split hasGutter>
             <SplitItem>
               <Button
                 variant="primary"
-                onClick={() => setIsSizingWizardOpen(true)}
+                onClick={() => vm.setIsSizingWizardOpen(true)}
               >
-                View recommendation for {exampleSizing.clusterName}
+                View recommendation for {vm.exampleSizing.clusterName}
               </Button>
             </SplitItem>
           </Split>
@@ -127,22 +70,24 @@ const ExampleReport: React.FC = () => {
             Ready
             <br />
             This is an example report showcasing the migration advisor dashboard
-            for RVtools file upload.
+            for RVTools file upload.
           </StackItem>
           <StackItem>
-            {clusterCount > 0 ? (
-              typeof vms?.total === "number" ? (
+            {vm.clusterCount > 0 ? (
+              typeof vm.vms?.total === "number" ? (
                 <>
-                  Detected <strong>{vms?.total} VMs</strong> in{" "}
+                  Detected <strong>{vm.vms.total} VMs</strong> in{" "}
                   <strong>
-                    {clusterCount} {clusterCount === 1 ? "cluster" : "clusters"}
+                    {vm.clusterCount}{" "}
+                    {vm.clusterCount === 1 ? "cluster" : "clusters"}
                   </strong>
                 </>
               ) : (
                 <>
                   Detected{" "}
                   <strong>
-                    {clusterCount} {clusterCount === 1 ? "cluster" : "clusters"}
+                    {vm.clusterCount}{" "}
+                    {vm.clusterCount === 1 ? "cluster" : "clusters"}
                   </strong>
                 </>
               )
@@ -153,30 +98,31 @@ const ExampleReport: React.FC = () => {
           <StackItem>
             <Select
               isScrollable
-              isOpen={isClusterSelectOpen}
-              selected={clusterView.selectionId}
-              onSelect={handleClusterSelect}
+              isOpen={vm.isClusterSelectOpen}
+              selected={vm.clusterView.selectionId}
+              onSelect={vm.handleClusterSelect}
               onOpenChange={(isOpen: boolean) => {
-                if (!clusterSelectDisabled) setIsClusterSelectOpen(isOpen);
+                if (!vm.clusterSelectDisabled)
+                  vm.setIsClusterSelectOpen(isOpen);
               }}
               toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
                 <MenuToggle
                   ref={toggleRef}
-                  isExpanded={isClusterSelectOpen}
+                  isExpanded={vm.isClusterSelectOpen}
                   onClick={() => {
-                    if (!clusterSelectDisabled) {
-                      setIsClusterSelectOpen((prev) => !prev);
+                    if (!vm.clusterSelectDisabled) {
+                      vm.setIsClusterSelectOpen(!vm.isClusterSelectOpen);
                     }
                   }}
-                  isDisabled={clusterSelectDisabled}
+                  isDisabled={vm.clusterSelectDisabled}
                   style={{ minWidth: "422px" }}
                 >
-                  {clusterView.selectionLabel}
+                  {vm.clusterView.selectionLabel}
                 </MenuToggle>
               )}
             >
               <SelectList>
-                {clusterView.clusterOptions.map((option: ClusterOption) => (
+                {vm.clusterView.clusterOptions.map((option: ClusterOption) => (
                   <SelectOption key={option.id} value={option.id}>
                     {option.label}
                   </SelectOption>
@@ -187,30 +133,40 @@ const ExampleReport: React.FC = () => {
         </Stack>
       }
     >
-      <Dashboard
-        infra={clusterView.viewInfra as Infra}
-        cpuCores={clusterView.cpuCores!}
-        ramGB={clusterView.ramGB!}
-        vms={clusterView.viewVms as VMs}
-        clusters={clusterView.viewClusters}
-        isAggregateView={clusterView.isAggregateView}
-        clusterFound={clusterView.clusterFound}
-      />
+      {vm.clusterView.viewInfra &&
+      vm.clusterView.viewVms &&
+      vm.clusterView.cpuCores &&
+      vm.clusterView.ramGB ? (
+        <Dashboard
+          infra={vm.clusterView.viewInfra}
+          cpuCores={vm.clusterView.cpuCores}
+          ramGB={vm.clusterView.ramGB}
+          vms={vm.clusterView.viewVms}
+          clusters={vm.clusterView.viewClusters}
+          isAggregateView={vm.clusterView.isAggregateView}
+          clusterFound={vm.clusterView.clusterFound}
+        />
+      ) : (
+        <Content component="p">
+          No data is available for the selected cluster.
+        </Content>
+      )}
 
-      {exampleSizing && (
+      {vm.exampleSizing && (
         <ClusterSizingWizard
-          key={selectedClusterId}
-          isOpen={isSizingWizardOpen}
-          onClose={() => setIsSizingWizardOpen(false)}
-          clusterName={exampleSizing.clusterName}
-          clusterId={selectedClusterId}
+          key={vm.selectedClusterId}
+          isOpen={vm.isSizingWizardOpen}
+          onClose={() => vm.setIsSizingWizardOpen(false)}
+          clusterName={vm.exampleSizing.clusterName}
+          clusterId={vm.selectedClusterId}
           assessmentId="example"
           options={{
-            initialSizerOutput: exampleSizing.result,
+            initialSizerOutput: vm.exampleSizing.result,
             initialFormValues: EXAMPLE_FORM_VALUES,
-            initialMigrationEstimation: exampleSizing.migrationEstimation,
-            initialComplexityEstimation: exampleSizing.complexityEstimation,
-            initialEstimationByComplexity: exampleSizing.estimationByComplexity,
+            initialMigrationEstimation: vm.exampleSizing.migrationEstimation,
+            initialComplexityEstimation: vm.exampleSizing.complexityEstimation,
+            initialEstimationByComplexity:
+              vm.exampleSizing.estimationByComplexity,
           }}
           isReadOnly
         />

--- a/src/ui/report/views/discovery-ova-example/ExampleStorageOffloadTab.tsx
+++ b/src/ui/report/views/discovery-ova-example/ExampleStorageOffloadTab.tsx
@@ -1,0 +1,175 @@
+import { css } from "@emotion/css";
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  Content,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Flex,
+  FlexItem,
+  Gallery,
+  GalleryItem,
+  Icon,
+  Label,
+  Popover,
+  Progress,
+  ProgressMeasureLocation,
+  Stack,
+  StackItem,
+} from "@patternfly/react-core";
+import {
+  CheckCircleIcon,
+  ExternalLinkAltIcon,
+  InfoCircleIcon,
+} from "@patternfly/react-icons";
+import React from "react";
+
+const sectionSpacing = css`
+  margin-top: var(--pf-t--global--spacer--lg);
+`;
+
+const TECH_PREVIEW_LINK =
+  "https://access.redhat.com/support/offerings/techpreview";
+
+const ExampleStorageOffloadTab: React.FC = () => (
+  <div className={sectionSpacing}>
+    <Stack hasGutter>
+      <StackItem>
+        <Flex
+          gap={{ default: "gapMd" }}
+          alignItems={{ default: "alignItemsCenter" }}
+        >
+          <FlexItem>
+            <Content component="h3">Storage Offload Estimator</Content>
+          </FlexItem>
+          <FlexItem>
+            <Popover
+              bodyContent={
+                <>
+                  Technology preview features provide early access to upcoming
+                  product innovations, enabling you to test functionality and
+                  provide feedback during the development process.{" "}
+                  <a
+                    href={TECH_PREVIEW_LINK}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Learn more <ExternalLinkAltIcon />
+                  </a>
+                </>
+              }
+              position="top"
+              withFocusTrap={false}
+            >
+              <Label
+                style={{ cursor: "pointer" }}
+                color="orange"
+                icon={<InfoCircleIcon />}
+              >
+                TP
+              </Label>
+            </Popover>
+          </FlexItem>
+        </Flex>
+      </StackItem>
+
+      <StackItem>
+        <Content component="p">
+          Estimate how long a storage-offload migration would take for your
+          environment by analyzing datastore pairs between source and target
+          arrays.
+        </Content>
+      </StackItem>
+
+      <StackItem>
+        <Gallery hasGutter minWidths={{ default: "300px", md: "45%" }}>
+          <GalleryItem>
+            <Card>
+              <CardTitle>Estimated datastore pairs</CardTitle>
+              <CardBody>
+                <DescriptionList isHorizontal>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Source array</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      NetApp FAS8200 (eco-iscsi-ds3)
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Target array</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      NetApp ONTAP Select (ocp-nfs-stor01)
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Total data</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      42.5 TB
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Transfer rate</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      0.5 - 2.0 GB/s
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                </DescriptionList>
+              </CardBody>
+            </Card>
+          </GalleryItem>
+
+          <GalleryItem>
+            <Card>
+              <CardTitle>Estimation results</CardTitle>
+              <CardBody>
+                <Stack hasGutter>
+                  <StackItem>
+                    <Content component="small">
+                      <Icon status="success" isInline>
+                        <CheckCircleIcon />
+                      </Icon>{" "}
+                      Completed — example estimation
+                    </Content>
+                  </StackItem>
+                  <StackItem>
+                    <DescriptionList isHorizontal>
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>
+                          Min estimated time
+                        </DescriptionListTerm>
+                        <DescriptionListDescription>
+                          <strong>5 hours 54 min</strong>
+                        </DescriptionListDescription>
+                      </DescriptionListGroup>
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>
+                          Max estimated time
+                        </DescriptionListTerm>
+                        <DescriptionListDescription>
+                          <strong>23 hours 36 min</strong>
+                        </DescriptionListDescription>
+                      </DescriptionListGroup>
+                    </DescriptionList>
+                  </StackItem>
+                  <StackItem>
+                    <Progress
+                      value={100}
+                      title="Estimation complete"
+                      measureLocation={ProgressMeasureLocation.outside}
+                    />
+                  </StackItem>
+                </Stack>
+              </CardBody>
+            </Card>
+          </GalleryItem>
+        </Gallery>
+      </StackItem>
+    </Stack>
+  </div>
+);
+
+ExampleStorageOffloadTab.displayName = "ExampleStorageOffloadTab";
+
+export { ExampleStorageOffloadTab };

--- a/src/ui/report/views/discovery-ova-example/ExampleStorageOffloadTab.tsx
+++ b/src/ui/report/views/discovery-ova-example/ExampleStorageOffloadTab.tsx
@@ -62,7 +62,6 @@ const ExampleStorageOffloadTab: React.FC = () => (
                 </>
               }
               position="top"
-              withFocusTrap={false}
             >
               <Label
                 style={{ cursor: "pointer" }}

--- a/src/ui/report/views/discovery-ova-example/ExampleVMTable.tsx
+++ b/src/ui/report/views/discovery-ova-example/ExampleVMTable.tsx
@@ -1,0 +1,193 @@
+import { css } from "@emotion/css";
+import {
+  Label,
+  Pagination,
+  SearchInput,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from "@patternfly/react-core";
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+} from "@patternfly/react-icons";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+import React, { useMemo, useState } from "react";
+
+import type { MockVirtualMachine } from "../example-data/ovaVmFixture";
+
+const MB_IN_GB = 1024;
+const MB_IN_TB = 1024 * 1024;
+
+const formatDiskSize = (sizeInMB: number): string => {
+  if (sizeInMB >= MB_IN_TB) {
+    const sizeInTB = sizeInMB / MB_IN_TB;
+    return `${sizeInTB.toFixed(sizeInTB % 1 === 0 ? 0 : 2)} TB`;
+  }
+  const sizeInGB = sizeInMB / MB_IN_GB;
+  return `${sizeInGB.toFixed(sizeInGB % 1 === 0 ? 0 : 2)} GB`;
+};
+
+const formatMemorySize = (sizeInMB: number): string => {
+  const sizeInGB = sizeInMB / MB_IN_GB;
+  return `${sizeInGB.toFixed(sizeInGB % 1 === 0 ? 0 : 2)} GB`;
+};
+
+const statusLabels: Record<string, string> = {
+  poweredOn: "Powered on",
+  poweredOff: "Powered off",
+  suspended: "Suspended",
+};
+
+const tableStyle = css`
+  th button {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    text-align: left;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+`;
+
+interface ExampleVMTableProps {
+  vms: MockVirtualMachine[];
+}
+
+export const ExampleVMTable: React.FC<ExampleVMTableProps> = ({ vms }) => {
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const filteredVMs = useMemo(() => {
+    if (!searchTerm.trim()) return vms;
+    const lowerSearch = searchTerm.toLowerCase();
+    return vms.filter(
+      (vm) =>
+        vm.name.toLowerCase().includes(lowerSearch) ||
+        vm.id.toLowerCase().includes(lowerSearch),
+    );
+  }, [vms, searchTerm]);
+
+  const paginatedVMs = useMemo(() => {
+    const start = (page - 1) * pageSize;
+    return filteredVMs.slice(start, start + pageSize);
+  }, [filteredVMs, page, pageSize]);
+
+  return (
+    <>
+      <Toolbar>
+        <ToolbarContent>
+          <ToolbarItem>
+            <SearchInput
+              placeholder="Search by name or ID"
+              value={searchTerm}
+              onChange={(_e, value) => {
+                setSearchTerm(value);
+                setPage(1);
+              }}
+              onClear={() => {
+                setSearchTerm("");
+                setPage(1);
+              }}
+            />
+          </ToolbarItem>
+          <ToolbarItem variant="pagination" align={{ default: "alignEnd" }}>
+            <Pagination
+              itemCount={filteredVMs.length}
+              perPage={pageSize}
+              page={page}
+              onSetPage={(_e, newPage) => setPage(newPage)}
+              onPerPageSelect={(_e, newSize) => {
+                setPageSize(newSize);
+                setPage(1);
+              }}
+              isCompact
+            />
+          </ToolbarItem>
+        </ToolbarContent>
+      </Toolbar>
+
+      <Table aria-label="Virtual Machines" className={tableStyle}>
+        <Thead>
+          <Tr>
+            <Th>Name</Th>
+            <Th>Status</Th>
+            <Th>Migration Readiness</Th>
+            <Th>Cluster</Th>
+            <Th>Disk size</Th>
+            <Th>Memory size</Th>
+            <Th>Issues</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {paginatedVMs.map((vm) => (
+            <Tr key={vm.id}>
+              <Td dataLabel="Name">{vm.name}</Td>
+              <Td dataLabel="Status">
+                <Label
+                  color={vm.vCenterState === "poweredOn" ? "green" : "grey"}
+                  isCompact
+                >
+                  {statusLabels[vm.vCenterState] ?? vm.vCenterState}
+                </Label>
+              </Td>
+              <Td dataLabel="Migration Readiness">
+                {vm.migratable ? (
+                  <Label color="green" icon={<CheckCircleIcon />} isCompact>
+                    Ready
+                  </Label>
+                ) : vm.issueCount > 0 ? (
+                  <Label
+                    color="orange"
+                    icon={<ExclamationTriangleIcon />}
+                    isCompact
+                  >
+                    With warnings
+                  </Label>
+                ) : (
+                  <Label color="red" icon={<ExclamationCircleIcon />} isCompact>
+                    Not ready
+                  </Label>
+                )}
+              </Td>
+              <Td dataLabel="Cluster">{vm.cluster}</Td>
+              <Td dataLabel="Disk size">{formatDiskSize(vm.diskSize)}</Td>
+              <Td dataLabel="Memory size">{formatMemorySize(vm.memory)}</Td>
+              <Td dataLabel="Issues">
+                {vm.issueCount > 0 ? (
+                  <Label color="orange" isCompact>
+                    {vm.issueCount}
+                  </Label>
+                ) : (
+                  "0"
+                )}
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+
+      <Toolbar>
+        <ToolbarContent>
+          <ToolbarItem variant="pagination" align={{ default: "alignEnd" }}>
+            <Pagination
+              itemCount={filteredVMs.length}
+              perPage={pageSize}
+              page={page}
+              onSetPage={(_e, newPage) => setPage(newPage)}
+              onPerPageSelect={(_e, newSize) => {
+                setPageSize(newSize);
+                setPage(1);
+              }}
+              isCompact
+            />
+          </ToolbarItem>
+        </ToolbarContent>
+      </Toolbar>
+    </>
+  );
+};
+
+ExampleVMTable.displayName = "ExampleVMTable";

--- a/src/ui/report/views/discovery-ova-example/ExampleVMTable.tsx
+++ b/src/ui/report/views/discovery-ova-example/ExampleVMTable.tsx
@@ -13,8 +13,9 @@ import {
   ExclamationTriangleIcon,
 } from "@patternfly/react-icons";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
-import React, { useMemo, useState } from "react";
+import React from "react";
 
+import { useExampleVMTable } from "../../view-models/useExampleVMTable";
 import type { MockVirtualMachine } from "../example-data/ovaVmFixture";
 
 const MB_IN_GB = 1024;
@@ -51,29 +52,45 @@ const tableStyle = css`
   }
 `;
 
+const MigrationReadinessCell: React.FC<{
+  vm: MockVirtualMachine;
+}> = ({ vm }) => {
+  if (vm.issueCount > 0) {
+    return (
+      <Label color="orange" icon={<ExclamationTriangleIcon />} isCompact>
+        With warnings
+      </Label>
+    );
+  }
+  if (vm.migratable) {
+    return (
+      <Label color="green" icon={<CheckCircleIcon />} isCompact>
+        Ready
+      </Label>
+    );
+  }
+  return (
+    <Label color="red" icon={<ExclamationCircleIcon />} isCompact>
+      Not ready
+    </Label>
+  );
+};
+
 interface ExampleVMTableProps {
   vms: MockVirtualMachine[];
 }
 
 export const ExampleVMTable: React.FC<ExampleVMTableProps> = ({ vms }) => {
-  const [page, setPage] = useState(1);
-  const [pageSize, setPageSize] = useState(20);
-  const [searchTerm, setSearchTerm] = useState("");
-
-  const filteredVMs = useMemo(() => {
-    if (!searchTerm.trim()) return vms;
-    const lowerSearch = searchTerm.toLowerCase();
-    return vms.filter(
-      (vm) =>
-        vm.name.toLowerCase().includes(lowerSearch) ||
-        vm.id.toLowerCase().includes(lowerSearch),
-    );
-  }, [vms, searchTerm]);
-
-  const paginatedVMs = useMemo(() => {
-    const start = (page - 1) * pageSize;
-    return filteredVMs.slice(start, start + pageSize);
-  }, [filteredVMs, page, pageSize]);
+  const {
+    page,
+    setPage,
+    pageSize,
+    setPageSize,
+    searchTerm,
+    setSearchTerm,
+    filteredVMs,
+    paginatedVMs,
+  } = useExampleVMTable(vms);
 
   return (
     <>
@@ -134,23 +151,7 @@ export const ExampleVMTable: React.FC<ExampleVMTableProps> = ({ vms }) => {
                 </Label>
               </Td>
               <Td dataLabel="Migration Readiness">
-                {vm.migratable ? (
-                  <Label color="green" icon={<CheckCircleIcon />} isCompact>
-                    Ready
-                  </Label>
-                ) : vm.issueCount > 0 ? (
-                  <Label
-                    color="orange"
-                    icon={<ExclamationTriangleIcon />}
-                    isCompact
-                  >
-                    With warnings
-                  </Label>
-                ) : (
-                  <Label color="red" icon={<ExclamationCircleIcon />} isCompact>
-                    Not ready
-                  </Label>
-                )}
+                <MigrationReadinessCell vm={vm} />
               </Td>
               <Td dataLabel="Cluster">{vm.cluster}</Td>
               <Td dataLabel="Disk size">{formatDiskSize(vm.diskSize)}</Td>

--- a/src/ui/report/views/example-data/ovaVmFixture.ts
+++ b/src/ui/report/views/example-data/ovaVmFixture.ts
@@ -1,0 +1,79 @@
+/**
+ * Mock VM list data for the Discovery OVA example report.
+ * Mirrors the VirtualMachine shape from @openshift-migration-advisor/agent-sdk.
+ */
+
+export interface MockVirtualMachine {
+  name: string;
+  id: string;
+  vCenterState: string;
+  cluster: string;
+  datacenter: string;
+  diskSize: number;
+  memory: number;
+  issueCount: number;
+  migratable: boolean;
+}
+
+const CLUSTERS = ["domain-c34", "domain-c146658"];
+const DATACENTER = "EcoDatacenter";
+
+const OS_PREFIXES: { prefix: string; count: number; migratable: boolean }[] = [
+  { prefix: "rhel9-", count: 50, migratable: true },
+  { prefix: "rhel8-", count: 20, migratable: true },
+  { prefix: "win2022-", count: 6, migratable: true },
+  { prefix: "win2019-", count: 5, migratable: true },
+  { prefix: "win10-", count: 4, migratable: true },
+  { prefix: "centos9-", count: 3, migratable: false },
+  { prefix: "fedora-", count: 10, migratable: false },
+  { prefix: "amazon-linux-", count: 5, migratable: false },
+  { prefix: "ubuntu-", count: 3, migratable: false },
+  { prefix: "suse-", count: 2, migratable: false },
+  { prefix: "debian-", count: 1, migratable: false },
+  { prefix: "other-linux-", count: 8, migratable: false },
+  { prefix: "legacy-vm-", count: 3, migratable: false },
+];
+
+function seededRandom(seed: number): () => number {
+  let s = seed;
+  return () => {
+    s = (s * 1103515245 + 12345) & 0x7fffffff;
+    return s / 0x7fffffff;
+  };
+}
+
+function generateMockVMs(): MockVirtualMachine[] {
+  const vms: MockVirtualMachine[] = [];
+  const rand = seededRandom(42);
+  let vmIndex = 0;
+
+  for (const { prefix, count, migratable } of OS_PREFIXES) {
+    for (let i = 1; i <= count; i++) {
+      const cluster = CLUSTERS[vmIndex % CLUSTERS.length];
+      const poweredOn = rand() > 0.78;
+      const diskGB = Math.round(20 + rand() * 480);
+      const memoryGB = Math.pow(2, Math.floor(rand() * 4 + 1));
+      const issues = migratable
+        ? Math.floor(rand() * 3)
+        : Math.floor(1 + rand() * 5);
+
+      vms.push({
+        name: `${prefix}${String(i).padStart(3, "0")}`,
+        id: `vm-${String(vmIndex + 1000).padStart(5, "0")}`,
+        vCenterState: poweredOn ? "poweredOn" : "poweredOff",
+        cluster,
+        datacenter: DATACENTER,
+        diskSize: diskGB * 1024,
+        memory: memoryGB * 1024,
+        issueCount: issues,
+        migratable,
+      });
+
+      vmIndex++;
+    }
+  }
+
+  return vms;
+}
+
+export const EXAMPLE_OVA_VMS: MockVirtualMachine[] = generateMockVMs();


### PR DESCRIPTION
Create different examples for OVA and RVTools

[recording - 2026-05-07T113653.790.webm](https://github.com/user-attachments/assets/2ce57921-c037-4c0f-9dc8-502f06e205d8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Discovery OVA example report with Overview, Virtual Machines, and Storage Offload Estimator tabs, including a cluster selector, VM table with search/pagination, and a read-only sizing wizard for example clusters.
  * Updated "How Does It Work" with distinct links to the RVTools and Discovery OVA example reports, making the new report accessible from the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->