### PR TITLE
ECOPROJECT-4680 | fix: add Tooltip around <Link> component inside assessment name's column

### DIFF
--- a/src/ui/assessment/views/AssessmentsTable.tsx
+++ b/src/ui/assessment/views/AssessmentsTable.tsx
@@ -521,7 +521,9 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
             {isColumnVisible("Name") && (
               <Td dataLabel={Columns.Name} modifier="truncate">
                 {row.hasData ? (
-                  <Link to={routes.assessmentById(row.id)}>{row.name}</Link>
+                  <Tooltip content={row.name}>
+                    <Link to={routes.assessmentById(row.id)}>{row.name}</Link>
+                  </Tooltip>
                 ) : (
                   <span>
                     <Tooltip


### PR DESCRIPTION
- By default if we use the modifier='truncate' in a <td> element and we put a <Link> component inside it, the Tooltip is not shown

<img width="470" height="119" alt="image" src="https://github.com/user-attachments/assets/5685cb1d-23a0-42f2-a51f-5d18660e4ba0" />
