### PR TITLE
ECOPROJECT-3973 | fix: standardize 'Cluster' terminology to distinguish between vSphere Source and OpenShift Target

### DIFF
--- a/src/ui/report/helpers/clusterViewModel.ts
+++ b/src/ui/report/helpers/clusterViewModel.ts
@@ -44,7 +44,7 @@ export const getClusterOptions = (clusters?: {
     compareClustersByVmCount(a, b, clusters),
   );
   return [
-    { id: "all", label: "All clusters" },
+    { id: "all", label: "All vSphere clusters" },
     ...sortedKeys.map((key) => ({ id: key, label: key })),
   ];
 };
@@ -89,7 +89,7 @@ export const buildClusterViewModel = ({
       viewClusters: clusters,
       isAggregateView: true,
       selectionId: "all",
-      selectionLabel: "All clusters",
+      selectionLabel: "All vSphere clusters",
       clusterOptions: options,
       clusterFound: true,
     };

--- a/src/ui/report/view-models/useExampleReportViewModel.ts
+++ b/src/ui/report/view-models/useExampleReportViewModel.ts
@@ -70,7 +70,8 @@ export function useExampleReportViewModel(): ExampleReportVM {
 
   const detectedSummaryText = useMemo(() => {
     if (clusterCount <= 0) return "No clusters detected";
-    const clusterLabel = clusterCount === 1 ? "cluster" : "clusters";
+    const clusterLabel =
+      clusterCount === 1 ? "vSphere cluster" : "vSphere clusters";
     const totalVMs = vms?.total;
     if (typeof totalVMs === "number") {
       return `Detected ${totalVMs} VMs in ${clusterCount} ${clusterLabel}`;

--- a/src/ui/report/views/DiscoveryOvaExampleReport.tsx
+++ b/src/ui/report/views/DiscoveryOvaExampleReport.tsx
@@ -125,7 +125,9 @@ const DiscoveryOvaExampleReport: React.FC = () => {
                   Detected <strong>{vm.vms?.total ?? 0} VMs</strong> in{" "}
                   <strong>
                     {vm.clusterCount}{" "}
-                    {vm.clusterCount === 1 ? "cluster" : "clusters"}
+                    {vm.clusterCount === 1
+                      ? "vSphere cluster"
+                      : "vSphere clusters"}
                   </strong>
                 </Content>
               </FlexItem>

--- a/src/ui/report/views/Report.tsx
+++ b/src/ui/report/views/Report.tsx
@@ -31,8 +31,8 @@ import { AgentStatusView } from "../../environment/views/AgentStatusView";
 import { useReportPageViewModel } from "../view-models/useReportPageViewModel";
 import type { ClusterOption } from "./assessment-report/ClusterView";
 import { Dashboard } from "./assessment-report/Dashboard";
-import { DeployOvaBanner } from "./DeployOvaBanner";
 import { ClusterSizingWizard } from "./cluster-sizer/ClusterSizingWizard";
+import { DeployOvaBanner } from "./DeployOvaBanner";
 import { ExportReportButton } from "./ExportReportButton";
 
 const alertSpacing = css`
@@ -166,7 +166,9 @@ const ReportContent: React.FC = () => {
                   Detected <strong>{vm.vms?.total} VMS</strong> in{" "}
                   <strong>
                     {vm.clusterCount}{" "}
-                    {vm.clusterCount === 1 ? "cluster" : "clusters"}
+                    {vm.clusterCount === 1
+                      ? "vSphere cluster"
+                      : "vSphere clusters"}
                   </strong>
                 </>
               ) : (
@@ -174,12 +176,14 @@ const ReportContent: React.FC = () => {
                   Detected{" "}
                   <strong>
                     {vm.clusterCount}{" "}
-                    {vm.clusterCount === 1 ? "cluster" : "clusters"}
+                    {vm.clusterCount === 1
+                      ? "vSphere cluster"
+                      : "vSphere clusters"}
                   </strong>
                 </>
               )
             ) : (
-              "No clusters detected"
+              "No vSphere clusters detected"
             )}
           </StackItem>
           <StackItem>

--- a/src/ui/report/views/assessment-report/__tests__/ClusterView.test.ts
+++ b/src/ui/report/views/assessment-report/__tests__/ClusterView.test.ts
@@ -57,7 +57,7 @@ describe("buildClusterViewModel", () => {
 
     expect(model.isAggregateView).toBe(true);
     expect(model.selectionId).toBe("all");
-    expect(model.selectionLabel).toBe("All clusters");
+    expect(model.selectionLabel).toBe("All vSphere clusters");
     expect(model.viewInfra).toBe(baseInfra);
     expect(model.viewVms).toBe(baseVms);
     expect(
@@ -126,7 +126,7 @@ describe("buildClusterViewModel", () => {
     expect(model.viewVms).toBeUndefined();
   });
 
-  it("returns cluster options with 'All clusters' first followed by cluster keys", () => {
+  it("returns cluster options with 'All vSphere clusters' first followed by cluster keys", () => {
     const clusters = {
       "Cluster A": { infra: baseInfra, vms: baseVms },
       "Cluster B": { infra: baseInfra, vms: baseVms },
@@ -140,7 +140,7 @@ describe("buildClusterViewModel", () => {
     });
 
     expect(model.clusterOptions[0].id).toBe("all");
-    expect(model.clusterOptions[0].label).toBe("All clusters");
+    expect(model.clusterOptions[0].label).toBe("All vSphere clusters");
     expect(model.clusterOptions[1].id).toBe("Cluster A");
     expect(model.clusterOptions[2].id).toBe("Cluster B");
   });


### PR DESCRIPTION
<img width="666" height="349" alt="Captura desde 2026-05-12 07-06-21" src="https://github.com/user-attachments/assets/968fa94d-8055-41fd-b144-0adf9ded101e" />
<img width="697" height="229" alt="Captura desde 2026-05-12 07-05-44" src="https://github.com/user-attachments/assets/312f3180-e63f-4d98-86ae-34159e2ed7a9" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Standardized cluster terminology to "vSphere cluster" / "vSphere clusters" across the UI.
  * Cluster selector now shows "All vSphere clusters" as the aggregate option.
  * Updated detected-VMs caption and empty-state messaging to reference "vSphere clusters".
  * Tests adjusted to expect the new wording.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner-ui-app/pull/691)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->