### PR TITLE
ECOPROJECT-4725 | fix: prevent XSS via credentialUrl validation

### DIFF
--- a/src/ui/assessment/views/CreateFromOva.tsx
+++ b/src/ui/assessment/views/CreateFromOva.tsx
@@ -21,6 +21,7 @@ import React from "react";
 
 import { routes } from "../../../routing/Routes";
 import { AppPage } from "../../core/components/AppPage";
+import { safeExternalUrl } from "../../core/utils/urlValidation";
 import { EnvironmentPageProvider } from "../../environment/view-models/EnvironmentPageContext";
 import { DiscoverySourceSetupModal } from "../../environment/views/DiscoverySourceSetupModal";
 import { SourcesTable } from "../../environment/views/SourcesTable";
@@ -190,10 +191,12 @@ const CreateFromOvaContent: React.FC = () => {
                 variant="custom"
                 title="Discovery VM"
                 actionLinks={
-                  vm.createdSource?.agent?.credentialUrl ? (
+                  safeExternalUrl(vm.createdSource?.agent?.credentialUrl) ? (
                     <AlertActionLink
                       component="a"
-                      href={vm.createdSource.agent.credentialUrl}
+                      href={safeExternalUrl(
+                        vm.createdSource.agent.credentialUrl,
+                      )}
                       target="_blank"
                       rel="noopener noreferrer"
                     >

--- a/src/ui/core/utils/__tests__/urlValidation.test.ts
+++ b/src/ui/core/utils/__tests__/urlValidation.test.ts
@@ -1,0 +1,129 @@
+import { safeExternalUrl } from "../urlValidation";
+
+describe("safeExternalUrl", () => {
+  describe("should return the URL for valid http/https URLs", () => {
+    test("https URL", () => {
+      expect(safeExternalUrl("https://example.com")).toBe(
+        "https://example.com",
+      );
+    });
+
+    test("http URL", () => {
+      expect(safeExternalUrl("http://example.com")).toBe("http://example.com");
+    });
+
+    test("https URL with path", () => {
+      expect(safeExternalUrl("https://example.com/path/to/resource")).toBe(
+        "https://example.com/path/to/resource",
+      );
+    });
+
+    test("https URL with query parameters", () => {
+      expect(safeExternalUrl("https://example.com?foo=bar&baz=qux")).toBe(
+        "https://example.com?foo=bar&baz=qux",
+      );
+    });
+
+    test("https URL with fragment", () => {
+      expect(safeExternalUrl("https://example.com#section")).toBe(
+        "https://example.com#section",
+      );
+    });
+
+    test("https URL with port", () => {
+      expect(safeExternalUrl("https://example.com:8443/api")).toBe(
+        "https://example.com:8443/api",
+      );
+    });
+  });
+
+  describe("should return undefined for dangerous protocols (XSS prevention)", () => {
+    test("javascript: protocol", () => {
+      expect(safeExternalUrl("javascript:alert(1)")).toBeUndefined();
+    });
+
+    test("javascript: protocol with encoded characters", () => {
+      expect(
+        safeExternalUrl("javascript:alert(document.cookie)"),
+      ).toBeUndefined();
+    });
+
+    test("data: protocol", () => {
+      expect(
+        safeExternalUrl("data:text/html,<script>alert(1)</script>"),
+      ).toBeUndefined();
+    });
+
+    test("vbscript: protocol", () => {
+      expect(safeExternalUrl("vbscript:msgbox(1)")).toBeUndefined();
+    });
+
+    test("file: protocol", () => {
+      expect(safeExternalUrl("file:///etc/passwd")).toBeUndefined();
+    });
+
+    test("ftp: protocol", () => {
+      expect(safeExternalUrl("ftp://example.com")).toBeUndefined();
+    });
+  });
+
+  describe("should return undefined for null, undefined, and empty values", () => {
+    test("null", () => {
+      expect(safeExternalUrl(null)).toBeUndefined();
+    });
+
+    test("undefined", () => {
+      expect(safeExternalUrl(undefined)).toBeUndefined();
+    });
+
+    test("empty string", () => {
+      expect(safeExternalUrl("")).toBeUndefined();
+    });
+  });
+
+  describe("should return undefined for invalid URLs", () => {
+    test("malformed URL", () => {
+      expect(safeExternalUrl("not-a-url")).toBeUndefined();
+    });
+
+    test("URL without protocol", () => {
+      expect(safeExternalUrl("example.com")).toBeUndefined();
+    });
+
+    test("invalid characters", () => {
+      expect(safeExternalUrl("https://exam ple.com")).toBeUndefined();
+    });
+  });
+
+  describe("edge cases", () => {
+    test("protocol-relative URL (//example.com)", () => {
+      // Protocol-relative URLs are not valid for URL constructor without a base
+      expect(safeExternalUrl("//example.com")).toBeUndefined();
+    });
+
+    test("URL with credentials", () => {
+      expect(safeExternalUrl("https://user:pass@example.com")).toBe(
+        "https://user:pass@example.com",
+      );
+    });
+
+    test("localhost URL", () => {
+      expect(safeExternalUrl("http://localhost:3000")).toBe(
+        "http://localhost:3000",
+      );
+    });
+
+    test("IP address URL", () => {
+      expect(safeExternalUrl("https://192.168.1.1")).toBe(
+        "https://192.168.1.1",
+      );
+    });
+
+    test("mixed case protocol (hTTps:)", () => {
+      // URL constructor normalizes protocols to lowercase
+      expect(safeExternalUrl("hTTps://example.com")).toBe(
+        "hTTps://example.com",
+      );
+    });
+  });
+});

--- a/src/ui/core/utils/urlValidation.ts
+++ b/src/ui/core/utils/urlValidation.ts
@@ -1,0 +1,28 @@
+/**
+ * Parses a URL and returns it only if the protocol is http: or https:.
+ * This prevents XSS attacks via javascript:, data:, vbscript:, and other malicious protocols.
+ *
+ * @param url - The URL string to validate
+ * @returns The original URL string if safe (http/https), or undefined otherwise
+ *
+ * @example
+ * safeExternalUrl('https://example.com') // 'https://example.com'
+ * safeExternalUrl('http://example.com')  // 'http://example.com'
+ * safeExternalUrl('javascript:alert(1)') // undefined
+ * safeExternalUrl('data:text/html,<script>') // undefined
+ * safeExternalUrl(null) // undefined
+ */
+export const safeExternalUrl = (
+  url: string | undefined | null,
+): string | undefined => {
+  if (!url) {
+    return undefined;
+  }
+
+  try {
+    const parsed = new URL(url);
+    return ["http:", "https:"].includes(parsed.protocol) ? url : undefined;
+  } catch {
+    return undefined;
+  }
+};

--- a/src/ui/environment/views/AgentStatusView.tsx
+++ b/src/ui/environment/views/AgentStatusView.tsx
@@ -22,6 +22,7 @@ import React, { useMemo } from "react";
 import { Link } from "react-router-dom";
 
 import { VCenterSetupInstructions } from "../../core/components/VCenterSetupInstructions";
+import { safeExternalUrl } from "../../core/utils/urlValidation";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace AgentStatusView {
@@ -38,6 +39,8 @@ export namespace AgentStatusView {
 const StatusInfoWaitingForCredentials: React.FC<{
   credentialUrl?: Agent["credentialUrl"];
 }> = ({ credentialUrl }) => {
+  const safeUrl = safeExternalUrl(credentialUrl);
+
   return (
     <>
       <Content>
@@ -46,9 +49,9 @@ const StatusInfoWaitingForCredentials: React.FC<{
           VMware environment.
         </Content>
       </Content>
-      {credentialUrl && (
-        <Link to={credentialUrl} target="_blank">
-          {credentialUrl}
+      {safeUrl && (
+        <Link to={safeUrl} target="_blank">
+          {safeUrl}
         </Link>
       )}
     </>

--- a/src/ui/environment/views/Environment.tsx
+++ b/src/ui/environment/views/Environment.tsx
@@ -8,6 +8,7 @@ import {
 import React, { useCallback, useEffect, useState } from "react";
 
 import { LoadingSpinner } from "../../core/components/LoadingSpinner";
+import { safeExternalUrl } from "../../core/utils/urlValidation";
 import { useEnvironmentPage } from "../view-models/EnvironmentPageContext";
 import type { EnvironmentPageViewModel } from "../view-models/useEnvironmentPageViewModel";
 import { DiscoverySourceSetupModal } from "./DiscoverySourceSetupModal";
@@ -126,14 +127,16 @@ const EnvironmentContent: React.FC<EnvironmentContentProps> = ({ vm }) => {
               variant="custom"
               title="Discovery VM"
               actionLinks={
-                <AlertActionLink
-                  component="a"
-                  href={sourceSelected?.agent.credentialUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {sourceSelected?.agent.credentialUrl}
-                </AlertActionLink>
+                safeExternalUrl(sourceSelected?.agent.credentialUrl) ? (
+                  <AlertActionLink
+                    component="a"
+                    href={safeExternalUrl(sourceSelected.agent.credentialUrl)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {sourceSelected.agent.credentialUrl}
+                  </AlertActionLink>
+                ) : undefined
               }
             >
               <Content>


### PR DESCRIPTION
Introduce safeExternalUrl() helper to validate agent credentialUrl before rendering. Only http: and https: protocols are allowed, blocking javascript:, data:, and other malicious schemes.

CVE-ID: CVE-2026-53473