### PR TITLE
NO-JIRA | fix: add npm min-release-age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,4 @@
 @jsr:registry=https://npm.jsr.io
+
+# Block packages published in the last 7 days (supply-chain hardening; requires npm >= 11.10).
+min-release-age=7

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "engines": {
     "node": ">=20.0.0",
-    "npm": ">=10.0.0"
+    "npm": ">=11.10.0"
   },
   "scripts": {
     "build": "make build",


### PR DESCRIPTION
Set min-release-age=7 in .npmrc and require npm >=11.10 so installs skip packages published in the last week.
