### PR TITLE
ECOPROJECT-4610 | fix: use yellow color instead of red for non-supported OS and non-migratable VMs

### DIFF
--- a/src/ui/report/views/assessment-report/VMMigrationStatus.tsx
+++ b/src/ui/report/views/assessment-report/VMMigrationStatus.tsx
@@ -26,16 +26,16 @@ export const VMMigrationStatus: React.FC<VmMigrationStatusProps> = ({
       legendCategory: "Migratable",
     },
     {
-      name: "Unready for migration",
+      name: "Not ready for migration",
       count: data.nonMigratable,
       countDisplay: `${data.nonMigratable} VMs`,
-      legendCategory: "Unready for migration",
+      legendCategory: "Not ready for migration",
     },
   ];
 
   const legend = {
     Migratable: chartColorSuccess,
-    "Unready for migration": chartColorFailure,
+    "Not ready for migration": chartColorFailure,
   };
 
   return (

--- a/src/ui/report/views/assessment-report/constants.ts
+++ b/src/ui/report/views/assessment-report/constants.ts
@@ -1,10 +1,10 @@
 import { chart_color_blue_300 } from "@patternfly/react-tokens/dist/esm/chart_color_blue_300";
-import { chart_color_red_orange_400 } from "@patternfly/react-tokens/dist/esm/chart_color_red_orange_400";
+import { chart_color_yellow_300 } from "@patternfly/react-tokens/dist/esm/chart_color_yellow_300";
 
 /**
  * PatternFly chart color semantics (https://www.patternfly.org/charts/colors-for-charts/design-guidelines/#best-practices):
  *   Blue  → success / migratable / supported
- *   Red-orange → failure / non-migratable / unsupported
+ *   Yellow → failure / non-migratable / unsupported
  */
 export const chartColorSuccess = chart_color_blue_300.value;
-export const chartColorFailure = chart_color_red_orange_400.value;
+export const chartColorFailure = chart_color_yellow_300.value;


### PR DESCRIPTION
<img width="1571" height="546" alt="Captura desde 2026-05-13 15-13-44" src="https://github.com/user-attachments/assets/0037d0ac-004c-44cb-bb82-f72b4b69f653" />
