### PR TITLE
ECOPROJECT-3795 | refactor: change empty state for cards without data

### DIFF
--- a/src/ui/core/components/CardEmptyState.tsx
+++ b/src/ui/core/components/CardEmptyState.tsx
@@ -1,0 +1,40 @@
+import { css } from "@emotion/css";
+import { EmptyState, EmptyStateBody } from "@patternfly/react-core";
+import { RhUiSearchIcon } from "@patternfly/react-icons";
+import React from "react";
+
+export const CARD_EMPTY_STATE_DESCRIPTION =
+  "This data is not available for older inventories or certain imported reports.";
+
+const cardEmptyStateContainer = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  flex: 1;
+  min-height: 250px;
+`;
+
+export interface CardEmptyStateProps {
+  title: string;
+  description?: string;
+}
+
+export const CardEmptyState: React.FC<CardEmptyStateProps> = ({
+  title,
+  description = CARD_EMPTY_STATE_DESCRIPTION,
+}) => {
+  return (
+    <div className={cardEmptyStateContainer}>
+      <EmptyState
+        headingLevel="h4"
+        icon={RhUiSearchIcon}
+        titleText={title}
+        variant="sm"
+      >
+        <EmptyStateBody>{description}</EmptyStateBody>
+      </EmptyState>
+    </div>
+  );
+};
+
+CardEmptyState.displayName = "CardEmptyState";

--- a/src/ui/core/components/MigrationDonutChart.tsx
+++ b/src/ui/core/components/MigrationDonutChart.tsx
@@ -2,6 +2,8 @@ import { ChartDonut, ChartLabel, ChartLegend } from "@patternfly/react-charts";
 import { Flex, FlexItem } from "@patternfly/react-core";
 import React, { useCallback, useMemo } from "react";
 
+import { CardEmptyState } from "./CardEmptyState";
+
 interface OSData {
   name: string;
   count: number;
@@ -45,6 +47,8 @@ interface MigrationDonutChartProps {
     percent: number;
     total: number;
   }) => string;
+  emptyStateTitle?: string;
+  emptyStateDescription?: string;
 }
 
 const legendColors = [
@@ -76,6 +80,8 @@ const MigrationDonutChart: React.FC<MigrationDonutChartProps> = ({
   donutThickness = 45,
   padAngle = 1,
   tooltipLabelFormatter,
+  emptyStateTitle = "Data not collected",
+  emptyStateDescription,
 }: MigrationDonutChartProps) => {
   const dynamicLegend = useMemo<Record<string, string>>(() => {
     const legendMap: Record<string, string> = {};
@@ -152,9 +158,10 @@ const MigrationDonutChart: React.FC<MigrationDonutChartProps> = ({
 
   if (!data || data.length === 0) {
     return (
-      <div style={{ padding: "20px", textAlign: "center" }}>
-        No data available
-      </div>
+      <CardEmptyState
+        title={emptyStateTitle}
+        description={emptyStateDescription}
+      />
     );
   }
 

--- a/src/ui/report/views/assessment-report/ClustersOverview.tsx
+++ b/src/ui/report/views/assessment-report/ClustersOverview.tsx
@@ -14,7 +14,9 @@ import {
 } from "@patternfly/react-core";
 import React, { useMemo, useState } from "react";
 
+import { CardEmptyState } from "../../../core/components/CardEmptyState";
 import MigrationDonutChart from "../../../core/components/MigrationDonutChart";
+import { REPORT_CARD_EMPTY_STATE_TITLES } from "./constants";
 import { dashboardCard } from "./styles";
 
 // ---------------------------------------------------------------------------
@@ -539,6 +541,7 @@ export const ClustersOverview: React.FC<ClustersOverviewProps> = ({
                   itemsPerRow={Math.ceil(vmByClusterData.chartData.length / 2)}
                   labelFontSize={18}
                   marginLeft="12%"
+                  emptyStateTitle={REPORT_CARD_EMPTY_STATE_TITLES.clusters}
                   tooltipLabelFormatter={({ datum, percent }) =>
                     `${datum.countDisplay}\n${percent.toFixed(1)}%`
                   }
@@ -565,6 +568,7 @@ export const ClustersOverview: React.FC<ClustersOverviewProps> = ({
                   )}
                   labelFontSize={17}
                   marginLeft="0%"
+                  emptyStateTitle={REPORT_CARD_EMPTY_STATE_TITLES.clusters}
                   tooltipLabelFormatter={({ datum, percent }) =>
                     `${datum.countDisplay}\n${percent.toFixed(1)}%`
                   }
@@ -577,14 +581,9 @@ export const ClustersOverview: React.FC<ClustersOverviewProps> = ({
                   {VIEW_MODE_LABELS["cpuOverCommitment"]}
                 </div>
                 {cpuOverCommitmentData.chartData.length === 0 ? (
-                  <div
-                    style={{
-                      color: "var(--pf-t--global--text--color--subtle)",
-                      textAlign: "center",
-                    }}
-                  >
-                    This inventory has no cpuOverCommitment information.
-                  </div>
+                  <CardEmptyState
+                    title={REPORT_CARD_EMPTY_STATE_TITLES.cpuOvercommitment}
+                  />
                 ) : (
                   <>
                     <div className={cpuOvercommitBoxes}>
@@ -630,14 +629,9 @@ export const ClustersOverview: React.FC<ClustersOverviewProps> = ({
         ) : viewMode === "cpuOverCommitment" ? (
           <>
             {chartData.length === 0 ? (
-              <div
-                style={{
-                  color: "var(--pf-t--global--text--color--subtle)",
-                  textAlign: "center",
-                }}
-              >
-                This inventory has no cpuOverCommitment information.
-              </div>
+              <CardEmptyState
+                title={REPORT_CARD_EMPTY_STATE_TITLES.cpuOvercommitment}
+              />
             ) : (
               <>
                 <div className={cpuOvercommitBoxes}>
@@ -684,6 +678,7 @@ export const ClustersOverview: React.FC<ClustersOverviewProps> = ({
             itemsPerRow={Math.ceil(chartData.length / 2)}
             labelFontSize={viewMode === "vmByCluster" ? 18 : 17}
             marginLeft={viewMode === "vmByCluster" ? "12%" : "0%"}
+            emptyStateTitle={REPORT_CARD_EMPTY_STATE_TITLES.clusters}
             tooltipLabelFormatter={({ datum, percent }) =>
               `${datum.countDisplay}\n${percent.toFixed(1)}%`
             }

--- a/src/ui/report/views/assessment-report/CpuAndMemoryOverview.tsx
+++ b/src/ui/report/views/assessment-report/CpuAndMemoryOverview.tsx
@@ -13,6 +13,7 @@ import {
 import React, { useMemo, useState } from "react";
 
 import MigrationDonutChart from "../../../core/components/MigrationDonutChart";
+import { REPORT_CARD_EMPTY_STATE_TITLES } from "./constants";
 import { dashboardCard } from "./styles";
 
 interface CpuAndMemoryOverviewProps {
@@ -240,6 +241,7 @@ export const CpuAndMemoryOverview: React.FC<CpuAndMemoryOverviewProps> = ({
                 itemsPerRow={Math.ceil(memorySlices.length / 2)}
                 labelFontSize={18}
                 marginLeft="0%"
+                emptyStateTitle={REPORT_CARD_EMPTY_STATE_TITLES.memory}
                 tooltipLabelFormatter={({ datum, percent }) =>
                   `${datum.countDisplay}\n${percent.toFixed(1)}%`
                 }
@@ -269,6 +271,7 @@ export const CpuAndMemoryOverview: React.FC<CpuAndMemoryOverviewProps> = ({
                 itemsPerRow={Math.ceil(vcpuSlices.length / 2)}
                 labelFontSize={18}
                 marginLeft="52%"
+                emptyStateTitle={REPORT_CARD_EMPTY_STATE_TITLES.cpu}
                 tooltipLabelFormatter={({ datum, percent }) =>
                   `${datum.countDisplay}\n${percent.toFixed(1)}%`
                 }
@@ -297,6 +300,11 @@ export const CpuAndMemoryOverview: React.FC<CpuAndMemoryOverviewProps> = ({
             itemsPerRow={Math.ceil(activeSlices.length / 2)}
             labelFontSize={18}
             marginLeft="52%"
+            emptyStateTitle={
+              viewMode === "memoryTiers"
+                ? REPORT_CARD_EMPTY_STATE_TITLES.memory
+                : REPORT_CARD_EMPTY_STATE_TITLES.cpu
+            }
             tooltipLabelFormatter={({ datum, percent }) =>
               `${datum.countDisplay}\n${percent.toFixed(1)}%`
             }

--- a/src/ui/report/views/assessment-report/HostsOverview.tsx
+++ b/src/ui/report/views/assessment-report/HostsOverview.tsx
@@ -9,6 +9,7 @@ import {
 import React, { useMemo } from "react";
 
 import MigrationDonutChart from "../../../core/components/MigrationDonutChart";
+import { REPORT_CARD_EMPTY_STATE_TITLES } from "./constants";
 import { dashboardCard } from "./styles";
 
 type HostLike = {
@@ -138,6 +139,7 @@ export const HostsOverview: React.FC<HostsOverviewProps> = ({
           itemsPerRow={2}
           labelFontSize={16}
           marginLeft="0%"
+          emptyStateTitle={REPORT_CARD_EMPTY_STATE_TITLES.hosts}
           tooltipLabelFormatter={({ datum, percent }) =>
             `${datum.countDisplay}\n${percent.toFixed(1)}%`
           }

--- a/src/ui/report/views/assessment-report/NetworkOverview.tsx
+++ b/src/ui/report/views/assessment-report/NetworkOverview.tsx
@@ -17,6 +17,7 @@ import {
 import React, { useMemo, useState } from "react";
 
 import MigrationDonutChart from "../../../core/components/MigrationDonutChart";
+import { REPORT_CARD_EMPTY_STATE_TITLES } from "./constants";
 import { dashboardCard } from "./styles";
 
 // Reuse an extended palette similar to ClustersOverview to provide stable colors
@@ -330,6 +331,7 @@ export const NetworkOverview: React.FC<NetworkOverviewProps> = ({
                 subTitleColor="var(--pf-t--global--text--color--subtle)"
                 itemsPerRow={Math.ceil(chartData.length / 2)}
                 labelFontSize={18}
+                emptyStateTitle={REPORT_CARD_EMPTY_STATE_TITLES.networks}
                 tooltipLabelFormatter={({ datum, percent }) =>
                   `${datum.countDisplay}\n${percent.toFixed(1)}%\nVLAN: ${legendVlanMap[datum.legendCategory] ?? "-"}`
                 }
@@ -351,6 +353,7 @@ export const NetworkOverview: React.FC<NetworkOverviewProps> = ({
                 subTitleColor="var(--pf-t--global--text--color--subtle)"
                 itemsPerRow={Math.ceil((nicChartData?.length ?? 0) / 2)}
                 labelFontSize={18}
+                emptyStateTitle={REPORT_CARD_EMPTY_STATE_TITLES.nicCount}
                 tooltipLabelFormatter={({ datum, percent }) =>
                   `${datum.countDisplay}\n${percent.toFixed(1)}%`
                 }
@@ -372,6 +375,7 @@ export const NetworkOverview: React.FC<NetworkOverviewProps> = ({
                 subTitleColor="var(--pf-t--global--text--color--subtle)"
                 itemsPerRow={Math.ceil(chartData.length / 2)}
                 labelFontSize={18}
+                emptyStateTitle={REPORT_CARD_EMPTY_STATE_TITLES.networks}
                 tooltipLabelFormatter={({ datum, percent }) =>
                   `${datum.countDisplay}\n${percent.toFixed(1)}%\nVLAN: ${legendVlanMap[datum.legendCategory] ?? "-"}`
                 }
@@ -390,6 +394,7 @@ export const NetworkOverview: React.FC<NetworkOverviewProps> = ({
                 subTitleColor="var(--pf-t--global--text--color--subtle)"
                 itemsPerRow={Math.ceil((nicChartData?.length ?? 0) / 2)}
                 labelFontSize={18}
+                emptyStateTitle={REPORT_CARD_EMPTY_STATE_TITLES.nicCount}
                 tooltipLabelFormatter={({ datum, percent }) =>
                   `${datum.countDisplay}\n${percent.toFixed(1)}%`
                 }

--- a/src/ui/report/views/assessment-report/OSDistribution.tsx
+++ b/src/ui/report/views/assessment-report/OSDistribution.tsx
@@ -11,8 +11,13 @@ import {
 import { RhUiInformationFillIcon } from "@patternfly/react-icons";
 import React from "react";
 
+import { CardEmptyState } from "../../../core/components/CardEmptyState";
 import MigrationChart from "../../../core/components/MigrationChart";
-import { chartColorFailure, chartColorSuccess } from "./constants";
+import {
+  chartColorFailure,
+  chartColorSuccess,
+  REPORT_CARD_EMPTY_STATE_TITLES,
+} from "./constants";
 import { dashboardCard } from "./styles";
 
 interface OSDistributionProps {
@@ -108,6 +113,12 @@ export const OSBarChart: React.FC<OSBarChartProps> = ({
       : "Not supported by MTV",
     infoText: osInfo.upgradeRecommendation,
   }));
+
+  if (chartData.length === 0) {
+    return (
+      <CardEmptyState title={REPORT_CARD_EMPTY_STATE_TITLES.operatingSystems} />
+    );
+  }
 
   // Define custom colors: green for supported, red for not supported
   const customLegend = {

--- a/src/ui/report/views/assessment-report/StorageOverview.tsx
+++ b/src/ui/report/views/assessment-report/StorageOverview.tsx
@@ -26,7 +26,9 @@ import {
 } from "@patternfly/react-core";
 import React, { useMemo, useState } from "react";
 
+import { CardEmptyState } from "../../../core/components/CardEmptyState";
 import MigrationDonutChart from "../../../core/components/MigrationDonutChart";
+import { REPORT_CARD_EMPTY_STATE_TITLES } from "./constants";
 import {
   dashboardCard,
   storageCardOverflowHidden,
@@ -36,7 +38,6 @@ import {
   storageExportSectionTitle,
   storageFlexFullWidth,
   storageMenuToggleMinWidth,
-  storageNoDataContainer,
   storageTotalsNote,
 } from "./styles";
 
@@ -408,7 +409,9 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
         {!isExportMode || !exportAllViews ? (
           viewMode === "vmCountByDiskType" ? (
             diskTypeChartData.length === 0 ? (
-              <div className={storageNoDataContainer}>No Data Available</div>
+              <CardEmptyState
+                title={REPORT_CARD_EMPTY_STATE_TITLES.diskTypes}
+              />
             ) : (
               <>
                 <div className={storageChartWrapper}>
@@ -491,6 +494,7 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
               itemsPerRow={Math.ceil(sharedDisksChartData.length / 2)}
               labelFontSize={18}
               marginLeft="52%"
+              emptyStateTitle={REPORT_CARD_EMPTY_STATE_TITLES.storage}
               tooltipLabelFormatter={({ datum, percent }) =>
                 `${datum.countDisplay}\n${percent.toFixed(1)}%`
               }
@@ -516,6 +520,7 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
               itemsPerRow={Math.min(Math.ceil(chartData.length / 2), 2)}
               legendWidth={420}
               labelFontSize={14}
+              emptyStateTitle={REPORT_CARD_EMPTY_STATE_TITLES.storage}
               tooltipLabelFormatter={({ datum, percent }) =>
                 `${datum.countDisplay}\n${percent.toFixed(1)}%`
               }
@@ -611,6 +616,7 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
                 )}
                 legendWidth={420}
                 labelFontSize={14}
+                emptyStateTitle={REPORT_CARD_EMPTY_STATE_TITLES.storage}
                 tooltipLabelFormatter={({ datum, percent }) =>
                   `${datum.countDisplay}\n${percent.toFixed(1)}%`
                 }
@@ -635,6 +641,7 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
                 )}
                 legendWidth={420}
                 labelFontSize={14}
+                emptyStateTitle={REPORT_CARD_EMPTY_STATE_TITLES.storage}
                 tooltipLabelFormatter={({ datum, percent }) =>
                   `${datum.countDisplay}\n${percent.toFixed(1)}%`
                 }
@@ -656,6 +663,7 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
                 itemsPerRow={Math.ceil(sharedDisksChartData.length / 2)}
                 labelFontSize={18}
                 marginLeft="52%"
+                emptyStateTitle={REPORT_CARD_EMPTY_STATE_TITLES.storage}
                 tooltipLabelFormatter={({ datum, percent }) =>
                   `${datum.countDisplay}\n${percent.toFixed(1)}%`
                 }

--- a/src/ui/report/views/assessment-report/VMMigrationStatus.tsx
+++ b/src/ui/report/views/assessment-report/VMMigrationStatus.tsx
@@ -3,7 +3,11 @@ import RhUiVirtualMachineIcon from "@patternfly/react-icons/dist/esm/icons/virtu
 import React from "react";
 
 import MigrationDonutChart from "../../../core/components/MigrationDonutChart";
-import { chartColorFailure, chartColorSuccess } from "./constants";
+import {
+  chartColorFailure,
+  chartColorSuccess,
+  REPORT_CARD_EMPTY_STATE_TITLES,
+} from "./constants";
 import { dashboardCard } from "./styles";
 
 interface VmMigrationStatusProps {
@@ -65,6 +69,7 @@ export const VMMigrationStatus: React.FC<VmMigrationStatusProps> = ({
           labelFontSize={18}
           itemsPerRow={2}
           marginLeft="40%"
+          emptyStateTitle={REPORT_CARD_EMPTY_STATE_TITLES.migrationStatus}
         />
       </CardBody>
     </Card>

--- a/src/ui/report/views/assessment-report/constants.ts
+++ b/src/ui/report/views/assessment-report/constants.ts
@@ -8,3 +8,18 @@ import { chart_color_yellow_300 } from "@patternfly/react-tokens/dist/esm/chart_
  */
 export const chartColorSuccess = chart_color_blue_300.value;
 export const chartColorFailure = chart_color_yellow_300.value;
+
+export const REPORT_CARD_EMPTY_STATE_TITLES = {
+  networks: "Network data not collected",
+  nicCount: "NIC count data not collected",
+  hosts: "Host data not collected",
+  cpuMemory: "CPU and memory data not collected",
+  cpu: "CPU data not collected",
+  memory: "Memory data not collected",
+  storage: "Storage data not collected",
+  diskTypes: "Disk type data not collected",
+  clusters: "Cluster data not collected",
+  cpuOvercommitment: "CPU overcommitment data not collected",
+  operatingSystems: "Operating system data not collected",
+  migrationStatus: "Migration status data not collected",
+} as const;

--- a/src/ui/report/views/assessment-report/styles.ts
+++ b/src/ui/report/views/assessment-report/styles.ts
@@ -84,11 +84,6 @@ export const storageMenuToggleMinWidth = css`
   min-width: 250px;
 `;
 
-export const storageNoDataContainer = css`
-  padding: 20px;
-  text-align: center;
-`;
-
 export const storageChartWrapper = css`
   display: flex;
   justify-content: center;


### PR DESCRIPTION
- New CardEmptyState component created
- Default description: "This data is not available for older inventories or certain imported reports."
- MigrationDonutChart now renders CardEmptyState when chart data is empty with configurable emptyStateTitle and emptyStateDescription props

[recording - 2026-06-11T135553.929.webm](https://github.com/user-attachments/assets/96ea18f0-767d-42ac-892e-06e66bdb58da)
