### PR TITLE
NO-JIRA | fix: address the ENOSPC: System limit for number of file watchers reached error when running npm run start / make start.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ BUILD_ARGS := $(foreach var,$(BUILD_VAR_NAMES),--build-arg $(var)=$($(var)))
 ESLINT_CMD := npx eslint --cache --cache-location node_modules/.cache/eslintcache --cache-strategy content .
 PRETTIER_CMD := npx prettier --cache --cache-location node_modules/.cache/prettiercache --cache-strategy content .
 
-.PHONY: help oc install ci-install clean build-standalone run-standalone preview-standalone patch-hosts start start-dev-proxy start-federated build lint format type-check test coverage security-scan security-fix security-fix-force validate-all podman-build podman-run podman-stop podman-logs podman-status podman-clean podman-tag-latest podman-deploy podman-dev quay-login podman-push deploy-on-openshift delete-from-openshift version test-watch
+.PHONY: help oc install ci-install clean build-standalone run-standalone preview-standalone patch-hosts start start-polling start-dev-proxy start-federated build lint format type-check test coverage security-scan security-fix security-fix-force validate-all podman-build podman-run podman-stop podman-logs podman-status podman-clean podman-tag-latest podman-deploy podman-dev quay-login podman-push deploy-on-openshift delete-from-openshift version test-watch
 
 # Default target
 .DEFAULT_GOAL := help
@@ -57,6 +57,7 @@ help:
 	@echo "  run-standalone      Run the standalone application locally"
 	@echo "  preview-standalone  Preview standalone build"
 	@echo "  start               Start federated dev server (HOT mode)"
+	@echo "  start-polling       Start federated dev server (polling; ENOSPC workaround)"
 	@echo "  start-dev-proxy     Start dev proxy server"
 	@echo "  start-federated     Start federated static server"
 	@echo "  patch-hosts         Patch /etc/hosts for local development"
@@ -175,6 +176,12 @@ patch-hosts: install
 start: install
 	@echo "🚀 Starting federated dev server..."
 	@$(BUILD_ENV) HOT=true npx fec dev --clouddotEnv=stage --uiEnv=stable
+	@echo "✅ Federated dev server started!"
+
+# Polling mode avoids inotify limits (ENOSPC) on systems with many open watchers
+start-polling: install
+	@echo "🚀 Starting federated dev server (polling mode)..."
+	@$(BUILD_ENV) HOT=true WATCHPACK_POLLING=1000 npx fec dev --clouddotEnv=stage --uiEnv=stable
 	@echo "✅ Federated dev server started!"
 
 # Start dev proxy server

--- a/fec.config.js
+++ b/fec.config.js
@@ -33,16 +33,33 @@ module.exports = {
         "/openshift/migration-advisor",
       ),
     }),
-    // Prevent EMFILE (too many open files) by excluding node_modules from
-    // webpack's file-system watcher.  The FEC-generated config sets no
-    // watchOptions, so without this patch watchpack opens OS-level watchers
-    // for every file in node_modules.
+    // Prevent ENOSPC / EMFILE by excluding node_modules from webpack's
+    // file-system watcher.  The FEC-generated config sets no watchOptions,
+    // so without this patch watchpack opens OS-level watchers for every
+    // file in node_modules (~150k files).
     {
       apply(compiler) {
-        compiler.options.watchOptions = {
-          ...compiler.options.watchOptions,
-          ignored: ["**/node_modules/**", "**/build-tools/**"],
+        const ignored = /[\\/]node_modules[\\/]|[\\/]build-tools[\\/]/;
+        const polling = process.env.WATCHPACK_POLLING;
+        const patchWatchOptions = (c) => {
+          c.options.watchOptions = {
+            ...c.options.watchOptions,
+            ignored,
+            followSymlinks: false,
+            ...(polling ? { poll: Number(polling) || 1000 } : {}),
+          };
         };
+        compiler.hooks.afterEnvironment.tap("ExcludeNodeModulesFromWatch", () =>
+          patchWatchOptions(compiler),
+        );
+        if (Array.isArray(compiler.compilers)) {
+          for (const child of compiler.compilers) {
+            child.hooks.afterEnvironment.tap(
+              "ExcludeNodeModulesFromWatch",
+              () => patchWatchOptions(child),
+            );
+          }
+        }
       },
     },
   ],


### PR DESCRIPTION
- fec.config: tries to prevent watching node_modules in the first place
- Makefile: adds start-polling as a fallback when system inotify limits are still exceeded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added polling mode for the development server. Users can now use an alternative file watching mechanism to improve reliability when encountering file system limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->