### PR TITLE
ECOPROJECT-4750 | fix: Show Download OVA modal in assessment creation flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3811,9 +3811,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -15582,12 +15582,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -15597,13 +15597,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/src/ui/assessment/view-models/useCreateFromOvaViewModel.ts
+++ b/src/ui/assessment/view-models/useCreateFromOvaViewModel.ts
@@ -35,6 +35,12 @@ export interface CreateFromOvaViewModel {
   setIsSetupModalOpen: (val: boolean) => void;
   isStepsModalOpen: boolean;
   setIsStepsModalOpen: (val: boolean) => void;
+  isDownloadModalOpen: boolean;
+  setIsDownloadModalOpen: (val: boolean) => void;
+  downloadModalUrl: string;
+  setDownloadModalUrl: (url: string) => void;
+  downloadModalSourceName: string;
+  setDownloadModalSourceName: (name: string) => void;
 
   // Submission
   isCreatingAssessment: boolean;
@@ -94,6 +100,10 @@ export const useCreateFromOvaViewModel = (): CreateFromOvaViewModel => {
   // Modal state
   const [isSetupModalOpen, setIsSetupModalOpen] = React.useState(false);
   const [isStepsModalOpen, setIsStepsModalOpen] = React.useState(false);
+  const [isDownloadModalOpen, setIsDownloadModalOpen] = React.useState(false);
+  const [downloadModalUrl, setDownloadModalUrl] = React.useState("");
+  const [downloadModalSourceName, setDownloadModalSourceName] =
+    React.useState("");
 
   // Error dismiss flag (cleared on next submission, set when user edits name)
   const [dismissSubmitError, setDismissSubmitError] = React.useState(false);
@@ -235,6 +245,12 @@ export const useCreateFromOvaViewModel = (): CreateFromOvaViewModel => {
     setIsSetupModalOpen,
     isStepsModalOpen,
     setIsStepsModalOpen,
+    isDownloadModalOpen,
+    setIsDownloadModalOpen,
+    downloadModalUrl,
+    setDownloadModalUrl,
+    downloadModalSourceName,
+    setDownloadModalSourceName,
 
     isCreatingAssessment: submitState.loading,
     isCreatingSource: refreshAfterCloseState.loading,

--- a/src/ui/assessment/views/CreateFromOva.tsx
+++ b/src/ui/assessment/views/CreateFromOva.tsx
@@ -23,7 +23,10 @@ import { routes } from "../../../routing/Routes";
 import { AppPage } from "../../core/components/AppPage";
 import { safeExternalUrl } from "../../core/utils/urlValidation";
 import { EnvironmentPageProvider } from "../../environment/view-models/EnvironmentPageContext";
-import { EnvironmentModal } from "../../environment/views/environment-modals";
+import {
+  DownloadEnvironmentModal,
+  EnvironmentModal,
+} from "../../environment/views/environment-modals";
 import { SourcesTable } from "../../environment/views/SourcesTable";
 import { useCreateFromOvaViewModel } from "../view-models/useCreateFromOvaViewModel";
 import { MigrationAssessmentStepsModal } from "./MigrationAssessmentStepsModal";
@@ -239,9 +242,24 @@ const CreateFromOvaContent: React.FC = () => {
         <EnvironmentModal
           isOpen={vm.isSetupModalOpen}
           onClose={vm.handleSetupModalClose}
-          onSuccess={() => {
+          onSuccess={(url, name) => {
+            vm.setIsSetupModalOpen(false);
+            vm.setDownloadModalUrl(url);
+            vm.setDownloadModalSourceName(name);
+            vm.setIsDownloadModalOpen(true);
+          }}
+        />
+
+        <DownloadEnvironmentModal
+          isOpen={vm.isDownloadModalOpen}
+          onClose={() => {
+            vm.setIsDownloadModalOpen(false);
+          }}
+          downloadUrl={vm.downloadModalUrl}
+          sourceName={vm.downloadModalSourceName}
+          onAfterDownload={async () => {
+            await vm.handleSetupModalAfterDownload();
             vm.envVm.setDownloadUrl("");
-            void vm.handleSetupModalAfterDownload();
           }}
         />
 


### PR DESCRIPTION
When creating a new environment during assessment creation (Assessments → with Discovery OVA → Add environment → Generate OVA), the UI would hang after OVA generation instead of showing the Download OVA modal.

This was a regression from commit da01827 which refactored the monolithic DiscoverySourceSetupModal into separate EnvironmentModal and DownloadEnvironmentModal components. The assessment flow was not updated to show the download modal after generation completed.

Changes:
- Add download modal state (isDownloadModalOpen, downloadModalUrl, downloadModalSourceName) to CreateFromOvaViewModel
- Update EnvironmentModal onSuccess callback to accept (url, name) parameters and open DownloadEnvironmentModal
- Add DownloadEnvironmentModal to CreateFromOva component

The flow now matches the Environments tab behavior: EnvironmentModal for configuration → DownloadEnvironmentModal for download instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a download modal to the OVA environment creation workflow, appearing after environment setup completion.

* **Improvements**
  * Enhanced the import process flow with better state management between setup and download stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->