### PR TITLE
NO-JIRA | fix: issue in standalone mode with permissions

### DIFF
--- a/src/models/AssessmentModel.ts
+++ b/src/models/AssessmentModel.ts
@@ -1,5 +1,6 @@
 import type {
   Assessment,
+  AssessmentPermissionsEnum,
   Snapshot,
 } from "@openshift-migration-advisor/planner-sdk";
 
@@ -33,6 +34,25 @@ export type AssessmentModel = Assessment & {
 };
 
 // ---------------------------------------------------------------------------
+// Permissions
+// ---------------------------------------------------------------------------
+
+/**
+ * Default permissions when the API omits them (e.g. standalone with auth disabled).
+ * Auth-enabled deployments always populate permissions via AuthzAssessmentService.
+ */
+const DEFAULT_OWNER_PERMISSIONS: AssessmentPermissionsEnum[] = [
+  "read",
+  "share",
+  "delete",
+];
+
+const resolvePermissions = (
+  permissions: Assessment["permissions"],
+): AssessmentPermissionsEnum[] =>
+  permissions?.length ? permissions : DEFAULT_OWNER_PERMISSIONS;
+
+// ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
 
@@ -58,6 +78,7 @@ const computeOwnerFullName = (raw: Assessment): string => {
  */
 export const createAssessmentModel = (raw: Assessment): AssessmentModel => ({
   ...raw,
+  permissions: resolvePermissions(raw.permissions),
   ownerFullName: computeOwnerFullName(raw),
   latestSnapshot: parseLatestSnapshot(raw.snapshots),
   hasUsefulData: hasUsefulData(raw.snapshots),

--- a/src/models/__tests__/AssessmentModel.test.ts
+++ b/src/models/__tests__/AssessmentModel.test.ts
@@ -1,0 +1,29 @@
+import type { Assessment } from "@openshift-migration-advisor/planner-sdk";
+import { describe, expect, it } from "vitest";
+
+import { createAssessmentModel } from "../AssessmentModel";
+
+const makeAssessment = (overrides: Partial<Assessment> = {}): Assessment => ({
+  id: "a-1",
+  name: "Test Assessment",
+  sourceType: "inventory",
+  createdAt: new Date("2026-01-01"),
+  snapshots: [],
+  ...overrides,
+});
+
+describe("createAssessmentModel", () => {
+  it("defaults owner permissions when API omits them", () => {
+    const model = createAssessmentModel(makeAssessment());
+
+    expect(model.permissions).toEqual(["read", "share", "delete"]);
+  });
+
+  it("preserves permissions returned by auth-enabled API", () => {
+    const model = createAssessmentModel(
+      makeAssessment({ permissions: ["read"] }),
+    );
+
+    expect(model.permissions).toEqual(["read"]);
+  });
+});


### PR DESCRIPTION
In standalone mode the migration-planner API runs with AuthenticationType: "none", so it skips AuthzAssessmentService and returns assessments without a permissions field. The UI treated that as no read access and disabled the button.


<img width="229" height="126" alt="Captura desde 2026-06-16 07-26-32" src="https://github.com/user-attachments/assets/6606faaa-6b00-4b81-82ce-3ae71d9fc509" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assessments now automatically default to owner permissions (read, share, delete) when explicit permissions are not provided by the API, ensuring consistent permission handling.

* **Tests**
  * Added test coverage for assessment permission resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->