### PR TITLE
ECOPROJECT-4632 | fix: solving color inconsistency between dark and light mode

### DIFF
--- a/src/lib/patternfly/__tests__/flyoutAppendTo.test.ts
+++ b/src/lib/patternfly/__tests__/flyoutAppendTo.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { getFlyoutAppendTo } from "../flyoutAppendTo";
+
+describe("getFlyoutAppendTo", () => {
+  it("appends flyouts to document.body for PatternFly typography inheritance", () => {
+    expect(getFlyoutAppendTo()).toBe(document.body);
+  });
+});

--- a/src/lib/patternfly/flyoutAppendTo.ts
+++ b/src/lib/patternfly/flyoutAppendTo.ts
@@ -1,0 +1,83 @@
+import { css } from "@emotion/css";
+
+/**
+ * DOM target for portaled PatternFly flyouts (Popover, Tooltip).
+ * Uses `document.body` so flyouts inherit Red Hat Text from PatternFly base styles.
+ * Appending to `document.documentElement` (where the theme class often lives) leaves
+ * flyouts outside `body` and they fall back to the browser serif default.
+ */
+export const getFlyoutAppendTo = (): HTMLElement => document.body;
+
+const flyoutTypography = css`
+  .pf-v6-c-popover__content,
+  .pf-v6-c-popover__title-text,
+  .pf-v6-c-tooltip__content {
+    font-family: var(--pf-t--global--font--family--body);
+    line-height: var(--pf-t--global--font--line-height--body);
+  }
+
+  .pf-v6-c-tooltip__content {
+    font-size: var(--pf-t--global--font--size--body--sm);
+  }
+`;
+
+/** Popover surfaces that respect the active PatternFly theme. */
+export const themeAwarePopoverClassName = css`
+  --pf-v6-c-popover__content--BackgroundColor: var(
+    --pf-t--global--background--color--floating--default
+  );
+  --pf-v6-c-popover__content--Color: var(--pf-t--global--text--color--regular);
+  --pf-v6-c-popover__arrow--BackgroundColor: var(
+    --pf-t--global--background--color--floating--default
+  );
+  --pf-v6-c-popover__arrow--BorderColor: var(
+    --pf-t--global--border--color--default
+  );
+  ${flyoutTypography}
+`;
+
+/** Tooltip surfaces that respect the active PatternFly theme. */
+export const themeAwareTooltipClassName = css`
+  --pf-v6-c-tooltip__content--BackgroundColor: var(
+    --pf-t--global--background--color--floating--default
+  );
+  --pf-v6-c-tooltip__content--Color: var(--pf-t--global--text--color--regular);
+  --pf-v6-c-tooltip__arrow--BackgroundColor: var(
+    --pf-t--global--background--color--floating--default
+  );
+  --pf-v6-c-tooltip__arrow--BorderColor: var(
+    --pf-t--global--border--color--default
+  );
+  ${flyoutTypography}
+`;
+
+/** Victory chart tooltips (Voronoi) that respect the active PatternFly theme. */
+export const themedChartTooltipStyle = {
+  fontSize: 9,
+  fill: "var(--pf-t--global--text--color--regular)",
+} as const;
+
+export const themedChartTooltipFlyoutStyle = {
+  stroke: "var(--pf-t--global--border--color--default)",
+  strokeWidth: 1,
+  fill: "var(--pf-t--global--background--color--floating--default)",
+} as const;
+
+export const themedChartTooltipFlyoutPadding = {
+  top: 6,
+  bottom: 6,
+  left: 10,
+  right: 10,
+} as const;
+
+/** Shared props for theme-aware PatternFly Popovers. */
+export const themePopoverFlyoutProps = {
+  appendTo: getFlyoutAppendTo,
+  className: themeAwarePopoverClassName,
+} as const;
+
+/** Shared props for theme-aware PatternFly Tooltips. */
+export const themeTooltipFlyoutProps = {
+  appendTo: getFlyoutAppendTo,
+  className: themeAwareTooltipClassName,
+} as const;

--- a/src/lib/patternfly/flyoutAppendTo.ts
+++ b/src/lib/patternfly/flyoutAppendTo.ts
@@ -1,4 +1,4 @@
-import { css } from "@emotion/css";
+import { css, cx } from "@emotion/css";
 
 /**
  * DOM target for portaled PatternFly flyouts (Popover, Tooltip).
@@ -8,7 +8,8 @@ import { css } from "@emotion/css";
  */
 export const getFlyoutAppendTo = (): HTMLElement => document.body;
 
