### PR TITLE
ECOPROJECT-4732 | fix: HTML Export Script Tag Breakout via Type Confusion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2441,19 +2441,6 @@
         "eslint-scope": "5.1.1"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@nuxt/opencollective": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.4.1.tgz",
@@ -2764,9 +2751,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2788,9 +2772,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2812,9 +2793,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2836,9 +2814,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2860,9 +2835,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2884,9 +2856,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3918,9 +3887,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3935,9 +3901,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3952,9 +3915,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3969,9 +3929,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3986,9 +3943,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4003,9 +3957,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4020,9 +3971,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4037,9 +3985,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4054,9 +3999,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4071,9 +4013,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4088,9 +4027,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4105,9 +4041,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4122,9 +4055,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4746,9 +4676,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4766,9 +4693,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4786,9 +4710,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4806,9 +4727,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4826,9 +4744,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4846,9 +4761,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -19878,22 +19790,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/src/services/html-export/ChartDataTransformer.ts
+++ b/src/services/html-export/ChartDataTransformer.ts
@@ -20,6 +20,7 @@ const MEMORY_OVERHEAD_FACTOR = 1.25;
  */
 const STORAGE_SAFETY_MULTIPLIER = 1.15;
 
+import { coerceFiniteNumber } from "./scriptSafeNumbers";
 import type {
   ChartData,
   Datastore,
@@ -38,12 +39,18 @@ export class ChartDataTransformer {
     // Check if osInfo exists (new format)
     if (vms.osInfo && Object.keys(vms.osInfo).length > 0) {
       return Object.entries(vms.osInfo).map(
-        ([osName, osInfo]: [string, OSInfo]) => [osName, osInfo.count],
+        ([osName, osInfo]: [string, OSInfo]) => [
+          osName,
+          coerceFiniteNumber(osInfo.count),
+        ],
       );
     }
     // Fallback to os (old format)
     if (vms.os && Object.keys(vms.os).length > 0) {
-      return Object.entries(vms.os);
+      return Object.entries(vms.os).map(([osName, count]) => [
+        osName,
+        coerceFiniteNumber(count),
+      ]);
     }
     return [];
   }
@@ -103,28 +110,24 @@ export class ChartDataTransformer {
   private buildPowerStateData(vms: VMsData): Array<[string, number]> {
     const ps = vms.powerStates ?? {};
     return [
-      ["Powered On", ps.poweredOn ?? 0],
-      ["Powered Off", ps.poweredOff ?? 0],
-      ["Suspended", ps.suspended ?? 0],
+      ["Powered On", coerceFiniteNumber(ps.poweredOn)],
+      ["Powered Off", coerceFiniteNumber(ps.poweredOff)],
+      ["Suspended", coerceFiniteNumber(ps.suspended)],
     ];
   }
 
   private buildResourceData(vms: VMsData): Array<[string, number, number]> {
+    const cpuTotal = coerceFiniteNumber(vms.cpuCores.total);
+    const ramTotal = coerceFiniteNumber(vms.ramGB.total);
+    const diskTotal = coerceFiniteNumber(vms.diskGB.total);
+
     return [
-      [
-        "CPU Cores",
-        vms.cpuCores.total,
-        Math.round(vms.cpuCores.total * CPU_CAPACITY_MARGIN),
-      ],
-      [
-        "Memory GB",
-        vms.ramGB.total,
-        Math.round(vms.ramGB.total * MEMORY_OVERHEAD_FACTOR),
-      ],
+      ["CPU Cores", cpuTotal, Math.round(cpuTotal * CPU_CAPACITY_MARGIN)],
+      ["Memory GB", ramTotal, Math.round(ramTotal * MEMORY_OVERHEAD_FACTOR)],
       [
         "Storage GB",
-        vms.diskGB.total,
-        Math.round(vms.diskGB.total * STORAGE_SAFETY_MULTIPLIER),
+        diskTotal,
+        Math.round(diskTotal * STORAGE_SAFETY_MULTIPLIER),
       ],
     ];
   }
@@ -136,7 +139,10 @@ export class ChartDataTransformer {
   }
 
   private buildWarningsData(vms: VMsData): Array<[string, number]> {
-    return vms.migrationWarnings.map((w) => [w.label, w.count]);
+    return vms.migrationWarnings.map((w) => [
+      w.label,
+      coerceFiniteNumber(w.count),
+    ]);
   }
 
   private buildStorageData(infra: InfraData): {
@@ -147,11 +153,13 @@ export class ChartDataTransformer {
     const storageLabels = infra.datastores.map(
       (ds: Datastore) => `${ds.vendor} ${ds.type}`,
     );
-    const storageUsedData = infra.datastores.map(
-      (ds: Datastore) => ds.totalCapacityGB - ds.freeCapacityGB,
-    );
-    const storageTotalData = infra.datastores.map(
-      (ds: Datastore) => ds.totalCapacityGB,
+    const storageUsedData = infra.datastores.map((ds: Datastore) => {
+      const total = coerceFiniteNumber(ds.totalCapacityGB);
+      const free = coerceFiniteNumber(ds.freeCapacityGB);
+      return total - free;
+    });
+    const storageTotalData = infra.datastores.map((ds: Datastore) =>
+      coerceFiniteNumber(ds.totalCapacityGB),
     );
 
     return { storageLabels, storageUsedData, storageTotalData };

--- a/src/services/html-export/HtmlTemplateBuilder.ts
+++ b/src/services/html-export/HtmlTemplateBuilder.ts
@@ -3,6 +3,10 @@
  */
 
 import { ChartDataTransformer } from "./ChartDataTransformer";
+import {
+  coerceFiniteNumber,
+  stringifyScriptNumbers,
+} from "./scriptSafeNumbers";
 import type {
   ChartData,
   Datastore,
@@ -15,14 +19,15 @@ import type {
 
 export const DEFAULT_DOCUMENT_TITLE = "VMware Infrastructure Assessment Report";
 
-const formatNumber = (num: number): string => {
-  if (num >= 1_000_000) {
-    return `${(num / 1_000_000).toFixed(1)}M`;
+const formatNumber = (num: unknown): string => {
+  const n = coerceFiniteNumber(num);
+  if (n >= 1_000_000) {
+    return `${(n / 1_000_000).toFixed(1)}M`;
   }
-  if (num >= 1_000) {
-    return `${(num / 1_000).toFixed(1)}K`;
+  if (n >= 1_000) {
+    return `${(n / 1_000).toFixed(1)}K`;
   }
-  return num.toString();
+  return n.toString();
 };
 
 const escapeHtml = (str: string): string => {
@@ -418,11 +423,12 @@ export class HtmlTemplateBuilder {
 
     return infra.datastores
       .map((ds: Datastore) => {
+        const totalCapacityGB = coerceFiniteNumber(ds.totalCapacityGB);
+        const freeCapacityGB = coerceFiniteNumber(ds.freeCapacityGB);
         const utilization =
-          ds.totalCapacityGB > 0
+          totalCapacityGB > 0
             ? (
-                ((ds.totalCapacityGB - ds.freeCapacityGB) /
-                  ds.totalCapacityGB) *
+                ((totalCapacityGB - freeCapacityGB) / totalCapacityGB) *
                 100
               ).toFixed(1)
             : "0.0";
@@ -433,8 +439,8 @@ export class HtmlTemplateBuilder {
         <td><strong>${escapeHtml(ds.vendor)}</strong></td>
         <td>${escapeHtml(ds.type)}</td>
         <td>${escapeHtml(ds.protocolType)}</td>
-        <td>${formatNumber(ds.totalCapacityGB)}</td>
-        <td>${formatNumber(ds.freeCapacityGB)}</td>
+        <td>${formatNumber(totalCapacityGB)}</td>
+        <td>${formatNumber(freeCapacityGB)}</td>
         <td>${utilization}%</td>
         <td>${hwAccel}</td>
       </tr>`;
@@ -463,7 +469,7 @@ export class HtmlTemplateBuilder {
                     data: {
                         labels: ${JSON.stringify(powerStateData.map((d) => d[0])).replace(/<\//g, "<\\/")},
                         datasets: [{
-                            data: ${JSON.stringify(powerStateData.map((d) => d[1]))},
+                            data: ${stringifyScriptNumbers(powerStateData.map((d) => d[1]))},
                             backgroundColor: ['${CHART_COLORS.SUCCESS}', '${CHART_COLORS.DANGER}', '${CHART_COLORS.WARNING}']
                         }]
                     },
@@ -484,11 +490,11 @@ export class HtmlTemplateBuilder {
                         labels: ${JSON.stringify(resourceData.map((d) => d[0])).replace(/<\//g, "<\\/")},
                         datasets: [{
                             label: 'Current',
-                            data: ${JSON.stringify(resourceData.map((d) => d[1]))},
+                            data: ${stringifyScriptNumbers(resourceData.map((d) => d[1]))},
                             backgroundColor: '${CHART_COLORS.PRIMARY}'
                         }, {
                             label: 'Recommended',
-                            data: ${JSON.stringify(resourceData.map((d) => d[2]))},
+                            data: ${stringifyScriptNumbers(resourceData.map((d) => d[2]))},
                             backgroundColor: '${CHART_COLORS.SUCCESS}'
                         }]
                     },
@@ -509,7 +515,7 @@ export class HtmlTemplateBuilder {
                     data: {
                         labels: ${JSON.stringify(osData.map((d) => d[0])).replace(/<\//g, "<\\/")},
                         datasets: [{
-                            data: ${JSON.stringify(osData.map((d) => d[1]))},
+                            data: ${stringifyScriptNumbers(osData.map((d) => d[1]))},
                             backgroundColor: ${JSON.stringify([
                               CHART_COLORS.PRIMARY,
                               CHART_COLORS.DANGER,
@@ -543,10 +549,10 @@ export class HtmlTemplateBuilder {
                     data: {
                         labels: ${JSON.stringify(warningsData.map((d) => d[0])).replace(/<\//g, "<\\/")},
                         datasets: [{
-                            data: ${JSON.stringify(warningsData.map((d) => d[1]))},
+                            data: ${stringifyScriptNumbers(warningsData.map((d) => d[1]))},
                             backgroundColor: ${JSON.stringify(
                               warningsData.map((d) => {
-                                const count = Number(d[1]);
+                                const count = coerceFiniteNumber(d[1]);
                                 return count > 50
                                   ? CHART_COLORS.DANGER
                                   : count > 20
@@ -581,11 +587,11 @@ export class HtmlTemplateBuilder {
                         labels: ${JSON.stringify(storageLabels).replace(/<\//g, "<\\/")},
                         datasets: [{
                             label: 'Used (GB)',
-                            data: ${JSON.stringify(storageUsedData)},
+                            data: ${stringifyScriptNumbers(storageUsedData)},
                             backgroundColor: '${CHART_COLORS.DANGER}'
                         }, {
                             label: 'Total (GB)',
-                            data: ${JSON.stringify(storageTotalData)},
+                            data: ${stringifyScriptNumbers(storageTotalData)},
                             backgroundColor: '${CHART_COLORS.PRIMARY}'
                         }]
                     },

--- a/src/services/html-export/__tests__/ChartDataTransformer.test.ts
+++ b/src/services/html-export/__tests__/ChartDataTransformer.test.ts
@@ -227,6 +227,23 @@ describe("ChartDataTransformer", () => {
       expect(result.storageTotalData).toEqual([1000, 500]);
     });
 
+    it("coerces string values in numeric inventory fields", () => {
+      const inventory = makeInventory();
+      inventory.infra.datastores[0].totalCapacityGB =
+        "</script><img src=x onerror=alert(1)>" as unknown as number;
+      inventory.infra.datastores[0].freeCapacityGB = "400" as unknown as number;
+      inventory.vms.powerStates.poweredOn = "7" as unknown as number;
+      inventory.vms.migrationWarnings[0].count =
+        '"></script><script>alert(1)</script>' as unknown as number;
+
+      const result = transformer.transform(inventory);
+
+      expect(result.storageTotalData[0]).toBe(0);
+      expect(result.storageUsedData[0]).toBe(-400);
+      expect(result.powerStateData[0][1]).toBe(7);
+      expect(result.warningsData[0][1]).toBe(0);
+    });
+
     it("sorts OS data by count descending and limits to 8", () => {
       const osInfo: Record<string, { count: number; supported: boolean }> = {};
       for (let i = 0; i < 12; i++) {

--- a/src/services/html-export/__tests__/HtmlTemplateBuilder.test.ts
+++ b/src/services/html-export/__tests__/HtmlTemplateBuilder.test.ts
@@ -140,5 +140,32 @@ describe("HtmlTemplateBuilder", () => {
         expect(html).toContain("cdnjs.cloudflare.com/ajax/libs/Chart.js");
       });
     });
+
+    describe("inline chart script safety", () => {
+      const scriptBreaker = "</script><img src=x onerror=alert(1)>";
+
+      it("does not embed malicious strings in chart data arrays", () => {
+        const chartData: ChartData = {
+          ...mockChartData,
+          storageTotalData: [scriptBreaker as unknown as number],
+          storageUsedData: [scriptBreaker as unknown as number],
+          powerStateData: [["Powered On", scriptBreaker as unknown as number]],
+          resourceData: [
+            [
+              "CPU",
+              scriptBreaker as unknown as number,
+              scriptBreaker as unknown as number,
+            ],
+          ],
+          osData: [["Linux", scriptBreaker as unknown as number]],
+          warningsData: [["Warn", scriptBreaker as unknown as number]],
+        };
+
+        const html = builder.build(chartData, mockInventory);
+
+        expect(html).not.toContain(scriptBreaker);
+        expect(html).not.toContain("onerror=alert");
+      });
+    });
   });
 });

--- a/src/services/html-export/__tests__/scriptSafeNumbers.test.ts
+++ b/src/services/html-export/__tests__/scriptSafeNumbers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  coerceFiniteNumber,
+  stringifyScriptNumbers,
+} from "../scriptSafeNumbers";
+
+describe("scriptSafeNumbers", () => {
+  describe("coerceFiniteNumber", () => {
+    it("returns finite numbers unchanged", () => {
+      expect(coerceFiniteNumber(42)).toBe(42);
+      expect(coerceFiniteNumber("123")).toBe(123);
+    });
+
+    it("returns 0 for non-numeric and non-finite values", () => {
+      expect(coerceFiniteNumber("not-a-number")).toBe(0);
+      expect(coerceFiniteNumber("</script><img src=x onerror=alert(1)>")).toBe(
+        0,
+      );
+      expect(coerceFiniteNumber(Infinity)).toBe(0);
+      expect(coerceFiniteNumber(null)).toBe(0);
+      expect(coerceFiniteNumber(undefined)).toBe(0);
+    });
+  });
+
+  describe("stringifyScriptNumbers", () => {
+    it("serializes only JSON numbers", () => {
+      expect(stringifyScriptNumbers([1, 2, 3])).toBe("[1,2,3]");
+    });
+
+    it("does not embed script-breaking strings", () => {
+      const payload = "</script><img src=x onerror=alert(1)>";
+      expect(stringifyScriptNumbers([payload])).toBe("[0]");
+      expect(stringifyScriptNumbers([payload])).not.toContain("</script>");
+    });
+  });
+});

--- a/src/services/html-export/scriptSafeNumbers.ts
+++ b/src/services/html-export/scriptSafeNumbers.ts
@@ -1,0 +1,14 @@
+/**
+ * Coerce untrusted values to finite numbers for HTML export.
+ * SDK responses are not runtime-validated; string payloads in numeric
+ * fields must not be embedded verbatim inside inline <script> blocks.
+ */
+export function coerceFiniteNumber(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** JSON array of numbers safe for interpolation into inline script tags. */
+export function stringifyScriptNumbers(values: readonly unknown[]): string {
+  return JSON.stringify(values.map(coerceFiniteNumber));
+}


### PR DESCRIPTION
Related with https://redhat.atlassian.net/browse/ECOPROJECT-4732

Prevent script injection when inventory numeric fields arrive as strings. The SDK does not validate types at runtime; malicious values in chart data arrays could break out of inline <script> blocks via JSON.stringify.

- Add scriptSafeNumbers helpers (coerceFiniteNumber, stringifyScriptNumbers)
- Coerce numeric inventory fields in ChartDataTransformer
- Use safe numeric serialization for all chart data arrays in HtmlTemplateBuilder
- Harden formatNumber and storage table capacity math
- Add unit tests for malicious string payloads