### PR TITLE
ECOPROJECT-4644 | fix: Long assessment names are truncated from both side

### DIFF
--- a/src/ui/assessment/views/AssessmentsTable.tsx
+++ b/src/ui/assessment/views/AssessmentsTable.tsx
@@ -1,9 +1,9 @@
-import { css } from "@emotion/css";
 import {
   Button,
   Dropdown,
   DropdownItem,
   DropdownList,
+  Icon,
   MenuToggle,
   type MenuToggleElement,
   Tooltip,
@@ -26,24 +26,11 @@ import {
   Tr,
 } from "@patternfly/react-table";
 import React, { useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 import type { AssessmentModel } from "../../../models/AssessmentModel";
 import { routes } from "../../../routing/Routes";
 import { EmptySearchResults } from "../../core/components/EmptySearchResults";
-
-const themedTooltipStyle = css`
-  .pf-v6-c-tooltip__content {
-    background-color: var(--pf-t--global--background--color--primary--default);
-    color: var(--pf-t--global--text--color--regular);
-    box-shadow: var(--pf-t--global--box-shadow--md);
-  }
-  .pf-v6-c-tooltip__arrow {
-    --pf-v6-c-tooltip__arrow--BackgroundColor: var(
-      --pf-t--global--background--color--primary--default
-    );
-  }
-`;
 
 const openAssistedInstaller = (): void => {
   const currentHost = window.location.hostname;
@@ -466,49 +453,27 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
         {rows.map((row) => (
           <Tr key={row.key}>
             {isColumnVisible("Name") && (
-              <Td dataLabel={Columns.Name}>
-                <TableText wrapModifier="truncate">
-                  <div
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: "8px",
-                    }}
-                  >
-                    <Tooltip content={row.name} className={themedTooltipStyle}>
-                      <Button
-                        variant={row.hasData ? "link" : "plain"}
-                        style={{ padding: 0 }}
-                        isDisabled={!row.hasData}
-                        onClick={
-                          row.hasData
-                            ? (): void =>
-                                navigate(routes.assessmentById(row.id))
-                            : undefined
-                        }
-                      >
-                        {row.name}
-                      </Button>
+              <Td dataLabel={Columns.Name} modifier="truncate">
+                {row.hasData ? (
+                  <Link to={routes.assessmentById(row.id)}>{row.name}</Link>
+                ) : (
+                  <span>
+                    <Tooltip
+                      content={
+                        row.sourceType.toLowerCase().includes("rvtools")
+                          ? "No inventory data found. The uploaded file may be corrupted. Please verify and re-upload."
+                          : "No inventory data yet. Data collection may be in progress or the source connection failed."
+                      }
+                    >
+                      <Icon status="warning">
+                        <ExclamationTriangleIcon />
+                      </Icon>
+                    </Tooltip>{" "}
+                    <Tooltip content={row.name}>
+                      <span>{row.name}</span>
                     </Tooltip>
-                    {!row.hasData && (
-                      <Tooltip
-                        content={
-                          row.sourceType.toLowerCase().includes("rvtools")
-                            ? "No inventory data found. The uploaded file may be corrupted. Please verify and re-upload."
-                            : "No inventory data yet. Data collection may be in progress or the source connection failed."
-                        }
-                      >
-                        <ExclamationTriangleIcon
-                          style={{
-                            color:
-                              "var(--pf-t--global--icon--color--status--warning--default)",
-                            cursor: "help",
-                          }}
-                        />
-                      </Tooltip>
-                    )}
-                  </div>
-                </TableText>
+                  </span>
+                )}
               </Td>
             )}
             {isColumnVisible("SourceType") && (


### PR DESCRIPTION
When an assessment has a long name, the full text is not visible in the assessments list and gets truncated/cut both sides. This makes it difficult to identify and distinguish assessments with similar names. Truncate only on the right.
Use the default tooltip component from patternfly. Use proper link in the table list.

<img width="616" height="235" alt="1" src="https://github.com/user-attachments/assets/79e0c1ab-71fd-427f-9253-409ae4d9c809" />
<img width="448" height="238" alt="2" src="https://github.com/user-attachments/assets/81b867aa-2a32-489d-8a65-ea12ae27dccf" />
<img width="650" height="266" alt="3" src="https://github.com/user-attachments/assets/5d0ee637-ba1c-4b4d-911c-77f78bd3e68b" />
<img width="451" height="260" alt="4" src="https://github.com/user-attachments/assets/96cb023e-db70-4c54-8bc0-6fbfb4837e38" />
<img width="451" height="252" alt="5" src="https://github.com/user-attachments/assets/75554849-6cce-43f8-b7ab-9dac5d3d3985" />
<img width="452" height="278" alt="6" src="https://github.com/user-attachments/assets/bc56961a-9cfb-4d2a-b928-ca89114b8121" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Redesigned assessment table name cell with warning indicators and tooltips for improved clarity
  * Updated navigation interactions based on assessment data availability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner-ui-app/pull/710?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->