### PR TITLE
ECOPROJECT-4432 | fix: store the expanded state for migration preferences for each tab

### DIFF
--- a/src/ui/report/views/cluster-sizer/ClusterSizingWizard.tsx
+++ b/src/ui/report/views/cluster-sizer/ClusterSizingWizard.tsx
@@ -124,6 +124,25 @@ export const ClusterSizingWizard: React.FC<ClusterSizingWizardProps> = ({
   const [selectedMenuItem, setSelectedMenuItem] =
     useState<MenuItem>("architecture");
 
+  const [preferencesExpanded, setPreferencesExpanded] = useState<
+    Record<string, boolean>
+  >({
+    architecture: !isReadOnly,
+    "time-estimation": !isReadOnly,
+  });
+
+  const getPreferencesExpanded = useCallback(
+    (tab: string) => preferencesExpanded[tab] ?? !isReadOnly,
+    [preferencesExpanded, isReadOnly],
+  );
+
+  const setPreferencesExpandedForTab = useCallback(
+    (tab: string) => (expanded: boolean) => {
+      setPreferencesExpanded((prev) => ({ ...prev, [tab]: expanded }));
+    },
+    [],
+  );
+
   useEffect(() => {
     if (vm.sizerOutput && onCalculated) {
       onCalculated(vm.sizerOutput, vm.formValues);
@@ -135,8 +154,12 @@ export const ClusterSizingWizard: React.FC<ClusterSizingWizardProps> = ({
   const handleClose = useCallback(() => {
     vm.reset();
     setSelectedMenuItem("architecture");
+    setPreferencesExpanded({
+      architecture: !isReadOnly,
+      "time-estimation": !isReadOnly,
+    });
     onClose();
-  }, [onClose, vm]);
+  }, [onClose, vm, isReadOnly]);
 
   const handleCalculate = useCallback(() => {
     void vm.calculate();
@@ -208,7 +231,10 @@ export const ClusterSizingWizard: React.FC<ClusterSizingWizardProps> = ({
             )}
             generateButtonText="Generate recommendation"
             hasError={Boolean(vm.calculateError)}
-            isPreferencesInitiallyExpanded={!isReadOnly}
+            isPreferencesExpanded={getPreferencesExpanded("architecture")}
+            onPreferencesExpandedChange={setPreferencesExpandedForTab(
+              "architecture",
+            )}
             isPreferencesDisabled={isReadOnly}
             headerAction={
               vm.sizerOutput ? (
@@ -269,7 +295,10 @@ export const ClusterSizingWizard: React.FC<ClusterSizingWizardProps> = ({
             resultsTitle=""
             showAlert={false}
             hasError={Boolean(vm.estimationError)}
-            isPreferencesInitiallyExpanded={!isReadOnly}
+            isPreferencesExpanded={getPreferencesExpanded("time-estimation")}
+            onPreferencesExpandedChange={setPreferencesExpandedForTab(
+              "time-estimation",
+            )}
             isPreferencesDisabled={isReadOnly}
           />
         );

--- a/src/ui/report/views/cluster-sizer/RecommendationTemplate.tsx
+++ b/src/ui/report/views/cluster-sizer/RecommendationTemplate.tsx
@@ -63,7 +63,15 @@ interface RecommendationTemplateProps {
   resultsTitle?: string;
   /** Whether to show the info alert in the results section (defaults to true) */
   showAlert?: boolean;
-  /** Initial expanded state for preferences section (defaults to true) */
+  /**
+   * Controlled expanded state for the preferences section.
+   * When provided together with `onPreferencesExpandedChange`, the component
+   * becomes controlled and `isPreferencesInitiallyExpanded` is ignored.
+   */
+  isPreferencesExpanded?: boolean;
+  /** Callback fired when the user toggles the preferences section (controlled mode). */
+  onPreferencesExpandedChange?: (expanded: boolean) => void;
+  /** Initial expanded state for preferences section (defaults to true). Ignored when controlled. */
   isPreferencesInitiallyExpanded?: boolean;
   /** Whether the preferences section is disabled (defaults to false) */
   isPreferencesDisabled?: boolean;
@@ -87,6 +95,8 @@ export const RecommendationTemplate: React.FC<RecommendationTemplateProps> = ({
   generateButtonText = "Generate recommendation",
   resultsTitle = "Cluster recommendations",
   showAlert = true,
+  isPreferencesExpanded: controlledExpanded,
+  onPreferencesExpandedChange,
   isPreferencesInitiallyExpanded = true,
   isPreferencesDisabled = false,
   isGenerateDisabled = false,
@@ -94,9 +104,21 @@ export const RecommendationTemplate: React.FC<RecommendationTemplateProps> = ({
   headerAction,
   hasError = false,
 }) => {
-  const [manualExpanded, setManualExpanded] = useState(
+  const isControlled =
+    controlledExpanded !== undefined &&
+    onPreferencesExpandedChange !== undefined;
+
+  const [uncontrolledExpanded, setUncontrolledExpanded] = useState(
     isPreferencesInitiallyExpanded,
   );
+
+  const manualExpanded = isControlled
+    ? controlledExpanded
+    : uncontrolledExpanded;
+  const setManualExpanded = isControlled
+    ? onPreferencesExpandedChange
+    : setUncontrolledExpanded;
+
   const isPreferencesExpanded = hasError || manualExpanded;
 
   const handleGenerate = () => {


### PR DESCRIPTION
- Lifted the preferences expanded state up to ClusterSizingWizard, which stays mounted across tab switches. Each tab ("architecture" and "time-estimation") now has its own persisted expanded state stored in a Record<string, boolean>.

[recording - 2026-05-13T121559.212.webm](https://github.com/user-attachments/assets/2a00d8ea-42b2-4755-b100-207f042a9cba)
