### PR TITLE
NO-JIRA | fix: resolve js-cookie high severity vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12345,10 +12345,13 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
-      "license": "MIT"
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@redhat-cloud-services/tsc-transform-imports": {
       "glob": ">=10.4.6"
     },
+    "js-cookie": ">=3.0.7",
     "sanitize-html": ">=2.17.4",
     "serialize-javascript": ">=7.0.3",
     "uuid": ">=14.0.0"


### PR DESCRIPTION
`react-use@17.6.0` depends on `js-cookie@^2.2.1` which has a high severity prototype hijack vulnerability ([GHSA-qjx8-664m-686j](https://github.com/advisories/GHSA-qjx8-664m-686j)). `react-use` hasn't released a fix yet and `npm audit fix --force` would downgrade it from 17.x to 13.x.

Added an npm override to force `js-cookie>=3.0.7`. The v2→v3 API is backwards-compatible for the `get`/`set`/`remove` methods that `react-use` uses.. verified with `npm audit` (0 vulnerabilities) and `tsc --noEmit` (0 errors).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraints for improved compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner-ui-app/pull/724?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->