### PR TITLE
ECOPROJECT-4432 | fix: 'Migration Preferences' state is synchronized across unrelated tabs

### DIFF
--- a/src/ui/report/views/cluster-sizer/ClusterSizingWizard.tsx
+++ b/src/ui/report/views/cluster-sizer/ClusterSizingWizard.tsx
@@ -179,6 +179,7 @@ export const ClusterSizingWizard: React.FC<ClusterSizingWizardProps> = ({
       case "architecture":
         return (
           <RecommendationTemplate
+            key="architecture"
             preferencesTitle="Migration preferences"
             preferencesContent={
               <SizingInputForm
@@ -228,6 +229,7 @@ export const ClusterSizingWizard: React.FC<ClusterSizingWizardProps> = ({
         return (
           <RecommendationTabContent
             id="cost-estimation"
+            key="cost-estimation"
             title="Cost estimation"
             content={
               <CostEstimationResult costEstimation={vm.costEstimation} />
@@ -240,6 +242,7 @@ export const ClusterSizingWizard: React.FC<ClusterSizingWizardProps> = ({
       case "time-estimation":
         return (
           <RecommendationTemplate
+            key="time-estimation"
             preferencesTitle="Migration preferences"
             preferencesContent={
               <TimeEstimationForm
@@ -273,6 +276,7 @@ export const ClusterSizingWizard: React.FC<ClusterSizingWizardProps> = ({
       case "complexity":
         return (
           <RecommendationTemplate
+            key="complexity"
             preferencesTitle="Complexity analysis parameters"
             preferencesContent={<div>Analysis parameters (coming soon)</div>}
             resultsContent={


### PR DESCRIPTION
[recording - 2026-05-12T080644.752.webm](https://github.com/user-attachments/assets/8bc64772-0354-4b48-8df6-bd2d24ff440a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent content when switching tabs in the Cluster Sizing Wizard (Architecture, Time Estimation, Complexity, Cost Estimation), ensuring each tab reliably retains and displays the correct information during navigation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner-ui-app/pull/692)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->