### PR TITLE
ECOPROJECT-4777 | feat: add a popover with info about how we calculate migration complexity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16619,9 +16619,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "js-cookie": ">=3.0.7",
     "sanitize-html": ">=2.17.4",
     "serialize-javascript": ">=7.0.3",
+    "shell-quote": ">=1.8.4",
     "uuid": ">=14.0.0"
   },
   "insights": {

--- a/src/ui/report/views/cluster-sizer/ComplexityResult.tsx
+++ b/src/ui/report/views/cluster-sizer/ComplexityResult.tsx
@@ -31,6 +31,8 @@ import {
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import React, { useState } from "react";
 
+import { COMPLEXITY_COLORS, COMPLEXITY_LABELS } from "./constants";
+import MigrationComplexityHelpPopover from "./MigrationComplexityHelpPopover";
 import { durationToHours } from "./timeUtils";
 
 interface ComplexityResultProps {
@@ -56,6 +58,12 @@ interface ChartDatum {
 
 const headerStyle = css`
   margin-bottom: var(--pf-t--global--spacer--200);
+`;
+
+const titleWithHelpStyle = css`
+  display: flex;
+  align-items: center;
+  gap: var(--pf-t--global--spacer--100);
 `;
 
 const legendContainerStyle = css`
@@ -94,23 +102,6 @@ const formatPercentage = (value: number): string =>
     minimumFractionDigits: 1,
     maximumFractionDigits: 1,
   });
-
-// Complexity colors based on score
-const COMPLEXITY_COLORS: Record<number, string> = {
-  0: "#8A8D90", // Unknown - gray
-  1: "#5BA352", // Easiest - green
-  2: "#009596", // Easy - cyan
-  3: "#F0AB00", // Moderate - orange/yellow
-  4: "#C9190B", // Hardest - red
-};
-
-const COMPLEXITY_LABELS: Record<number, string> = {
-  0: "Unknown",
-  1: "Easiest",
-  2: "Easy",
-  3: "Moderate",
-  4: "Hardest",
-};
 
 // Disk size tier labels based on score
 const DISK_SIZE_LABELS: Record<number, string> = {
@@ -564,7 +555,10 @@ export const ComplexityResult: React.FC<ComplexityResultProps> = ({
         >
           <FlexItem>
             <div className={headerStyle}>
-              <Title headingLevel="h2">Migration complexity</Title>
+              <div className={titleWithHelpStyle}>
+                <Title headingLevel="h2">Migration complexity</Title>
+                <MigrationComplexityHelpPopover />
+              </div>
             </div>
           </FlexItem>
           <FlexItem>

--- a/src/ui/report/views/cluster-sizer/MigrationComplexityHelpPopover.tsx
+++ b/src/ui/report/views/cluster-sizer/MigrationComplexityHelpPopover.tsx
@@ -1,0 +1,83 @@
+import { css } from "@emotion/css";
+import { Badge } from "@patternfly/react-core";
+import React from "react";
+
+import { COMPLEXITY_COLORS, COMPLEXITY_LABELS } from "./constants";
+import PopoverIcon from "./PopoverIcon";
+
+const COMPLEXITY_TIER_SCORES = [1, 2, 3, 4, 0] as const;
+
+const COMPLEXITY_TIER_DESCRIPTIONS: Record<number, string> = {
+  1: "Modern, natively supported operating systems (e.g., RHEL 8/9) paired with smaller disk sizes under 10 TB. These workloads present the lowest risk and fastest turnaround.",
+  2: "Typically features modern operating systems with moderate disk sizes (10–20 TB), or slightly older but well-documented operating systems with small disk sizes.",
+  3: "Workloads with larger disk sizes (20–50 TB) that require longer data transfer times, or legacy operating systems that require specific configuration adjustments.",
+  4: "Massive disk sizes (50+ TB) requiring extended migration windows, or heavily outdated/unsupported operating systems that require complex manual intervention.",
+  0: "The operating system is not recognized by the built-in migration list. Because the planner cannot verify OS compatibility, a reliable complexity and risk assessment cannot be generated.",
+};
+
+const tierListStyle = css`
+  list-style: none;
+  padding: 0;
+  margin: var(--pf-t--global--spacer--200) 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--pf-t--global--spacer--300);
+`;
+
+const tierItemStyle = css`
+  display: flex;
+  gap: var(--pf-t--global--spacer--200);
+  align-items: flex-start;
+`;
+
+const tierBadgeStyle = css`
+  flex-shrink: 0;
+`;
+
+const tierDefinitionsTitleStyle = css`
+  font-weight: var(--pf-t--global--font--weight--body--bold);
+  margin-top: var(--pf-t--global--spacer--200);
+`;
+
+const MigrationComplexityHelpBody: React.FC = () => (
+  <div>
+    <p>
+      Complexity is determined by combining a virtual machine&apos;s Operating
+      System support tier and its total Disk Size.
+    </p>
+    <div className={tierDefinitionsTitleStyle}>
+      Complexity Tier Definitions:
+    </div>
+    <ul className={tierListStyle}>
+      {COMPLEXITY_TIER_SCORES.map((score) => (
+        <li key={score} className={tierItemStyle}>
+          <Badge
+            className={tierBadgeStyle}
+            style={{
+              backgroundColor: COMPLEXITY_COLORS[score],
+              color: "white",
+            }}
+          >
+            {COMPLEXITY_LABELS[score]}
+          </Badge>
+          <span>{COMPLEXITY_TIER_DESCRIPTIONS[score]}</span>
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+export const MigrationComplexityHelpPopover: React.FC = () => (
+  <PopoverIcon
+    noVerticalAlign
+    maxWidth="40rem"
+    headerContent="How is migration complexity calculated?"
+    bodyContent={<MigrationComplexityHelpBody />}
+    buttonOuiaId="migration-complexity-help"
+    aria-label="Migration complexity help"
+  />
+);
+
+MigrationComplexityHelpPopover.displayName = "MigrationComplexityHelpPopover";
+
+export default MigrationComplexityHelpPopover;

--- a/src/ui/report/views/cluster-sizer/PopoverIcon.tsx
+++ b/src/ui/report/views/cluster-sizer/PopoverIcon.tsx
@@ -39,7 +39,10 @@ const PopoverIcon: React.FC<PopoverIconProps> = ({
       }
       component={component}
       variant={variant}
-      onClick={(e) => e.preventDefault()}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      }}
       className={classNames(
         "pf-v6-c-form__group-label-help",
         "pf-v6-u-p-0",

--- a/src/ui/report/views/cluster-sizer/constants.ts
+++ b/src/ui/report/views/cluster-sizer/constants.ts
@@ -271,6 +271,24 @@ export const WORKER_NODE_CONSTRAINTS = {
 /**
  * Form field labels and help text
  */
+/** Complexity tier colors keyed by score (0 = Unknown, 1 = Easiest, …, 4 = Hardest). */
+export const COMPLEXITY_COLORS: Record<number, string> = {
+  0: "#8A8D90", // Unknown - gray
+  1: "#5BA352", // Easiest - green
+  2: "#009596", // Easy - cyan
+  3: "#F0AB00", // Moderate - orange/yellow
+  4: "#C9190B", // Hardest - red
+};
+
+/** Complexity tier labels keyed by score. */
+export const COMPLEXITY_LABELS: Record<number, string> = {
+  0: "Unknown",
+  1: "Easiest",
+  2: "Easy",
+  3: "Moderate",
+  4: "Hardest",
+};
+
 export const FORM_LABELS = {
   workerNodeSize: {
     label: "Worker Node Size",


### PR DESCRIPTION
<img width="1182" height="570" alt="Captura desde 2026-06-10 08-21-13" src="https://github.com/user-attachments/assets/92accd22-3880-4142-bc68-14df6b6905fd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a help popover in the migration complexity section displaying complexity tiers with color-coded badges and tier descriptions.

* **Bug Fixes**
  * Improved event handling in the popover icon to prevent unintended click propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->