### PR TITLE
ECOPROJECT-4588 | feat: replace column select dropdown with ColumnManagementModal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@openshift-migration-advisor/planner-sdk": "^0.13.1-5b03e25a9bc5",
         "@patternfly/react-charts": "7.4.9",
+        "@patternfly/react-component-groups": "^6.4.0",
         "@patternfly/react-core": "^6.4.1",
         "@patternfly/react-icons": "^6.4.0",
         "@patternfly/react-table": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@openshift-migration-advisor/planner-sdk": "^0.13.1-5b03e25a9bc5",
     "@patternfly/react-charts": "7.4.9",
+    "@patternfly/react-component-groups": "^6.4.0",
     "@patternfly/react-core": "^6.4.1",
     "@patternfly/react-icons": "^6.4.0",
     "@patternfly/react-table": "^6.4.1",

--- a/src/ui/assessment/view-models/useAssessmentPageViewModel.ts
+++ b/src/ui/assessment/view-models/useAssessmentPageViewModel.ts
@@ -117,14 +117,14 @@ export interface AssessmentPageViewModel {
 
   // -- Column visibility & sorting -------------------------------------------
 
-  /** Whether the column selection dropdown is open. */
-  isColumnSelectOpen: boolean;
-  /** Toggle the column selection dropdown. */
-  setIsColumnSelectOpen: (open: boolean) => void;
+  /** Whether the column management modal is open. */
+  isColumnModalOpen: boolean;
+  /** Toggle the column management modal. */
+  setIsColumnModalOpen: (open: boolean) => void;
   /** Visible columns (includes mandatory columns). */
   visibleColumns: ColumnKey[];
-  /** Toggle a column's visibility. */
-  toggleColumn: (columnKey: ColumnKey) => void;
+  /** Set visible columns (bulk update). */
+  setVisibleColumns: (columns: ColumnKey[]) => void;
   /** Current sort state. */
   sortBy: { columnKey: SortableColumn; direction: "asc" | "desc" } | undefined;
   /** Update the sort state. */
@@ -180,7 +180,7 @@ export const useAssessmentPageViewModel = (): AssessmentPageViewModel => {
 
   // ---- Column visibility and sorting --------------------------------------
 
-  const [isColumnSelectOpen, setIsColumnSelectOpen] = useState(false);
+  const [isColumnModalOpen, setIsColumnModalOpen] = useState(false);
 
   const userSelectedColumnsVersion = 2;
   const [userSelectedColumns, setUserSelectedColumns] = useLocalStorage<
@@ -220,13 +220,9 @@ export const useAssessmentPageViewModel = (): AssessmentPageViewModel => {
     }
   }, [sortBy, visibleColumns]);
 
