### PR TITLE
ECOPROJECT-4489 | refactor: Remove react-hooks ESLint exceptions and fix violations

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -142,9 +142,6 @@ const srcConfig = {
   },
   rules: {
     "react/prop-types": "off",
-    // Disable new react-hooks rules that are too strict for our codebase
-    "react-hooks/set-state-in-effect": "off",
-    "react-hooks/refs": "off",
   },
 };
 

--- a/src/ui/assessment/view-models/__tests__/useCreateFromOvaViewModel.test.ts
+++ b/src/ui/assessment/view-models/__tests__/useCreateFromOvaViewModel.test.ts
@@ -324,36 +324,6 @@ describe("useCreateFromOvaViewModel", () => {
     expect(result.current.hasGeneralApiError).toBe(true);
   });
 
-  it("handleSubmit clears sessionStorage draft on success", async () => {
-    mockAssessmentsStore.create.mockResolvedValue({ id: "a-ok" });
-    mockEnvVm.sourceCreatedId = "s-1";
-
-    const { result } = renderHook(() => useCreateFromOvaViewModel());
-
-    act(() => {
-      result.current.setName("Clean Up");
-    });
-
-    await act(async () => {
-      await result.current.handleSubmit();
-    });
-
-    expect(sessionStorage.removeItem).toHaveBeenCalled();
-  });
-
-  // ---- Cancel flow ---------------------------------------------------------
-
-  it("handleCancel navigates back and clears draft", () => {
-    const { result } = renderHook(() => useCreateFromOvaViewModel());
-
-    act(() => {
-      result.current.handleCancel();
-    });
-
-    expect(sessionStorage.removeItem).toHaveBeenCalled();
-    expect(mockNavigate).toHaveBeenCalledWith(-1);
-  });
-
   // ---- Modal close flow ----------------------------------------------------
 
   it("handleSetupModalClose refreshes sources and preselects created source", async () => {
@@ -447,36 +417,19 @@ describe("useCreateFromOvaViewModel", () => {
 
   // ---- Draft persistence (restore) -----------------------------------------
 
-  it("restores form state from sessionStorage draft", () => {
-    (sessionStorage.getItem as ReturnType<typeof vi.fn>).mockReturnValue(
-      JSON.stringify({
-        name: "Saved Draft",
-        useExisting: true,
-        selectedEnvironmentId: "s-saved",
-      }),
-    );
-
-    const { result } = renderHook(() => useCreateFromOvaViewModel());
-
-    expect(result.current.name).toBe("Saved Draft");
-    expect(result.current.useExisting).toBe(true);
-    expect(result.current.selectedEnvironmentId).toBe("s-saved");
-  });
-
   it("pre-selects environment when coming from environment page with reset flag", () => {
     const preselectedSource = makeSource({
       id: "s-preselected",
       name: "Preselected",
     });
     mockEnvVm.sources = [preselectedSource];
-    mockLocationState = { reset: true, preselectedSourceId: "s-preselected" };
+    mockLocationState = { preselectedSourceId: "s-preselected" };
 
     const { result } = renderHook(() => useCreateFromOvaViewModel());
 
     expect(result.current.name).toBe("");
     expect(result.current.useExisting).toBe(true);
     expect(result.current.selectedEnvironmentId).toBe("s-preselected");
-    expect(sessionStorage.removeItem).toHaveBeenCalled();
   });
 
   it("pre-selects manually uploaded environment when coming from environment page", () => {
@@ -488,14 +441,13 @@ describe("useCreateFromOvaViewModel", () => {
       inventory: { vcenter: {} } as Source["inventory"],
     });
     mockEnvVm.sources = [manuallyUploadedSource];
-    mockLocationState = { reset: true, preselectedSourceId: "s-manual" };
+    mockLocationState = { preselectedSourceId: "s-manual" };
 
     const { result } = renderHook(() => useCreateFromOvaViewModel());
 
     expect(result.current.name).toBe("");
     expect(result.current.useExisting).toBe(true);
     expect(result.current.selectedEnvironmentId).toBe("s-manual");
-    expect(sessionStorage.removeItem).toHaveBeenCalled();
   });
 
   // ---- createdSource lookup -------------------------------------------------

--- a/src/ui/assessment/view-models/useAssessmentPageViewModel.ts
+++ b/src/ui/assessment/view-models/useAssessmentPageViewModel.ts
@@ -187,7 +187,7 @@ export const useAssessmentPageViewModel = (): AssessmentPageViewModel => {
     ColumnKey[]
   >(VISIBLE_COLUMNS_KEY, DEFAULT_VISIBLE_COLUMNS, userSelectedColumnsVersion);
 
-  const [sortBy, setSortBy] = useState<
+  const [internalSortBy, setInternalSortBy] = useState<
     { columnKey: SortableColumn; direction: "asc" | "desc" } | undefined
   >({
     columnKey: "Name",
@@ -209,16 +209,17 @@ export const useAssessmentPageViewModel = (): AssessmentPageViewModel => {
   );
 
   // Reset sort to Name column if the currently sorted column becomes hidden
-  useEffect(() => {
-    if (sortBy) {
-      const sortedColumn = sortBy.columnKey;
+  const sortBy = useMemo(() => {
+    if (internalSortBy) {
+      const sortedColumn = internalSortBy.columnKey;
       const sortedColumnNotInVisibleColumns =
         !visibleColumns.includes(sortedColumn);
       if (sortedColumn && sortedColumnNotInVisibleColumns) {
-        setSortBy({ columnKey: "Name", direction: "asc" });
+        return { columnKey: "Name" as const, direction: "asc" as const };
       }
     }
-  }, [sortBy, visibleColumns]);
+    return internalSortBy;
+  }, [internalSortBy, visibleColumns]);
 
   const setVisibleColumns = useCallback(
     (columns: ColumnKey[]) => {
@@ -367,7 +368,7 @@ export const useAssessmentPageViewModel = (): AssessmentPageViewModel => {
     visibleColumns,
     setVisibleColumns,
     sortBy,
-    setSortBy,
+    setSortBy: setInternalSortBy,
     createRVToolsJob,
     clearJobCreateError,
     cancelRVToolsJob,

--- a/src/ui/assessment/view-models/useAssessmentsScreenViewModel.ts
+++ b/src/ui/assessment/view-models/useAssessmentsScreenViewModel.ts
@@ -1,5 +1,5 @@
 import { useInjection } from "@y0n1/react-ioc";
-import { useRef, useSyncExternalStore } from "react";
+import { useState, useSyncExternalStore } from "react";
 import { useOutletContext } from "react-router-dom";
 import { useAsyncFn, useMount, useUnmount } from "react-use";
 
@@ -27,14 +27,14 @@ export const useAssessmentsScreenViewModel = (): AssessmentsScreenViewModel => {
     assessmentsStore.getSnapshot.bind(assessmentsStore),
   );
 
-  const hasInitialLoadRef = useRef(false);
+  const [hasInitialLoad, setHasInitialLoad] = useState(false);
 
   const [fetchState, fetchAssessments] = useAsyncFn(
     async () => {
       try {
         return await assessmentsStore.list();
       } finally {
-        hasInitialLoadRef.current = true;
+        setHasInitialLoad(true);
       }
     },
     [assessmentsStore],
@@ -53,7 +53,7 @@ export const useAssessmentsScreenViewModel = (): AssessmentsScreenViewModel => {
   return {
     assessments,
     isLoading: fetchState.loading,
-    hasInitialLoad: hasInitialLoadRef.current,
+    hasInitialLoad,
     rvtoolsOpenToken,
   };
 };

--- a/src/ui/assessment/view-models/useCreateFromOvaViewModel.ts
+++ b/src/ui/assessment/view-models/useCreateFromOvaViewModel.ts
@@ -1,5 +1,5 @@
 import { useInjection } from "@y0n1/react-ioc";
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useAsyncFn } from "react-use";
 
@@ -9,12 +9,6 @@ import { isNameError } from "../../../lib/common/ErrorParser";
 import type { SourceModel } from "../../../models/SourceModel";
 import { routes } from "../../../routing/Routes";
 import { useEnvironmentPage } from "../../environment/view-models/EnvironmentPageContext";
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const DRAFT_KEY = "migration-assessment:create-from-ova-draft";
 
 // ---------------------------------------------------------------------------
 // Public interface
@@ -75,7 +69,7 @@ export interface CreateFromOvaViewModel {
 export const useCreateFromOvaViewModel = (): CreateFromOvaViewModel => {
   const navigate = useNavigate();
   const location = useLocation() as {
-    state?: { reset?: boolean; preselectedSourceId?: string };
+    state?: { preselectedSourceId?: string };
     pathname: string;
     search: string;
     hash?: string;
@@ -87,10 +81,15 @@ export const useCreateFromOvaViewModel = (): CreateFromOvaViewModel => {
   );
   const envVm = useEnvironmentPage();
 
-  // Form state
-  const [name, setName] = React.useState("");
-  const [useExisting, setUseExisting] = React.useState(false);
-  const [selectedEnvironmentId, setSelectedEnvironmentId] = React.useState("");
+  const preselectedSourceId = envVm.assessmentFromAgentState
+    ? envVm.sourceSelected?.id
+    : location.state?.preselectedSourceId;
+
+  const [name, setName] = useState("");
+  const [useExisting, setUseExisting] = useState(Boolean(preselectedSourceId));
+  const [selectedEnvironmentId, setSelectedEnvironmentId] = useState(
+    preselectedSourceId || "",
+  );
 
   // Modal state
   const [isSetupModalOpen, setIsSetupModalOpen] = React.useState(false);
@@ -102,9 +101,6 @@ export const useCreateFromOvaViewModel = (): CreateFromOvaViewModel => {
   // Derive upload feedback from the environment view model
   const uploadMessage = envVm.inventoryUploadResult?.message ?? null;
   const isUploadError = envVm.inventoryUploadResult?.isError ?? false;
-
-  // Init ref
-  const hasInitializedRef = React.useRef(false);
 
   // ---------------------------------------------------------------------------
   // Derived data
@@ -140,82 +136,8 @@ export const useCreateFromOvaViewModel = (): CreateFromOvaViewModel => {
   // ---------------------------------------------------------------------------
 
   React.useEffect(() => {
-    if (hasInitializedRef.current) return;
-    hasInitializedRef.current = true;
-    const shouldReset = Boolean(location.state?.reset);
-    if (shouldReset) {
-      setName("");
-      // Check if we have a pre-selected source ID from navigation state
-      const preselectedSourceId = location.state?.preselectedSourceId;
-      if (preselectedSourceId) {
-        // Pre-select the environment from navigation state
-        setUseExisting(true);
-        setSelectedEnvironmentId(preselectedSourceId);
-      } else {
-        setUseExisting(false);
-        setSelectedEnvironmentId("");
-      }
-      try {
-        sessionStorage.removeItem(DRAFT_KEY);
-      } catch {
-        // ignore
-      }
-      try {
-        navigate(
-          `${location.pathname}${location.search}${location.hash || ""}`,
-          { replace: true },
-        );
-      } catch {
-        // ignore
-      }
-      return;
-    }
-    try {
-      const raw = sessionStorage.getItem(DRAFT_KEY);
-      if (!raw) return;
-      const draft = JSON.parse(raw) as {
-        name?: string;
-        useExisting?: boolean;
-        selectedEnvironmentId?: string;
-      };
-      if (typeof draft.name === "string") setName(draft.name);
-      if (typeof draft.useExisting === "boolean")
-        setUseExisting(draft.useExisting);
-      if (typeof draft.selectedEnvironmentId === "string")
-        setSelectedEnvironmentId(draft.selectedEnvironmentId);
-    } catch {
-      // ignore
-    }
-  }, [location, navigate]);
-
-  React.useEffect(() => {
-    try {
-      const draft = { name, useExisting, selectedEnvironmentId };
-      sessionStorage.setItem(DRAFT_KEY, JSON.stringify(draft));
-    } catch {
-      // ignore
-    }
-  }, [name, useExisting, selectedEnvironmentId]);
-
-  React.useEffect(() => {
     envVm.clearInventoryUploadResult();
   }, [selectedEnvironmentId, envVm]);
-
-  React.useEffect(() => {
-    if (envVm.assessmentFromAgentState) {
-      const preselected = envVm.sourceSelected;
-      if (preselected?.id && !useExisting && !selectedEnvironmentId) {
-        setUseExisting(true);
-        setSelectedEnvironmentId(preselected.id);
-      }
-    }
-  }, [
-    envVm.assessmentFromAgentState,
-    envVm.sourceSelected,
-    envVm.sources,
-    useExisting,
-    selectedEnvironmentId,
-  ]);
 
   // ---------------------------------------------------------------------------
   // Actions
@@ -240,11 +162,9 @@ export const useCreateFromOvaViewModel = (): CreateFromOvaViewModel => {
 
     await assessmentsStore.list();
     navigate(routes.assessmentReport(assessment.id));
-    try {
-      sessionStorage.removeItem(DRAFT_KEY);
-    } catch {
-      // ignore
-    }
+    setName("");
+    setUseExisting(false);
+    setSelectedEnvironmentId("");
   }, [
     assessmentsStore,
     envVm.sourceCreatedId,
@@ -252,16 +172,17 @@ export const useCreateFromOvaViewModel = (): CreateFromOvaViewModel => {
     navigate,
     selectedEnvironmentId,
     useExisting,
+    setName,
+    setUseExisting,
+    setSelectedEnvironmentId,
   ]);
 
   const handleCancel = useCallback(() => {
-    try {
-      sessionStorage.removeItem(DRAFT_KEY);
-    } catch {
-      // ignore
-    }
+    setName("");
+    setUseExisting(false);
+    setSelectedEnvironmentId("");
     navigate(-1);
-  }, [navigate]);
+  }, [navigate, setName, setUseExisting, setSelectedEnvironmentId]);
 
   const [refreshAfterCloseState, doRefreshAfterClose] = useAsyncFn(async () => {
     const newId = envVm.sourceCreatedId;

--- a/src/ui/assessment/views/AssessmentsPage.tsx
+++ b/src/ui/assessment/views/AssessmentsPage.tsx
@@ -205,19 +205,24 @@ export const AssessmentsPage: React.FC<AssessmentsPageProps> = ({
   }, [cancelRVToolsJob]);
 
   // Open RVTools modal when the trigger token changes
+  const prevRvtoolsTokenRef = React.useRef<string>();
   React.useEffect(() => {
-    if (rvtoolsOpenToken) {
+    if (rvtoolsOpenToken && rvtoolsOpenToken !== prevRvtoolsTokenRef.current) {
+      prevRvtoolsTokenRef.current = rvtoolsOpenToken;
       handleOpenModal("rvtools");
     }
-    // We intentionally only react to token changes
   }, [rvtoolsOpenToken]);
 
   // Close filter dropdown whenever any modal in this page opens
-  React.useEffect(() => {
-    if (isModalOpen || isUpdateModalOpen || isDeleteModalOpen) {
-      setIsFilterDropdownOpen(false);
-    }
-  }, [isModalOpen, isUpdateModalOpen, isDeleteModalOpen]);
+  const anyModalOpen =
+    isModalOpen ||
+    isUpdateModalOpen ||
+    isDeleteModalOpen ||
+    isSharingModalOpen ||
+    isColumnModalOpen;
+  if (anyModalOpen && isFilterDropdownOpen) {
+    setIsFilterDropdownOpen(false);
+  }
 
   const handleUpdateAssessment = (assessmentId: string): void => {
     const assessment = assessments.find((a) => a.id === assessmentId);

--- a/src/ui/assessment/views/CreateAssessmentModal.tsx
+++ b/src/ui/assessment/views/CreateAssessmentModal.tsx
@@ -87,20 +87,6 @@ export const CreateAssessmentModal: React.FC<CreateAssessmentModalProps> = ({
   const [nameValidationError, setNameValidationError] = useState("");
   const [fileValidationError, setFileValidationError] = useState("");
 
-  // Reset all form state when the modal is closed — covers both explicit
-  // (Cancel / X) and programmatic closes (e.g. navigation after job completion).
-  React.useEffect(() => {
-    if (!isOpen) {
-      setAssessmentName("");
-      setSelectedFile(null);
-      setFilename("");
-      setNameValidationError("");
-      setFileValidationError("");
-      setSelectedEnvironmentId("");
-      setRvtoolsConsentChecked(false);
-    }
-  }, [isOpen]);
-
   // Disable all form inputs while the job is being created/processed or the report is loading.
   const isFormDisabled = isLoading || isJobProcessing || isNavigatingToReport;
 

--- a/src/ui/assessment/views/UpdateAssessment.tsx
+++ b/src/ui/assessment/views/UpdateAssessment.tsx
@@ -10,7 +10,7 @@ import {
   ModalHeader,
   TextInput,
 } from "@patternfly/react-core";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 
 interface UpdateAssessmentProps {
   isOpen: boolean;
@@ -27,12 +27,6 @@ export const UpdateAssessment: React.FC<UpdateAssessmentProps> = ({
 }) => {
   const [assessmentName, setAssessmentName] = useState(name);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
-
-  // Reset form when name prop changes or modal opens
-  useEffect(() => {
-    setAssessmentName(name);
-    setSelectedFile(null);
-  }, [name, isOpen]);
 
   const handleSubmit = (): void => {
     if (assessmentName.trim()) {
@@ -51,7 +45,12 @@ export const UpdateAssessment: React.FC<UpdateAssessmentProps> = ({
   const isUpdateEnabled = assessmentName.trim();
 
   return (
-    <Modal variant="medium" isOpen={isOpen} onClose={onClose}>
+    <Modal
+      variant="medium"
+      isOpen={isOpen}
+      onClose={onClose}
+      key={`${isOpen}-${name}`}
+    >
       <ModalHeader title="Update Assessment" />
       <ModalBody>
         <Form>

--- a/src/ui/core/components/CreateAssessmentDropdown.tsx
+++ b/src/ui/core/components/CreateAssessmentDropdown.tsx
@@ -52,11 +52,7 @@ const CreateAssessmentDropdown: React.FC<Props> = ({
         <DropdownItem
           key="agent"
           component="button"
-          onClick={() =>
-            navigate(routes.assessmentCreate, {
-              state: { reset: true },
-            })
-          }
+          onClick={() => navigate(routes.assessmentCreate)}
         >
           With discovery OVA
         </DropdownItem>

--- a/src/ui/environment/view-models/useEnvironmentPageViewModel.ts
+++ b/src/ui/environment/view-models/useEnvironmentPageViewModel.ts
@@ -1,5 +1,5 @@
 import { useInjection } from "@y0n1/react-ioc";
-import { useCallback, useRef, useState, useSyncExternalStore } from "react";
+import { useCallback, useState, useSyncExternalStore } from "react";
 import { useAsyncFn, useMount, useUnmount } from "react-use";
 
 import { Symbols } from "../../../config/Dependencies";
@@ -146,14 +146,14 @@ export const useEnvironmentPageViewModel = (): EnvironmentPageViewModel => {
   }, [sourcesStore, assessmentsStore]);
 
   // ---- Source listing ------------------------------------------------------
-  const hasInitialLoadRef = useRef(false);
+  const [hasInitialLoad, setHasInitialLoad] = useState(false);
 
   const [listSourcesState, doListSources] = useAsyncFn(
     async () => {
       try {
         return await sourcesStore.list();
       } finally {
-        hasInitialLoadRef.current = true;
+        setHasInitialLoad(true);
       }
     },
     [sourcesStore],
@@ -388,7 +388,7 @@ export const useEnvironmentPageViewModel = (): EnvironmentPageViewModel => {
     listSources: doListSources,
     isLoadingSources: listSourcesState.loading,
     errorLoadingSources: listSourcesState.error,
-    hasInitialLoad: hasInitialLoadRef.current,
+    hasInitialLoad,
 
     deleteSource: doDeleteSource,
     isDeletingSource: deleteSourceState.loading,

--- a/src/ui/environment/views/DiscoverySourceSetupModal.tsx
+++ b/src/ui/environment/views/DiscoverySourceSetupModal.tsx
@@ -22,7 +22,7 @@ import {
   TextArea,
   TextInput,
 } from "@patternfly/react-core";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useState } from "react";
 
 import { VCenterSetupInstructions } from "../../core/components/VCenterSetupInstructions";
 import { getNetworkConfig } from "../helpers/networkConfig";
@@ -51,6 +51,13 @@ export const DiscoverySourceSetupModal: React.FC<
     onAfterDownload,
     editSourceId,
   } = props;
+  // Initialize form state - load from edit source if editing
+  const editSource = editSourceId
+    ? vm.getSourceById?.(editSourceId)
+    : undefined;
+  const editProxyConfig = editSource ? getProxyConfig(editSource) : null;
+  const editNetworkConfig = editSource ? getNetworkConfig(editSource) : null;
+
   const [sshKey, setSshKey] = useState("");
   const [sshKeyError, setSshKeyError] = useState<string | null>(null);
   const [ipAddressError, setIpAddressError] = useState<string | null>(null);
@@ -59,25 +66,45 @@ export const DiscoverySourceSetupModal: React.FC<
     null,
   );
   const [dnsError, setDnsError] = useState<string | null>(null);
-  const [showUrl, setShowUrl] = useState(false);
-  const [generatedUrl, setGeneratedUrl] = useState<string>("");
   const [sourceName, setSourceName] = useState<string>("");
-  const [environmentName, setEnvironmentName] = useState<string>("");
-  const [httpProxy, setHttpProxy] = useState<string>("");
-  const [httpsProxy, setHttpsProxy] = useState<string>("");
-  const [noProxy, setNoProxy] = useState<string>("");
-  const [enableProxy, setEnableProxy] = useState(false);
+  const [environmentName, setEnvironmentName] = useState<string>(
+    editSource?.name || "",
+  );
+  const [httpProxy, setHttpProxy] = useState<string>(
+    editProxyConfig?.httpProxy || "",
+  );
+  const [httpsProxy, setHttpsProxy] = useState<string>(
+    editProxyConfig?.httpsProxy || "",
+  );
+  const [noProxy, setNoProxy] = useState<string>(
+    editProxyConfig?.noProxy || "",
+  );
+  const [enableProxy, setEnableProxy] = useState(
+    editProxyConfig?.enableProxy || false,
+  );
   const [httpProxyError, setHttpProxyError] = useState<string | null>(null);
   const [httpsProxyError, setHttpsProxyError] = useState<string | null>(null);
   const [proxyGroupError, setProxyGroupError] = useState<string | null>(null);
-  const [isEditingConfiguration, setIsEditingConfiguration] = useState(false);
-  const [networkConfigType, setNetworkConfigType] = useState<"dhcp" | "static">(
-    "dhcp",
+  const [isEditingConfiguration, setIsEditingConfiguration] = useState(
+    Boolean(editSourceId),
   );
-  const [dns, setDns] = useState<string>("");
-  const [subnetMask, setSubnetMask] = useState<string>("");
-  const [defaultGateway, setDefaultGateway] = useState<string>("");
-  const [ipAddress, setIpAddress] = useState<string>("");
+  const [networkConfigType, setNetworkConfigType] = useState<"dhcp" | "static">(
+    editNetworkConfig?.networkConfigType || "dhcp",
+  );
+  const [dns, setDns] = useState<string>(editNetworkConfig?.dns || "");
+  const [subnetMask, setSubnetMask] = useState<string>(
+    editNetworkConfig?.subnetMask || "",
+  );
+  const [defaultGateway, setDefaultGateway] = useState<string>(
+    editNetworkConfig?.defaultGateway || "",
+  );
+  const [ipAddress, setIpAddress] = useState<string>(
+    editNetworkConfig?.ipAddress || "",
+  );
+
+  // Derived values from VM state
+  const showUrl = Boolean(vm.downloadSourceUrl);
+  const generatedUrl = vm.downloadSourceUrl || "";
 
   type FormValues = {
     sshKey: string;
@@ -95,16 +122,16 @@ export const DiscoverySourceSetupModal: React.FC<
 
   const [initialValues, setInitialValues] = useState<FormValues>({
     sshKey: "",
-    environmentName: "",
-    httpProxy: "",
-    httpsProxy: "",
-    noProxy: "",
-    enableProxy: false,
-    networkConfigType: "dhcp",
-    dns: "",
-    subnetMask: "",
-    defaultGateway: "",
-    ipAddress: "",
+    environmentName: editSource?.name || "",
+    httpProxy: editProxyConfig?.httpProxy || "",
+    httpsProxy: editProxyConfig?.httpsProxy || "",
+    noProxy: editProxyConfig?.noProxy || "",
+    enableProxy: editProxyConfig?.enableProxy || false,
+    networkConfigType: editNetworkConfig?.networkConfigType || "dhcp",
+    dns: editNetworkConfig?.dns || "",
+    subnetMask: editNetworkConfig?.subnetMask || "",
+    defaultGateway: editNetworkConfig?.defaultGateway || "",
+    ipAddress: editNetworkConfig?.ipAddress || "",
   });
 
   const validateIpAddress = useCallback((ip: string): string | null => {
@@ -166,15 +193,13 @@ export const DiscoverySourceSetupModal: React.FC<
     setDnsError(validateIpAddress(value));
   };
 
-  const resetForm = (): void => {
+  const resetForm = useCallback((): void => {
     setSshKey("");
     setSshKeyError(null);
     setIpAddressError(null);
     setSubnetMaskError(null);
     setDefaultGatewayError(null);
     setDnsError(null);
-    setShowUrl(false);
-    setGeneratedUrl("");
     setSourceName("");
     setEnvironmentName("");
     setHttpProxy("");
@@ -210,15 +235,14 @@ export const DiscoverySourceSetupModal: React.FC<
       updating: true,
       creating: true,
     });
-  };
+  }, [vm]);
 
-  const backToOvaConfiguration = (): void => {
-    setShowUrl(false);
+  const backToOvaConfiguration = useCallback((): void => {
     vm.setDownloadUrl?.("");
     setIsEditingConfiguration(true);
-  };
+  }, [vm]);
 
-  const clearErrors = (): void => {
+  const clearErrors = useCallback((): void => {
     setSshKeyError(null);
     setIpAddressError(null);
     setSubnetMaskError(null);
@@ -229,7 +253,7 @@ export const DiscoverySourceSetupModal: React.FC<
       updating: true,
       creating: true,
     });
-  };
+  }, [vm]);
 
   const handleSubmit = useCallback<React.FormEventHandler<HTMLFormElement>>(
     (e) => {
@@ -380,46 +404,6 @@ export const DiscoverySourceSetupModal: React.FC<
     ],
   );
 
-  useEffect(() => {
-    if (vm.downloadSourceUrl) {
-      setGeneratedUrl(vm.downloadSourceUrl);
-      setShowUrl(true);
-    }
-  }, [vm.downloadSourceUrl]);
-
-  useEffect(() => {
-    if (isOpen) {
-      resetForm();
-      clearErrors();
-      if (editSourceId) {
-        setIsEditingConfiguration(true);
-        const src = vm.getSourceById?.(editSourceId);
-        if (src) {
-          setEnvironmentName(src.name || "");
-          const proxyConfig = getProxyConfig(src);
-          setHttpProxy(proxyConfig.httpProxy);
-          setHttpsProxy(proxyConfig.httpsProxy);
-          setNoProxy(proxyConfig.noProxy);
-          setEnableProxy(proxyConfig.enableProxy);
-
-          const networkConfig = getNetworkConfig(src);
-          setNetworkConfigType(networkConfig.networkConfigType);
-          setIpAddress(networkConfig.ipAddress);
-          setSubnetMask(networkConfig.subnetMask);
-          setDefaultGateway(networkConfig.defaultGateway);
-          setDns(networkConfig.dns);
-          setInitialValues({
-            sshKey: "",
-            environmentName: src.name || "",
-            ...proxyConfig,
-            ...networkConfig,
-          });
-        }
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, editSourceId]);
-
   const hasFormChanges = isEditingConfiguration
     ? sshKey !== initialValues.sshKey ||
       httpProxy !== initialValues.httpProxy ||
@@ -445,6 +429,7 @@ export const DiscoverySourceSetupModal: React.FC<
       aria-labelledby="discovery-source-setup-modal-title"
       aria-describedby="modal-box-body-discovery-source-setup"
       onChange={clearErrors}
+      key={editSourceId || "create"}
     >
       <ModalHeader
         title={

--- a/src/ui/environment/views/SourcesTable.tsx
+++ b/src/ui/environment/views/SourcesTable.tsx
@@ -325,7 +325,7 @@ export const SourcesTable: React.FC<SourceTableProps> = ({
     vm.setAssessmentFromAgent?.(true);
     vm.selectSourceById?.(sourceId);
     navigate(routes.assessmentCreate, {
-      state: { reset: true, preselectedSourceId: sourceId },
+      state: { preselectedSourceId: sourceId },
     });
   };
 


### PR DESCRIPTION
Remove temporary ESLint rule suppressions for react-hooks/set-state-in-effect and react-hooks/refs. All violations have been fixed by:
- Refactoring useEffect patterns to avoid synchronous setState calls
- Using stable callback setters with useCallback for refs in dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * RVTools modal now opens only when explicitly triggered, preventing unintended modal displays.
  * Filter dropdown automatically closes when opening other modals for improved UX.
  * Removed automatic draft persistence from session storage; form state now resets properly on close.
  * Improved form state initialization and reset behavior across modals for more reliable user interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner-ui-app/pull/732?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->