### PR TITLE
ECOPROJECT-4812 | fix: Proxy URL is incorrectly optional when No Proxy Domains is specified

### DIFF
--- a/src/data/stores/SourcesStore.ts
+++ b/src/data/stores/SourcesStore.ts
@@ -38,24 +38,12 @@ const buildProxyPayload = (
   httpProxy: string,
   httpsProxy: string,
   noProxy: string,
-): ProxyPayload | undefined => {
-  const proxyFields: {
-    httpUrl?: string;
-    httpsUrl?: string;
-    noProxy?: string;
-  } = {};
-
-  if (httpProxy && httpProxy.trim()) {
-    proxyFields.httpUrl = httpProxy;
-  }
-  if (httpsProxy && httpsProxy.trim()) {
-    proxyFields.httpsUrl = httpsProxy;
-  }
-  if (noProxy && noProxy.trim()) {
-    proxyFields.noProxy = noProxy;
-  }
-
-  return Object.keys(proxyFields).length > 0 ? proxyFields : undefined;
+): ProxyPayload => {
+  return {
+    httpUrl: httpProxy && httpProxy.trim() ? httpProxy : null,
+    httpsUrl: httpsProxy && httpsProxy.trim() ? httpsProxy : null,
+    noProxy: noProxy && noProxy.trim() ? noProxy : null,
+  };
 };
 
 const buildNetworkPayload = (

--- a/src/ui/environment/views/environment-modals/EnvironmentForm.tsx
+++ b/src/ui/environment/views/environment-modals/EnvironmentForm.tsx
@@ -106,6 +106,19 @@ const createBaseValidationSchema = () =>
         if (!value) return true;
         const error = validateNoProxy(value);
         return error === null ? true : this.createError({ message: error });
+      })
+      .when(["httpProxy", "httpsProxy"], {
+        is: (httpProxy: string, httpsProxy: string) => {
+          return !httpProxy?.trim() && !httpsProxy?.trim();
+        },
+        then: (schema) =>
+          schema.test("requires-proxy-url", function (value) {
+            if (!value?.trim()) return true;
+            return this.createError({
+              message:
+                "No proxy domains requires at least one proxy URL (HTTP or HTTPS)",
+            });
+          }),
       }),
 
     networkConfigType: yup
@@ -217,10 +230,24 @@ export const EnvironmentForm: React.FC<EnvironmentFormProps> = ({
     control: methods.control,
     name: "networkConfigType",
   });
+  const httpProxy = useWatch({
+    control: methods.control,
+    name: "httpProxy",
+  });
+  const httpsProxy = useWatch({
+    control: methods.control,
+    name: "httpsProxy",
+  });
 
   useEffect(() => {
     setIsValid?.(methods.formState.isValid);
   }, [methods.formState.isValid, setIsValid]);
+
+  useEffect(() => {
+    if (methods.formState.touchedFields.noProxy) {
+      void methods.trigger("noProxy");
+    }
+  }, [httpProxy, httpsProxy, methods]);
 
   return (
     <FormProvider {...methods}>


### PR DESCRIPTION
When configuring an environment, the system allows the user to define values in the No Proxy Domains field without requiring a Proxy URL. This leads to an inconsistent and potentially invalid configuration, since No Proxy Domains are only meaningful in the context of an active proxy setup.