### PR TITLE
ECOPROJECT-4633 | fix: show upload progress immediately when creating RVTools assessment

### DIFF
--- a/src/ui/assessment/views/CreateAssessmentModal.tsx
+++ b/src/ui/assessment/views/CreateAssessmentModal.tsx
@@ -273,7 +273,9 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
 
   const progressMessage = isNavigatingToReport
     ? "Opening report..."
-    : `${jobProgressValue}% done. ${jobProgressLabel}`;
+    : isLoading
+      ? "Uploading file.."
+      : `${jobProgressValue}% done. ${jobProgressLabel}`;
 
   const actions = [
     <Button
@@ -293,7 +295,7 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
     >
       Cancel
     </Button>,
-    (isJobProcessing || isNavigatingToReport) && (
+    (isLoading || isJobProcessing || isNavigatingToReport) && (
       <div key="progress" style={{ marginRight: "auto" }}>
         {progressMessage}
       </div>


### PR DESCRIPTION
Show "Uploading file.." progress immediately when the user clicks Create Assessment, instead of staying static for ~1:40 during large file uploads.

The modal already had `isLoading` (true while the HTTP request is in flight) but only showed the progress indicator when `isJobProcessing` was true — which only kicks in after the server responds with a job. For large files the upload itself is the bottleneck, so the user saw nothing until the 202 came back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved progress feedback during assessment creation: the progress block now appears during file uploads and shows "Uploading file.." while the upload is in progress, then automatically switches to display job completion percentage and status during processing, providing clearer, real-time visibility into both upload and processing stages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner-ui-app/pull/723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->