-  const toggleColumn = useCallback(
-    (columnKey: ColumnKey) => {
-      setUserSelectedColumns((previousColumns) =>
-        previousColumns.includes(columnKey)
-          ? previousColumns.filter((c) => c !== columnKey)
-          : [...previousColumns, columnKey],
-      );
+  const setVisibleColumns = useCallback(
+    (columns: ColumnKey[]) => {
+      setUserSelectedColumns(columns);
     },
     [setUserSelectedColumns],
   );
@@ -366,10 +362,10 @@ export const useAssessmentPageViewModel = (): AssessmentPageViewModel => {
     deleteError: deleteState.error,
     isUpdatingAssessment: updateState.loading,
     updateError: updateState.error,
-    isColumnSelectOpen,
-    setIsColumnSelectOpen,
+    isColumnModalOpen,
+    setIsColumnModalOpen,
     visibleColumns,
-    toggleColumn,
+    setVisibleColumns,
     sortBy,
     setSortBy,
     createRVToolsJob,

--- a/src/ui/assessment/views/AssessmentsPage.tsx
+++ b/src/ui/assessment/views/AssessmentsPage.tsx
@@ -1,4 +1,7 @@
 import { css } from "@emotion/css";
+import ColumnManagementModal, {
+  type ColumnManagementModalColumn,
+} from "@patternfly/react-component-groups/dist/dynamic/ColumnManagementModal";
 import {
   Button,
   Dropdown,
@@ -9,9 +12,6 @@ import {
   MenuToggle,
   type MenuToggleElement,
   SearchInput,
-  Select,
-  SelectList,
-  SelectOption,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
@@ -28,9 +28,9 @@ import { useAssessmentPageViewModel } from "../view-models/useAssessmentPageView
 import AssessmentEmptyState from "./AssessmentEmptyState";
 import {
   AssessmentsTable,
+  COLUMN_MANAGEMENT_METADATA,
   type ColumnKey,
   Columns,
-  MANDATORY_COLUMNS,
   type SortableColumn,
 } from "./AssessmentsTable";
 import CreateAssessmentModal, {
@@ -94,10 +94,10 @@ export const AssessmentsPage: React.FC<AssessmentsPageProps> = ({
     isNavigatingToReport,
     isSharingAssessment,
     isDeletingAssessment,
-    isColumnSelectOpen,
-    setIsColumnSelectOpen,
+    isColumnModalOpen,
+    setIsColumnModalOpen,
     visibleColumns,
-    toggleColumn,
+    setVisibleColumns,
     sortBy,
     setSortBy,
     createRVToolsJob,
@@ -107,6 +107,31 @@ export const AssessmentsPage: React.FC<AssessmentsPageProps> = ({
     shareAssessment,
     deleteAssessment,
   } = useAssessmentPageViewModel();
+
+  const columnManagementData = React.useMemo(
+    (): ColumnManagementModalColumn[] =>
+      (Object.keys(Columns) as ColumnKey[])
+        .filter((key) => key !== "Actions")
+        .map((key) => ({
+          key,
+          title: COLUMN_MANAGEMENT_METADATA[key].title,
+          isShownByDefault: COLUMN_MANAGEMENT_METADATA[key].isShownByDefault,
+          isShown: visibleColumns.includes(key),
+          isUntoggleable: COLUMN_MANAGEMENT_METADATA[key].isUntoggleable,
+        })),
+    [visibleColumns],
+  );
+
+  const handleApplyColumns = React.useCallback(
+    (newColumns: ColumnManagementModalColumn[]) => {
+      const selectedKeys = newColumns
+        .filter((col) => col.isShown)
+        .map((col) => col.key as ColumnKey);
+      setVisibleColumns(selectedKeys);
+      setIsColumnModalOpen(false);
+    },
+    [setVisibleColumns, setIsColumnModalOpen],
+  );
 
   const [search, setSearch] = useState("");
   const [isFilterDropdownOpen, setIsFilterDropdownOpen] = useState(false);
@@ -396,45 +421,13 @@ export const AssessmentsPage: React.FC<AssessmentsPageProps> = ({
               </ToolbarItem>
 
               <ToolbarItem>
-                <Select
-                  isOpen={isColumnSelectOpen}
-                  onOpenChange={(isOpen) => setIsColumnSelectOpen(isOpen)}
-                  onSelect={(_event, value) => {
-                    if (typeof value === "string") {
-                      toggleColumn(value as ColumnKey);
-                    }
-                  }}
-                  toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                    <MenuToggle
-                      ref={toggleRef}
-                      onClick={() => setIsColumnSelectOpen(!isColumnSelectOpen)}
-                      isExpanded={isColumnSelectOpen}
-                      variant="plain"
-                      icon={<ColumnsIcon />}
-                    >
-                      Manage Columns
-                    </MenuToggle>
-                  )}
+                <Button
+                  variant="control"
+                  icon={<ColumnsIcon />}
+                  onClick={() => setIsColumnModalOpen(true)}
                 >
-                  <SelectList>
-                    {(Object.keys(Columns) as ColumnKey[]).map((columnKey) => {
-                      const isMandatory = MANDATORY_COLUMNS.includes(columnKey);
-                      const isSelected = visibleColumns.includes(columnKey);
-
-                      return (
-                        <SelectOption
-                          key={columnKey}
-                          value={columnKey}
-                          hasCheckbox
-                          isSelected={isSelected}
-                          isDisabled={isMandatory}
-                        >
-                          {Columns[columnKey] || columnKey}
-                        </SelectOption>
-                      );
-                    })}
-                  </SelectList>
-                </Select>
+                  Manage Columns
+                </Button>
               </ToolbarItem>
             </ToolbarGroup>
             <ToolbarGroup align={{ default: "alignStart", lg: "alignEnd" }}>
@@ -567,6 +560,13 @@ export const AssessmentsPage: React.FC<AssessmentsPageProps> = ({
         Are you sure you want to delete{" "}
         <b>{(selectedAssessment as AssessmentModel)?.name}?</b>
       </ConfirmationModal>
+
+      <ColumnManagementModal
+        isOpen={isColumnModalOpen}
+        onClose={() => setIsColumnModalOpen(false)}
+        appliedColumns={columnManagementData}
+        applyColumns={handleApplyColumns}
+      />
     </>
   );
 };

--- a/src/ui/assessment/views/AssessmentsTable.tsx
+++ b/src/ui/assessment/views/AssessmentsTable.tsx
@@ -83,6 +83,72 @@ export const Columns = {
 export type ColumnKey = keyof typeof Columns;
 export const DEFAULT_VISIBLE_COLUMNS = Object.keys(Columns) as ColumnKey[];
 export const MANDATORY_COLUMNS: ColumnKey[] = ["Name", "Actions"];
+
+export const COLUMN_MANAGEMENT_METADATA: Record<
+  ColumnKey,
+  {
+    title: string;
+    isShownByDefault: boolean;
+    isUntoggleable: boolean;
+  }
+> = {
+  Name: {
+    title: Columns.Name,
+    isShownByDefault: true,
+    isUntoggleable: true,
+  },
+  SourceType: {
+    title: Columns.SourceType,
+    isShownByDefault: true,
+    isUntoggleable: false,
+  },
+  LastUpdated: {
+    title: Columns.LastUpdated,
+    isShownByDefault: true,
+    isUntoggleable: false,
+  },
+  Owner: {
+    title: Columns.Owner,
+    isShownByDefault: true,
+    isUntoggleable: false,
+  },
+  Hosts: {
+    title: Columns.Hosts,
+    isShownByDefault: true,
+    isUntoggleable: false,
+  },
+  VMs: {
+    title: Columns.VMs,
+    isShownByDefault: true,
+    isUntoggleable: false,
+  },
+  Networks: {
+    title: Columns.Networks,
+    isShownByDefault: true,
+    isUntoggleable: false,
+  },
+  Datastores: {
+    title: Columns.Datastores,
+    isShownByDefault: true,
+    isUntoggleable: false,
+  },
+  AssessmentReport: {
+    title: Columns.AssessmentReport,
+    isShownByDefault: true,
+    isUntoggleable: false,
+  },
+  SharingStatus: {
+    title: Columns.SharingStatus,
+    isShownByDefault: true,
+    isUntoggleable: false,
+  },
+  Actions: {
+    title: Columns.Actions,
+    isShownByDefault: true,
+    isUntoggleable: true,
+  },
+};
+
 export type SortableColumn = Exclude<
   ColumnKey,
   "AssessmentReport" | "SharingStatus" | "Actions"


### PR DESCRIPTION
Replace the custom PatternFly Select dropdown for column management with the ColumnManagementModal component from @patternfly/react-component-groups. This provides a better UX with a dedicated modal interface and follows PatternFly's recommended pattern. The Actions column is excluded from the modal since it has no title and is always mandatory.


https://github.com/user-attachments/assets/8f3d713b-989e-49bb-99d0-af448b28adcb