-const flyoutTypography = css`
+/** Shared typography for portaled popover and tooltip content. */
+export const flyoutTypographyClassName = css`
   .pf-v6-c-popover__content,
   .pf-v6-c-popover__title-text,
   .pf-v6-c-tooltip__content {
@@ -21,7 +22,7 @@ const flyoutTypography = css`
   }
 `;
 
-/** Popover surfaces that respect the active PatternFly theme. */
+/** Popover color tokens that respect the active PatternFly theme. */
 export const themeAwarePopoverClassName = css`
   --pf-v6-c-popover__content--BackgroundColor: var(
     --pf-t--global--background--color--floating--default
@@ -33,10 +34,9 @@ export const themeAwarePopoverClassName = css`
   --pf-v6-c-popover__arrow--BorderColor: var(
     --pf-t--global--border--color--default
   );
-  ${flyoutTypography}
 `;
 
-/** Tooltip surfaces that respect the active PatternFly theme. */
+/** Tooltip color tokens that respect the active PatternFly theme. */
 export const themeAwareTooltipClassName = css`
   --pf-v6-c-tooltip__content--BackgroundColor: var(
     --pf-t--global--background--color--floating--default
@@ -48,8 +48,19 @@ export const themeAwareTooltipClassName = css`
   --pf-v6-c-tooltip__arrow--BorderColor: var(
     --pf-t--global--border--color--default
   );
-  ${flyoutTypography}
 `;
+
+/** Typography + theme tokens for popovers. */
+export const themePopoverFlyoutClassName = cx(
+  flyoutTypographyClassName,
+  themeAwarePopoverClassName,
+);
+
+/** Typography + theme tokens for tooltips. */
+export const themeTooltipFlyoutClassName = cx(
+  flyoutTypographyClassName,
+  themeAwareTooltipClassName,
+);
 
 /** Victory chart tooltips (Voronoi) that respect the active PatternFly theme. */
 export const themedChartTooltipStyle = {
@@ -73,11 +84,11 @@ export const themedChartTooltipFlyoutPadding = {
 /** Shared props for theme-aware PatternFly Popovers. */
 export const themePopoverFlyoutProps = {
   appendTo: getFlyoutAppendTo,
-  className: themeAwarePopoverClassName,
+  className: themePopoverFlyoutClassName,
 } as const;
 
 /** Shared props for theme-aware PatternFly Tooltips. */
 export const themeTooltipFlyoutProps = {
   appendTo: getFlyoutAppendTo,
-  className: themeAwareTooltipClassName,
+  className: themeTooltipFlyoutClassName,
 } as const;

--- a/src/ui/assessment/views/AssessmentsTable.tsx
+++ b/src/ui/assessment/views/AssessmentsTable.tsx
@@ -29,6 +29,10 @@ import React, { useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
 import type { AssessmentModel } from "../../../models/AssessmentModel";
+import {
+  getFlyoutAppendTo,
+  themeAwareTooltipClassName,
+} from "../../../lib/patternfly/flyoutAppendTo";
 import { routes } from "../../../routing/Routes";
 import { EmptySearchResults } from "../../core/components/EmptySearchResults";
 
@@ -521,12 +525,18 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
             {isColumnVisible("Name") && (
               <Td dataLabel={Columns.Name} modifier="truncate">
                 {row.hasData ? (
-                  <Tooltip content={row.name}>
+                  <Tooltip
+                    appendTo={getFlyoutAppendTo}
+                    className={themeAwareTooltipClassName}
+                    content={row.name}
+                  >
                     <Link to={routes.assessmentById(row.id)}>{row.name}</Link>
                   </Tooltip>
                 ) : (
                   <span>
                     <Tooltip
+                      appendTo={getFlyoutAppendTo}
+                      className={themeAwareTooltipClassName}
                       content={
                         row.sourceType.toLowerCase().includes("rvtools")
                           ? "No inventory data found. The uploaded file may be corrupted. Please verify and re-upload."
@@ -537,7 +547,11 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
                         <RhUiWarningFillIcon />
                       </Icon>
                     </Tooltip>{" "}
-                    <Tooltip content={row.name}>
+                    <Tooltip
+                      appendTo={getFlyoutAppendTo}
+                      className={themeAwareTooltipClassName}
+                      content={row.name}
+                    >
                       <span>{row.name}</span>
                     </Tooltip>
                   </span>
@@ -592,6 +606,8 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
               <Td dataLabel={Columns.AssessmentReport}>
                 <TableText>
                   <Tooltip
+                    appendTo={getFlyoutAppendTo}
+                    className={themeAwareTooltipClassName}
                     content={
                       row.hasData
                         ? "View assessment report"

--- a/src/ui/assessment/views/AssessmentsTable.tsx
+++ b/src/ui/assessment/views/AssessmentsTable.tsx
@@ -29,10 +29,7 @@ import React, { useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
 import type { AssessmentModel } from "../../../models/AssessmentModel";
-import {
-  getFlyoutAppendTo,
-  themeAwareTooltipClassName,
-} from "../../../lib/patternfly/flyoutAppendTo";
+import { themeTooltipFlyoutProps } from "../../../lib/patternfly/flyoutAppendTo";
 import { routes } from "../../../routing/Routes";
 import { EmptySearchResults } from "../../core/components/EmptySearchResults";
 
@@ -525,18 +522,13 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
             {isColumnVisible("Name") && (
               <Td dataLabel={Columns.Name} modifier="truncate">
                 {row.hasData ? (
-                  <Tooltip
-                    appendTo={getFlyoutAppendTo}
-                    className={themeAwareTooltipClassName}
-                    content={row.name}
-                  >
+                  <Tooltip {...themeTooltipFlyoutProps} content={row.name}>
                     <Link to={routes.assessmentById(row.id)}>{row.name}</Link>
                   </Tooltip>
                 ) : (
                   <span>
                     <Tooltip
-                      appendTo={getFlyoutAppendTo}
-                      className={themeAwareTooltipClassName}
+                      {...themeTooltipFlyoutProps}
                       content={
                         row.sourceType.toLowerCase().includes("rvtools")
                           ? "No inventory data found. The uploaded file may be corrupted. Please verify and re-upload."
@@ -547,11 +539,7 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
                         <RhUiWarningFillIcon />
                       </Icon>
                     </Tooltip>{" "}
-                    <Tooltip
-                      appendTo={getFlyoutAppendTo}
-                      className={themeAwareTooltipClassName}
-                      content={row.name}
-                    >
+                    <Tooltip {...themeTooltipFlyoutProps} content={row.name}>
                       <span>{row.name}</span>
                     </Tooltip>
                   </span>
@@ -606,8 +594,7 @@ export const AssessmentsTable: React.FC<AssessmentsTableProps> = ({
               <Td dataLabel={Columns.AssessmentReport}>
                 <TableText>
                   <Tooltip
-                    appendTo={getFlyoutAppendTo}
-                    className={themeAwareTooltipClassName}
+                    {...themeTooltipFlyoutProps}
                     content={
                       row.hasData
                         ? "View assessment report"

--- a/src/ui/core/components/MigrationChart.tsx
+++ b/src/ui/core/components/MigrationChart.tsx
@@ -13,6 +13,11 @@ import { chart_color_blue_300 } from "@patternfly/react-tokens/dist/esm/chart_co
 import { chart_color_red_orange_400 } from "@patternfly/react-tokens/dist/esm/chart_color_red_orange_400";
 import React, { useMemo } from "react";
 
+import {
+  getFlyoutAppendTo,
+  themeAwarePopoverClassName,
+} from "../../../lib/patternfly/flyoutAppendTo";
+
 interface OSData {
   name: string;
   count: number;
@@ -48,11 +53,9 @@ type DLength =
 // Styles
 // ---------------------------------------------------------------------------
 
-const upgradeRecommendationPopover = css`
-  .popover-override .pf-v5-c-popover__close .pf-v5-c-button.pf-m-plain {
-    color: var(--pf-t--global--text--color--regular);
-  }
-  .popover-override .pf-v5-c-popover__close .pf-v5-c-button.pf-m-plain:hover {
+const upgradeRecommendationPopoverCloseButton = css`
+  .pf-v6-c-popover__close .pf-v6-c-button.pf-m-plain,
+  .pf-v6-c-popover__close .pf-v6-c-button.pf-m-plain:hover {
     color: var(--pf-t--global--text--color--regular);
   }
 `;
@@ -178,7 +181,8 @@ const MigrationChart: React.FC<MigrationChartProps> = ({
                         {item.infoText ? (
                           <FlexItem shrink={{ default: "shrink" }}>
                             <Popover
-                              className={upgradeRecommendationPopover}
+                              appendTo={getFlyoutAppendTo}
+                              className={`${themeAwarePopoverClassName} ${upgradeRecommendationPopoverCloseButton}`}
                               position="bottom"
                               headerContent="Upgrade to get support"
                               bodyContent={<div>{item.infoText}</div>}

--- a/src/ui/core/components/MigrationChart.tsx
+++ b/src/ui/core/components/MigrationChart.tsx
@@ -15,7 +15,7 @@ import React, { useMemo } from "react";
 
 import {
   getFlyoutAppendTo,
-  themeAwarePopoverClassName,
+  themePopoverFlyoutClassName,
 } from "../../../lib/patternfly/flyoutAppendTo";
 
 interface OSData {
@@ -182,7 +182,7 @@ const MigrationChart: React.FC<MigrationChartProps> = ({
                           <FlexItem shrink={{ default: "shrink" }}>
                             <Popover
                               appendTo={getFlyoutAppendTo}
-                              className={`${themeAwarePopoverClassName} ${upgradeRecommendationPopoverCloseButton}`}
+                              className={`${themePopoverFlyoutClassName} ${upgradeRecommendationPopoverCloseButton}`}
                               position="bottom"
                               headerContent="Upgrade to get support"
                               bodyContent={<div>{item.infoText}</div>}

--- a/src/ui/core/components/MigrationDonutChart.tsx
+++ b/src/ui/core/components/MigrationDonutChart.tsx
@@ -1,6 +1,17 @@
-import { ChartDonut, ChartLabel, ChartLegend } from "@patternfly/react-charts";
+import {
+  ChartDonut,
+  ChartLabel,
+  ChartLegend,
+  ChartTooltip,
+} from "@patternfly/react-charts";
 import { Flex, FlexItem } from "@patternfly/react-core";
 import React, { useCallback, useMemo } from "react";
+
+import {
+  themedChartTooltipFlyoutPadding,
+  themedChartTooltipFlyoutStyle,
+  themedChartTooltipStyle,
+} from "../../../lib/patternfly/flyoutAppendTo";
 
 interface OSData {
   name: string;
@@ -150,6 +161,17 @@ const MigrationDonutChart: React.FC<MigrationDonutChartProps> = ({
     return chartData.reduce((sum, item) => sum + (Number(item.y) || 0), 0);
   }, [chartData]);
 
+  const donutTooltip = useMemo(
+    () => (
+      <ChartTooltip
+        style={themedChartTooltipStyle}
+        flyoutStyle={themedChartTooltipFlyoutStyle}
+        flyoutPadding={themedChartTooltipFlyoutPadding}
+      />
+    ),
+    [],
+  );
+
   if (!data || data.length === 0) {
     return (
       <div style={{ padding: "20px", textAlign: "center" }}>
@@ -167,6 +189,7 @@ const MigrationDonutChart: React.FC<MigrationDonutChartProps> = ({
         <ChartDonut
           ariaDesc="Migration data donut chart"
           data={chartData}
+          labelComponent={donutTooltip}
           labels={({ datum }) => {
             const safeDatum = datum as ChartDatum;
             const percent =

--- a/src/ui/environment/views/AgentStatusView.tsx
+++ b/src/ui/environment/views/AgentStatusView.tsx
@@ -21,6 +21,7 @@ import { t_global_icon_color_status_info_default as globalInfoColor100 } from "@
 import React, { useMemo } from "react";
 import { Link } from "react-router-dom";
 
+import { themePopoverFlyoutProps } from "../../../lib/patternfly/flyoutAppendTo";
 import { VCenterSetupInstructions } from "../../core/components/VCenterSetupInstructions";
 import { safeExternalUrl } from "../../core/utils/urlValidation";
 import { getDiscoveryVmStatusLabel } from "../helpers/discoveryVmStatus";
@@ -156,6 +157,7 @@ export const AgentStatusView: React.FC<AgentStatusView.Props> = (props) => {
           status !== "not-connected" &&
           status !== "up-to-date") ? (
           <Popover
+            {...themePopoverFlyoutProps}
             aria-label={statusView && statusView.text}
             headerContent={statusView && statusView.text}
             headerComponent="h1"
@@ -186,6 +188,7 @@ export const AgentStatusView: React.FC<AgentStatusView.Props> = (props) => {
       {isNotConnected && (
         <SplitItem>
           <Popover
+            {...themePopoverFlyoutProps}
             aria-label="Setup instructions"
             headerContent="Setup instructions"
             headerComponent="h2"

--- a/src/ui/environment/views/DownloadOvaAction.tsx
+++ b/src/ui/environment/views/DownloadOvaAction.tsx
@@ -2,6 +2,7 @@ import { Button, Icon, Tooltip } from "@patternfly/react-core";
 import { RhUiDownloadIcon } from "@patternfly/react-icons";
 import React, { useCallback, useState } from "react";
 
+import { themeTooltipFlyoutProps } from "../../../lib/patternfly/flyoutAppendTo";
 import { useEnvironmentPage } from "../view-models/EnvironmentPageContext";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -40,7 +41,7 @@ export const DownloadOvaAction: React.FC<DownloadOvaAction.Props> = (props) => {
   }, [sourceId, sourceName, url]);
 
   return (
-    <Tooltip content="Download OVA File">
+    <Tooltip {...themeTooltipFlyoutProps} content="Download OVA File">
       <Button
         icon={
           <Icon size="md" isInline>

--- a/src/ui/environment/views/ProxyFields.tsx
+++ b/src/ui/environment/views/ProxyFields.tsx
@@ -12,6 +12,8 @@ import {
 import { RhUiQuestionMarkCircleIcon } from "@patternfly/react-icons";
 import React, { useState } from "react";
 
+import { themePopoverFlyoutProps } from "../../../lib/patternfly/flyoutAppendTo";
+
 const ProxyInputFields = ({
   httpProxy,
   httpsProxy,
@@ -29,7 +31,10 @@ const ProxyInputFields = ({
         <FormGroup
           label="HTTP proxy URL"
           labelHelp={
-            <Popover bodyContent="The HTTP proxy URL that agents should use to access the discovery service.">
+            <Popover
+              {...themePopoverFlyoutProps}
+              bodyContent="The HTTP proxy URL that agents should use to access the discovery service."
+            >
               <button
                 type="button"
                 aria-label="More info about HTTP proxy URL"
@@ -60,7 +65,10 @@ const ProxyInputFields = ({
         <FormGroup
           label="HTTPS proxy URL"
           labelHelp={
-            <Popover bodyContent="Specify the HTTPS proxy that agents should use to access the discovery service. If you don't provide a value, your HTTP proxy URL will be used by default for both HTTP and HTTPS connections.">
+            <Popover
+              {...themePopoverFlyoutProps}
+              bodyContent="Specify the HTTPS proxy that agents should use to access the discovery service. If you don't provide a value, your HTTP proxy URL will be used by default for both HTTP and HTTPS connections."
+            >
               <button
                 type="button"
                 aria-label="More info about HTTPS proxy URL"
@@ -91,7 +99,10 @@ const ProxyInputFields = ({
         <FormGroup
           label="No proxy domains"
           labelHelp={
-            <Popover bodyContent="Exclude destination domain names, IP addresses, or other network CIDRs from proxying by adding them to this comma-separated list.">
+            <Popover
+              {...themePopoverFlyoutProps}
+              bodyContent="Exclude destination domain names, IP addresses, or other network CIDRs from proxying by adding them to this comma-separated list."
+            >
               <button
                 type="button"
                 aria-label="More info about no proxy domains"

--- a/src/ui/environment/views/RemoveSourceAction.tsx
+++ b/src/ui/environment/views/RemoveSourceAction.tsx
@@ -2,6 +2,7 @@ import { Button, Content, Icon, Tooltip } from "@patternfly/react-core";
 import { RhUiTrashIcon } from "@patternfly/react-icons";
 import React, { useCallback, useState } from "react";
 
+import { themeTooltipFlyoutProps } from "../../../lib/patternfly/flyoutAppendTo";
 import { ConfirmationModal } from "../../core/components/ConfirmationModal";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -46,7 +47,7 @@ export const RemoveSourceAction: React.FC<RemoveSourceAction.Props> = (
 
   return (
     <>
-      <Tooltip content="Remove">
+      <Tooltip {...themeTooltipFlyoutProps} content="Remove">
         <Button
           icon={
             <Icon size="md" isInline>

--- a/src/ui/environment/views/SourcesTable.tsx
+++ b/src/ui/environment/views/SourcesTable.tsx
@@ -26,6 +26,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import type { SourceModel } from "../../../models/SourceModel";
+import { themeTooltipFlyoutProps } from "../../../lib/patternfly/flyoutAppendTo";
 import { routes } from "../../../routing/Routes";
 import { ConfirmationModal } from "../../core/components/ConfirmationModal";
 import { EmptySearchResults } from "../../core/components/EmptySearchResults";
@@ -721,6 +722,7 @@ export const SourcesTable: React.FC<SourceTableProps> = ({
                   <Td dataLabel={Columns.LastSeen} className={tableCellTop}>
                     {source?.updatedAt ? (
                       <Tooltip
+                        {...themeTooltipFlyoutProps}
                         content={new Date(source.updatedAt).toLocaleString()}
                       >
                         <span>{formatRelativeTime(source.updatedAt)}</span>

--- a/src/ui/environment/views/UploadInventoryAction.tsx
+++ b/src/ui/environment/views/UploadInventoryAction.tsx
@@ -2,6 +2,7 @@ import { Button, Icon, Tooltip } from "@patternfly/react-core";
 import { RhUiUploadIcon } from "@patternfly/react-icons";
 import React, { useCallback } from "react";
 
+import { themeTooltipFlyoutProps } from "../../../lib/patternfly/flyoutAppendTo";
 import { useEnvironmentPage } from "../view-models/EnvironmentPageContext";
 
 interface UploadInventoryProps {
@@ -28,7 +29,7 @@ export const UploadInventoryAction: React.FC<UploadInventoryProps> = ({
       Upload discovery file (JSON)
     </Button>
   ) : (
-    <Tooltip content="Upload JSON file">
+    <Tooltip {...themeTooltipFlyoutProps} content="Upload JSON file">
       <Button
         icon={
           <Icon size="md" isInline>

--- a/src/ui/environment/views/VersionStatus.tsx
+++ b/src/ui/environment/views/VersionStatus.tsx
@@ -16,6 +16,7 @@ import { t_global_icon_color_status_info_default as globalInfoColor } from "@pat
 import { t_global_text_color_status_warning_default as globalTextWarningColor } from "@patternfly/react-tokens/dist/js/t_global_text_color_status_warning_default";
 import React from "react";
 
+import { themePopoverFlyoutProps } from "../../../lib/patternfly/flyoutAppendTo";
 import { VCenterSetupInstructions } from "../../core/components/VCenterSetupInstructions";
 
 export const AGENT_VERSION_NOT_AVAILABLE = "N/A";
@@ -61,6 +62,7 @@ const OvaDownloading: React.FC = () => (
     </SplitItem>
     <SplitItem>
       <Popover
+        {...themePopoverFlyoutProps}
         aria-label="OVA installation instructions"
         headerContent="Install the OVA in your vCenter"
         headerComponent="h2"
@@ -88,6 +90,7 @@ const OvaDownloaded: React.FC = () => (
     </SplitItem>
     <SplitItem>
       <Popover
+        {...themePopoverFlyoutProps}
         aria-label="OVA installation instructions"
         headerContent="Install the OVA in your vCenter"
         headerComponent="h2"
@@ -116,6 +119,7 @@ const NotAvailable: React.FC<{ warning?: string | null }> = ({ warning }) => (
     {warning && (
       <SplitItem>
         <Popover
+          {...themePopoverFlyoutProps}
           aria-label="Version information"
           headerContent="Version Information"
           headerComponent="h2"
@@ -143,6 +147,7 @@ const VersionWarning: React.FC<{ warning: string }> = ({ warning }) => (
     </SplitItem>
     <SplitItem>
       <Popover
+        {...themePopoverFlyoutProps}
         aria-label="Version warning"
         headerContent="Version Warning"
         headerComponent="h2"

--- a/src/ui/home/views/HowDoesItWork.tsx
+++ b/src/ui/home/views/HowDoesItWork.tsx
@@ -25,10 +25,7 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 
 import useLocalStorage from "../../../hooks/useLocalStorage";
-import {
-  getFlyoutAppendTo,
-  themeAwareTooltipClassName,
-} from "../../../lib/patternfly/flyoutAppendTo";
+import { themeTooltipFlyoutProps } from "../../../lib/patternfly/flyoutAppendTo";
 import { routes } from "../../../routing/Routes";
 import { CustomEnterpriseIcon } from "../../core/components/CustomEnterpriseIcon";
 
@@ -101,8 +98,7 @@ export const HowDoesItWork: React.FC = () => {
               <Content component="h3" className={headingStyle}>
                 Assess VMware
                 <Tooltip
-                  appendTo={getFlyoutAppendTo}
-                  className={themeAwareTooltipClassName}
+                  {...themeTooltipFlyoutProps}
                   content="As part of the discovery process, we're collecting aggregated data about your VMware environment. This includes information such as the number of clusters, hosts, and VMs; VM counts per operating system type; total CPU cores and memory; network types and VLANs; and a list of datastores."
                 >
                   <Icon size="lg" className={questionIconStyle}>

--- a/src/ui/home/views/HowDoesItWork.tsx
+++ b/src/ui/home/views/HowDoesItWork.tsx
@@ -25,6 +25,10 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 
 import useLocalStorage from "../../../hooks/useLocalStorage";
+import {
+  getFlyoutAppendTo,
+  themeAwareTooltipClassName,
+} from "../../../lib/patternfly/flyoutAppendTo";
 import { routes } from "../../../routing/Routes";
 import { CustomEnterpriseIcon } from "../../core/components/CustomEnterpriseIcon";
 
@@ -96,7 +100,11 @@ export const HowDoesItWork: React.FC = () => {
               </Icon>
               <Content component="h3" className={headingStyle}>
                 Assess VMware
-                <Tooltip content="As part of the discovery process, we're collecting aggregated data about your VMware environment. This includes information such as the number of clusters, hosts, and VMs; VM counts per operating system type; total CPU cores and memory; network types and VLANs; and a list of datastores.">
+                <Tooltip
+                  appendTo={getFlyoutAppendTo}
+                  className={themeAwareTooltipClassName}
+                  content="As part of the discovery process, we're collecting aggregated data about your VMware environment. This includes information such as the number of clusters, hosts, and VMs; VM counts per operating system type; total CPU cores and memory; network types and VLANs; and a list of datastores."
+                >
                   <Icon size="lg" className={questionIconStyle}>
                     <RhUiQuestionMarkCircleIcon
                       color={globalActiveColor300.var}

--- a/src/ui/report/views/DeployOvaBanner.tsx
+++ b/src/ui/report/views/DeployOvaBanner.tsx
@@ -15,6 +15,10 @@ import {
 import React from "react";
 import { useNavigate } from "react-router-dom";
 
+import {
+  getFlyoutAppendTo,
+  themeAwarePopoverClassName,
+} from "../../../lib/patternfly/flyoutAppendTo";
 import { routes } from "../../../routing/Routes";
 
 const bannerStyle = css`
@@ -39,6 +43,8 @@ export const DeployOvaBanner: React.FC = () => {
   return (
     <div className={bannerStyle}>
       <Popover
+        appendTo={getFlyoutAppendTo}
+        className={themeAwarePopoverClassName}
         headerContent="Deploy the Migration Advisor OVA"
         bodyContent={
           <div>

--- a/src/ui/report/views/DeployOvaBanner.tsx
+++ b/src/ui/report/views/DeployOvaBanner.tsx
@@ -15,10 +15,7 @@ import {
 import React from "react";
 import { useNavigate } from "react-router-dom";
 
-import {
-  getFlyoutAppendTo,
-  themeAwarePopoverClassName,
-} from "../../../lib/patternfly/flyoutAppendTo";
+import { themePopoverFlyoutProps } from "../../../lib/patternfly/flyoutAppendTo";
 import { routes } from "../../../routing/Routes";
 
 const bannerStyle = css`
@@ -43,8 +40,7 @@ export const DeployOvaBanner: React.FC = () => {
   return (
     <div className={bannerStyle}>
       <Popover
-        appendTo={getFlyoutAppendTo}
-        className={themeAwarePopoverClassName}
+        {...themePopoverFlyoutProps}
         headerContent="Deploy the Migration Advisor OVA"
         bodyContent={
           <div>

--- a/src/ui/report/views/Report.tsx
+++ b/src/ui/report/views/Report.tsx
@@ -22,10 +22,7 @@ import {
 import React, { useRef } from "react";
 import { Link } from "react-router-dom";
 
-import {
-  getFlyoutAppendTo,
-  themeAwareTooltipClassName,
-} from "../../../lib/patternfly/flyoutAppendTo";
+import { themeTooltipFlyoutProps } from "../../../lib/patternfly/flyoutAppendTo";
 import { routes } from "../../../routing/Routes";
 import CreateAssessmentModal from "../../assessment/views/CreateAssessmentModal";
 import { AppPage } from "../../core/components/AppPage";
@@ -283,8 +280,7 @@ const ReportContent: React.FC = () => {
                 />
               ) : (
                 <Tooltip
-                  appendTo={getFlyoutAppendTo}
-                  className={themeAwareTooltipClassName}
+                  {...themeTooltipFlyoutProps}
                   content={
                     <p>
                       Export is unavailable because this cluster has no VMs.
@@ -313,8 +309,7 @@ const ReportContent: React.FC = () => {
                   </Button>
                 ) : (
                   <Tooltip
-                    appendTo={getFlyoutAppendTo}
-                    className={themeAwareTooltipClassName}
+                    {...themeTooltipFlyoutProps}
                     content={
                       <p>
                         This cluster has no VMs. Cluster recommendations are not

--- a/src/ui/report/views/Report.tsx
+++ b/src/ui/report/views/Report.tsx
@@ -22,6 +22,10 @@ import {
 import React, { useRef } from "react";
 import { Link } from "react-router-dom";
 
+import {
+  getFlyoutAppendTo,
+  themeAwareTooltipClassName,
+} from "../../../lib/patternfly/flyoutAppendTo";
 import { routes } from "../../../routing/Routes";
 import CreateAssessmentModal from "../../assessment/views/CreateAssessmentModal";
 import { AppPage } from "../../core/components/AppPage";
@@ -279,6 +283,8 @@ const ReportContent: React.FC = () => {
                 />
               ) : (
                 <Tooltip
+                  appendTo={getFlyoutAppendTo}
+                  className={themeAwareTooltipClassName}
                   content={
                     <p>
                       Export is unavailable because this cluster has no VMs.
@@ -307,6 +313,8 @@ const ReportContent: React.FC = () => {
                   </Button>
                 ) : (
                   <Tooltip
+                    appendTo={getFlyoutAppendTo}
+                    className={themeAwareTooltipClassName}
                     content={
                       <p>
                         This cluster has no VMs. Cluster recommendations are not

--- a/src/ui/report/views/assessment-report/ErrorTable.tsx
+++ b/src/ui/report/views/assessment-report/ErrorTable.tsx
@@ -1,5 +1,5 @@
 import type { MigrationIssue } from "@openshift-migration-advisor/planner-sdk";
-import { Card, CardBody, CardTitle, Icon } from "@patternfly/react-core";
+import { Card, CardBody, CardTitle } from "@patternfly/react-core";
 import { RhUiErrorFillIcon } from "@patternfly/react-icons";
 import { t_global_icon_color_status_danger_default as globalDangerColor100 } from "@patternfly/react-tokens/dist/js/t_global_icon_color_status_danger_default";
 import React from "react";
@@ -20,10 +20,7 @@ export const ErrorTable: React.FC<ErrorTableProps> = ({
   return (
     <Card className={dashboardCard} id="errors-table">
       <CardTitle>
-        <Icon style={{ color: globalDangerColor100.var }}>
-          <RhUiErrorFillIcon />
-        </Icon>{" "}
-        Errors
+        <RhUiErrorFillIcon color={globalDangerColor100.var} /> Errors
       </CardTitle>
       <CardBody style={{ padding: 0 }}>
         {errors.length === 0 ? (

--- a/src/ui/report/views/assessment-report/StorageOverview.tsx
+++ b/src/ui/report/views/assessment-report/StorageOverview.tsx
@@ -26,6 +26,11 @@ import {
 } from "@patternfly/react-core";
 import React, { useMemo, useState } from "react";
 
+import {
+  themedChartTooltipFlyoutPadding,
+  themedChartTooltipFlyoutStyle,
+  themedChartTooltipStyle,
+} from "../../../../lib/patternfly/flyoutAppendTo";
 import MigrationDonutChart from "../../../core/components/MigrationDonutChart";
 import {
   dashboardCard,
@@ -426,7 +431,14 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
                           }}
                           constrainToVisibleArea
                           labelComponent={
-                            <ChartTooltip style={{ fontSize: 8 }} />
+                            <ChartTooltip
+                              style={{
+                                ...themedChartTooltipStyle,
+                                fontSize: 8,
+                              }}
+                              flyoutStyle={themedChartTooltipFlyoutStyle}
+                              flyoutPadding={themedChartTooltipFlyoutPadding}
+                            />
                           }
                         />
                       }
@@ -542,7 +554,11 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
                         }}
                         constrainToVisibleArea
                         labelComponent={
-                          <ChartTooltip style={{ fontSize: 8 }} />
+                          <ChartTooltip
+                            style={{ ...themedChartTooltipStyle, fontSize: 8 }}
+                            flyoutStyle={themedChartTooltipFlyoutStyle}
+                            flyoutPadding={themedChartTooltipFlyoutPadding}
+                          />
                         }
                       />
                     }

--- a/src/ui/report/views/assessment-report/WarningsTable.tsx
+++ b/src/ui/report/views/assessment-report/WarningsTable.tsx
@@ -1,5 +1,5 @@
 import type { MigrationIssue } from "@openshift-migration-advisor/planner-sdk";
-import { Card, CardBody, CardTitle, Icon } from "@patternfly/react-core";
+import { Card, CardBody, CardTitle } from "@patternfly/react-core";
 import { RhUiWarningFillIcon } from "@patternfly/react-icons";
 import { t_global_icon_color_status_warning_default as globalWarningColor100 } from "@patternfly/react-tokens/dist/js/t_global_icon_color_status_warning_default";
 import React from "react";
@@ -20,10 +20,7 @@ export const WarningsTable: React.FC<WarningsTableProps> = ({
   return (
     <Card className={dashboardCard} id="warnings-table">
       <CardTitle>
-        <Icon style={{ color: globalWarningColor100.var }}>
-          <RhUiWarningFillIcon />
-        </Icon>{" "}
-        Warnings
+        <RhUiWarningFillIcon color={globalWarningColor100.var} /> Warnings
       </CardTitle>
       <CardBody style={{ padding: 0 }}>
         <div

--- a/src/ui/report/views/cluster-sizer/ComplexityResult.tsx
+++ b/src/ui/report/views/cluster-sizer/ComplexityResult.tsx
@@ -31,6 +31,11 @@ import {
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import React, { useState } from "react";
 
+import {
+  themedChartTooltipFlyoutPadding,
+  themedChartTooltipFlyoutStyle,
+  themedChartTooltipStyle,
+} from "../../../../lib/patternfly/flyoutAppendTo";
 import { COMPLEXITY_COLORS, COMPLEXITY_LABELS } from "./constants";
 import MigrationComplexityHelpPopover from "./MigrationComplexityHelpPopover";
 import { durationToHours } from "./timeUtils";
@@ -217,17 +222,9 @@ export const ComplexityResult: React.FC<ComplexityResultProps> = ({
                   }}
                   labelComponent={
                     <ChartTooltip
-                      style={{
-                        fontSize: 9,
-                        fill: "var(--pf-t--global--text--color--inverse)",
-                      }}
-                      flyoutStyle={{
-                        stroke:
-                          "var(--pf-t--global--background--color--inverse--default)",
-                        strokeWidth: 1,
-                        fill: "var(--pf-t--global--background--color--inverse--default)",
-                      }}
-                      flyoutPadding={{ top: 6, bottom: 6, left: 10, right: 10 }}
+                      style={themedChartTooltipStyle}
+                      flyoutStyle={themedChartTooltipFlyoutStyle}
+                      flyoutPadding={themedChartTooltipFlyoutPadding}
                     />
                   }
                   constrainToVisibleArea
@@ -367,16 +364,9 @@ export const ComplexityResult: React.FC<ComplexityResultProps> = ({
                 }}
                 labelComponent={
                   <ChartTooltip
-                    style={{
-                      fontSize: 14,
-                      fill: "var(--pf-t--global--text--color--inverse)",
-                    }}
-                    flyoutStyle={{
-                      stroke:
-                        "var(--pf-t--global--background--color--inverse--default)",
-                      strokeWidth: 1,
-                      fill: "var(--pf-t--global--background--color--inverse--default)",
-                    }}
+                    style={{ ...themedChartTooltipStyle, fontSize: 14 }}
+                    flyoutStyle={themedChartTooltipFlyoutStyle}
+                    flyoutPadding={themedChartTooltipFlyoutPadding}
                   />
                 }
                 padding={{ bottom: 20, left: 20, right: 20, top: 20 }}

--- a/src/ui/report/views/cluster-sizer/PopoverIcon.tsx
+++ b/src/ui/report/views/cluster-sizer/PopoverIcon.tsx
@@ -12,7 +12,7 @@ import React from "react";
 
 import {
   getFlyoutAppendTo,
-  themeAwarePopoverClassName,
+  themePopoverFlyoutClassName,
 } from "../../../../lib/patternfly/flyoutAppendTo";
 
 type PopoverIconProps = PopoverProps & {
@@ -33,14 +33,19 @@ const PopoverIcon: React.FC<PopoverIconProps> = ({
   buttonClassName,
   buttonOuiaId,
   buttonStyle,
-  className,
   appendTo = getFlyoutAppendTo,
   ...props
 }) => (
+  // Popover prop order matters:
+  // 1. {...props} first — forwards all PopoverProps except those overridden below.
+  // 2. appendTo / className after the spread — prevents consumers from silently
+  //    dropping theme flyout styles by passing their own className via props.
+  // Do NOT destructure className out of props; it must stay on props so we can
+  // compose it here. classNames merge order: theme base, then consumer extension.
   <Popover
-    appendTo={appendTo}
-    className={classNames(themeAwarePopoverClassName, className)}
     {...props}
+    appendTo={appendTo}
+    className={classNames(themePopoverFlyoutClassName, props.className)}
   >
     <Button
       icon={

--- a/src/ui/report/views/cluster-sizer/PopoverIcon.tsx
+++ b/src/ui/report/views/cluster-sizer/PopoverIcon.tsx
@@ -10,6 +10,11 @@ import type { SVGIconProps } from "@patternfly/react-icons/dist/js/createIcon";
 import classNames from "classnames";
 import React from "react";
 
+import {
+  getFlyoutAppendTo,
+  themeAwarePopoverClassName,
+} from "../../../../lib/patternfly/flyoutAppendTo";
+
 type PopoverIconProps = PopoverProps & {
   variant?: ButtonProps["variant"];
   component?: ButtonProps["component"];
@@ -28,9 +33,15 @@ const PopoverIcon: React.FC<PopoverIconProps> = ({
   buttonClassName,
   buttonOuiaId,
   buttonStyle,
+  className,
+  appendTo = getFlyoutAppendTo,
   ...props
 }) => (
-  <Popover {...props}>
+  <Popover
+    appendTo={appendTo}
+    className={classNames(themeAwarePopoverClassName, className)}
+    {...props}
+  >
     <Button
       icon={
         <Icon isInline={noVerticalAlign}>

--- a/src/ui/report/views/discovery-ova-example/ExampleStorageOffloadTab.tsx
+++ b/src/ui/report/views/discovery-ova-example/ExampleStorageOffloadTab.tsx
@@ -27,6 +27,8 @@ import {
 } from "@patternfly/react-icons";
 import React from "react";
 
+import { themePopoverFlyoutProps } from "../../../../lib/patternfly/flyoutAppendTo";
+
 const sectionSpacing = css`
   margin-top: var(--pf-t--global--spacer--lg);
 `;
@@ -47,6 +49,7 @@ const ExampleStorageOffloadTab: React.FC = () => (
           </FlexItem>
           <FlexItem>
             <Popover
+              {...themePopoverFlyoutProps}
               bodyContent={
                 <>
                   Technology preview features provide early access to upcoming


### PR DESCRIPTION
- Implemented theme-aware styling for popovers, tooltips, and chart flyouts across the app. This restores and extends a previous fix that was lost after the PatternFly v6.5 upgrade.

- Added a shared utility at src/lib/patternfly/flyoutAppendTo.ts that provides:

1. Theme-aware CSS for Popover and Tooltip surfaces (floating background + regular text)
2. Themed chart tooltip styles for Victory ChartTooltip flyouts
3. appendTo={document.body} so flyouts inherit PatternFly typography

