### PR TITLE
ECOPROJECT-4828 | fix: show download modal after updating OVA configuration

### DIFF
--- a/src/ui/environment/views/Environment.tsx
+++ b/src/ui/environment/views/Environment.tsx
@@ -184,8 +184,11 @@ const EnvironmentContent: React.FC<EnvironmentContentProps> = ({ vm }) => {
             setShouldShowEditModal(false);
           }}
           sourceId={editSourceId}
-          onSuccess={() => {
-            void vm.listSources();
+          onSuccess={(url, name) => {
+            setShouldShowEditModal(false);
+            setDownloadUrlForModal(url);
+            setSourceNameForModal(name);
+            setShouldShowDownloadModal(true);
           }}
         />
       )}

--- a/src/ui/environment/views/environment-modals/EnvironmentModal.tsx
+++ b/src/ui/environment/views/environment-modals/EnvironmentModal.tsx
@@ -25,7 +25,7 @@ type CreateModeProps = {
 
 type EditModeProps = {
   sourceId: string;
-  onSuccess?: () => void;
+  onSuccess: (downloadUrl: string, sourceName: string) => void;
 };
 
 export type EnvironmentModalProps = {
@@ -88,36 +88,35 @@ export const EnvironmentModal: React.FC<EnvironmentModalProps> = (props) => {
         });
       } else {
         const editProps = props as EditModeProps;
-        void vm
-          .updateSource({
-            sourceId: editProps.sourceId,
-            sshPublicKey: normalizeSshKey(formValues.sshKey),
-            enableProxy: formValues.enableProxy,
-            httpProxy: formValues.httpProxy,
-            httpsProxy: formValues.httpsProxy,
-            noProxy: formValues.noProxy,
-            networkConfigType: formValues.networkConfigType,
-            ipAddress: formValues.ipAddress,
-            subnetMask: formValues.subnetMask,
-            defaultGateway: formValues.defaultGateway,
-            dns: formValues.dns,
-          })
-          .then(() => {
-            void vm.listSources();
-            editProps.onSuccess?.();
-            handleClose();
-          });
+        void vm.updateSource({
+          sourceId: editProps.sourceId,
+          sshPublicKey: normalizeSshKey(formValues.sshKey),
+          enableProxy: formValues.enableProxy,
+          httpProxy: formValues.httpProxy,
+          httpsProxy: formValues.httpsProxy,
+          noProxy: formValues.noProxy,
+          networkConfigType: formValues.networkConfigType,
+          ipAddress: formValues.ipAddress,
+          subnetMask: formValues.subnetMask,
+          defaultGateway: formValues.defaultGateway,
+          dns: formValues.dns,
+        });
       }
     },
     [vm, mode, props, handleClose],
   );
 
   useEffect(() => {
-    if (mode === "create" && vm.downloadSourceUrl && isOpen) {
+    if (vm.downloadSourceUrl && isOpen) {
       const url = vm.downloadSourceUrl;
-      const name = initialValues?.environmentName || "";
       void Promise.resolve().then(() => {
-        (props as CreateModeProps).onSuccess(url, name);
+        if (mode === "create") {
+          const name = initialValues?.environmentName || "";
+          props.onSuccess(url, name);
+        } else {
+          const sourceName = editSource?.name || "";
+          props.onSuccess(url, sourceName);
+        }
         resetForm();
       });
     }

--- a/src/ui/environment/views/environment-modals/__tests__/EnvironmentModal.test.tsx
+++ b/src/ui/environment/views/environment-modals/__tests__/EnvironmentModal.test.tsx
@@ -194,6 +194,7 @@ describe("EnvironmentModal - Edit mode", () => {
       isOpen: true,
       onClose: vi.fn(),
       sourceId: "source-123",
+      onSuccess: vi.fn(),
     };
 
     render(
@@ -212,6 +213,7 @@ describe("EnvironmentModal - Edit mode", () => {
       isOpen: false,
       onClose: vi.fn(),
       sourceId: "source-123",
+      onSuccess: vi.fn(),
     };
 
     render(
@@ -230,6 +232,7 @@ describe("EnvironmentModal - Edit mode", () => {
       isOpen: true,
       onClose: vi.fn(),
       sourceId: "source-123",
+      onSuccess: vi.fn(),
     };
 
     render(
@@ -248,6 +251,7 @@ describe("EnvironmentModal - Edit mode", () => {
       isOpen: true,
       onClose: vi.fn(),
       sourceId: "source-123",
+      onSuccess: vi.fn(),
     };
 
     render(
@@ -266,6 +270,7 @@ describe("EnvironmentModal - Edit mode", () => {
       isOpen: true,
       onClose,
       sourceId: "source-123",
+      onSuccess: vi.fn(),
     };
 
     render(
@@ -283,6 +288,7 @@ describe("EnvironmentModal - Edit mode", () => {
       isOpen: true,
       onClose: vi.fn(),
       sourceId: "source-123",
+      onSuccess: vi.fn(),
     };
 
     render(


### PR DESCRIPTION
Previously, after editing an environment and clicking "Update OVA configuration", if the user then clicked "Add environment", the download modal would appear instead of the empty create form.

This was caused by a stale downloadSourceUrl in the view model that wasn't properly scoped to create vs edit modes.

Solution: Unified the onSuccess callback signature for both create and edit modes to trigger the download modal in both cases. The useEffect now properly handles downloadSourceUrl for both flows, ensuring the download modal appears after both creating and updating an environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved environment source editing: after successfully updating a source, the system automatically opens a download step with the updated details pre-populated.

* **Tests**
  * Updated test coverage for the revised source editing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->