### PR TITLE
ECOPROJECT-4384 | feat: add group filter to assessment report

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4810,6 +4810,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/http-proxy": {
+      "version": "1.17.17",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
+      "integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/humanize-plus": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@types/humanize-plus/-/humanize-plus-1.8.2.tgz",
@@ -10978,23 +10988,6 @@
         "node": ">= 20"
       }
     },
-    "node_modules/http-proxy-middleware": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-4.1.1.tgz",
-      "integrity": "sha512-KX5ZofGXLFXqFAkQoOWZ+rTtaLTut7m0gyL+QzJrdejtIZ+F4bPPDoe7reISg2+v0CAz5OfVwEJEhty7X+e57g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.3",
-        "httpxy": "^0.5.3",
-        "is-glob": "^4.0.3",
-        "is-plain-obj": "^4.1.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": "^22.15.0 || ^24.0.0 || >=26.0.0"
-      }
-    },
     "node_modules/http-server": {
       "version": "14.1.1",
       "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
@@ -11035,13 +11028,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/httpxy": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.5.3.tgz",
-      "integrity": "sha512-SMS9V6Sn7VWaS11lYhoAr0ceoaiolTWf4jYdJn0NJhCdKMu9R2H9Fh0LBDWBHQF6HRLI1PmaePYsjanSpE5PEw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/humanize-plus": {
       "version": "1.8.2",
@@ -19511,6 +19497,31 @@
         "node": ">= 6"
       }
     },
+    "node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.8",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "is-plain-obj": "^3.0.0",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@types/express": "^4.17.13"
+      },
+      "peerDependenciesMeta": {
+        "@types/express": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webpack-dev-server/node_modules/ipaddr.js": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
@@ -19519,6 +19530,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/is-plain-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/webpack-dev-server/node_modules/picomatch": {

--- a/package.json
+++ b/package.json
@@ -87,8 +87,7 @@
   },
   "overrides": {
     "@redhat-cloud-services/frontend-components-config": {
-      "webpack-dev-server": ">=5.2.5",
-      "http-proxy-middleware": ">=3.0.6"
+      "webpack-dev-server": ">=5.2.5"
     },
     "@redhat-cloud-services/tsc-transform-imports": {
       "glob": ">=10.4.6"

--- a/src/data/stores/AssessmentsStore.ts
+++ b/src/data/stores/AssessmentsStore.ts
@@ -102,6 +102,31 @@ export class AssessmentsStore
     return this.assessments.find((assessment) => assessment.id === id);
   }
 
+  async get(
+    id: string,
+    initOverrides?: RequestInit | InitOverrideFunction,
+  ): Promise<AssessmentModel> {
+    let raw;
+    try {
+      raw = await this.api.getAssessment({ id }, initOverrides);
+    } catch (err) {
+      throw await parseApiError(err, "Failed to fetch assessment");
+    }
+    const model = createAssessmentModel(raw);
+    const existingIndex = this.assessments.findIndex(
+      (assessment) => assessment.id === model.id,
+    );
+    if (existingIndex >= 0) {
+      this.assessments = this.assessments.map((assessment) =>
+        assessment.id === model.id ? model : assessment,
+      );
+    } else {
+      this.assessments = [...this.assessments, model];
+    }
+    this.notify();
+    return model;
+  }
+
   async create(
     assessmentForm: AssessmentCreateForm,
     initOverrides?: RequestInit | InitOverrideFunction,

--- a/src/data/stores/__tests__/AssessmentsStore.test.ts
+++ b/src/data/stores/__tests__/AssessmentsStore.test.ts
@@ -23,6 +23,7 @@ const makeAssessment = (overrides: Partial<Assessment> = {}): Assessment =>
 const createMockApi = (): AssessmentApiInterface =>
   ({
     listAssessments: vi.fn(),
+    getAssessment: vi.fn(),
     createAssessment: vi.fn(),
     updateAssessment: vi.fn(),
     deleteAssessment: vi.fn(),
@@ -93,6 +94,32 @@ describe("AssessmentsStore", () => {
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("a-1");
     expect(result[0].name).toBe("Assessment");
+  });
+
+  it("get() fetches and upserts a single assessment", async () => {
+    const raw = makeAssessment({ id: "a-1", name: "Detailed" });
+    vi.mocked(api.getAssessment).mockResolvedValue(raw);
+
+    const result = await store.get("a-1");
+
+    expect(api.getAssessment).toHaveBeenCalledWith({ id: "a-1" }, undefined);
+    expect(result.id).toBe("a-1");
+    expect(store.getSnapshot()).toHaveLength(1);
+    expect(store.getById("a-1")?.name).toBe("Detailed");
+  });
+
+  it("get() replaces an existing assessment in local state", async () => {
+    const listed = makeAssessment({ id: "a-1", name: "Listed" });
+    vi.mocked(api.listAssessments).mockResolvedValue([listed]);
+    await store.list();
+
+    const detailed = makeAssessment({ id: "a-1", name: "Detailed" });
+    vi.mocked(api.getAssessment).mockResolvedValue(detailed);
+
+    await store.get("a-1");
+
+    expect(store.getById("a-1")?.name).toBe("Detailed");
+    expect(store.getSnapshot()).toHaveLength(1);
   });
 
   it("list() maps results to AssessmentModel (has ownerFullName, hasUsefulData etc.)", async () => {

--- a/src/data/stores/interfaces/IAssessmentsStore.ts
+++ b/src/data/stores/interfaces/IAssessmentsStore.ts
@@ -33,6 +33,10 @@ export interface IAssessmentsStore extends ExternalStore<AssessmentModel[]> {
     sourceId?: string,
     initOverrides?: RequestInit | InitOverrideFunction,
   ): Promise<AssessmentModel[]>;
+  get(
+    id: string,
+    initOverrides?: RequestInit | InitOverrideFunction,
+  ): Promise<AssessmentModel>;
   getById(id: string): AssessmentModel | undefined;
   create(
     assessmentForm: AssessmentCreateForm,

--- a/src/services/html-export/types.ts
+++ b/src/services/html-export/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type {
+  AssessmentSubsetInventory,
   Infra,
   InventoryData as ApiInventoryData,
   VMs,
@@ -117,4 +118,5 @@ export interface SnapshotLike {
     };
     clusters?: Record<string, unknown> | { [key: string]: ApiInventoryData };
   };
+  subsetInventories?: AssessmentSubsetInventory[] | null;
 }

--- a/src/ui/report/helpers/__tests__/groupInventoryFilter.test.ts
+++ b/src/ui/report/helpers/__tests__/groupInventoryFilter.test.ts
@@ -1,0 +1,190 @@
+import type {
+  Host,
+  Infra,
+  InventoryData,
+  VMs,
+} from "@openshift-migration-advisor/planner-sdk";
+import { describe, expect, it } from "vitest";
+
+import type { SnapshotLike } from "../../../../services/html-export/types";
+import {
+  assessmentHasSubsetDataFetched,
+  extractScopedInventoryData,
+  resolveActiveInventory,
+  resolveEffectiveGroupId,
+} from "../groupInventoryFilter";
+import { ALL_VMS_GROUP_ID } from "../groupViewModel";
+
+const createInfra = (totalHosts: number): Infra => ({
+  totalHosts,
+  hosts: Array(totalHosts).fill({}) as Host[],
+  clustersPerDatacenter: [],
+  hostPowerStates: {},
+  networks: [],
+  datastores: [],
+});
+
+const createVMs = (total: number): VMs => ({
+  total,
+  totalMigratable: total,
+  os: { Linux: total },
+  cpuCores: {
+    total,
+    totalForMigratable: total,
+    totalForMigratableWithWarnings: 0,
+    totalForNotMigratable: 0,
+  },
+  ramGB: {
+    total,
+    totalForMigratable: total,
+    totalForMigratableWithWarnings: 0,
+    totalForNotMigratable: 0,
+  },
+  diskGB: {
+    total: 0,
+    totalForMigratable: 0,
+    totalForMigratableWithWarnings: 0,
+    totalForNotMigratable: 0,
+  },
+  diskCount: {
+    total: 0,
+    totalForMigratable: 0,
+    totalForMigratableWithWarnings: 0,
+    totalForNotMigratable: 0,
+  },
+  diskSizeTier: {},
+  diskTypes: {},
+  nicCount: {
+    total: 0,
+    totalForMigratable: 0,
+    totalForMigratableWithWarnings: 0,
+    totalForNotMigratable: 0,
+  },
+  migrationWarnings: [],
+  notMigratableReasons: [],
+  powerStates: {},
+  distributionByCpuTier: {},
+  distributionByMemoryTier: {},
+});
+
+describe("groupInventoryFilter", () => {
+  describe("resolveEffectiveGroupId", () => {
+    it("defaults to all VMs when nothing is selected", () => {
+      expect(resolveEffectiveGroupId(null, [])).toBe(ALL_VMS_GROUP_ID);
+    });
+
+    it("returns a valid user selection", () => {
+      const subsets = [{ id: "group-1", name: "G1" }] as never[];
+      expect(resolveEffectiveGroupId("group-1", subsets)).toBe("group-1");
+    });
+
+    it("falls back to all VMs for invalid selections", () => {
+      const subsets = [{ id: "group-1", name: "G1" }] as never[];
+      expect(resolveEffectiveGroupId("missing", subsets)).toBe(
+        ALL_VMS_GROUP_ID,
+      );
+    });
+  });
+
+  describe("resolveActiveInventory", () => {
+    const clusterData: InventoryData = {
+      infra: createInfra(5),
+      vms: createVMs(10),
+    };
+    const fullInventory = {
+      vcenterId: "vc-1",
+      clusters: { "Cluster-A": clusterData },
+      vcenter: { infra: createInfra(5), vms: createVMs(10) },
+    };
+
+    it("returns full inventory for all VMs selection", () => {
+      expect(resolveActiveInventory(ALL_VMS_GROUP_ID, [], fullInventory)).toBe(
+        fullInventory,
+      );
+    });
+
+    it("returns subset inventory when a group is selected", () => {
+      const subsetInventory = {
+        vcenterId: "vc-1",
+        clusters: {
+          "Cluster-A": {
+            infra: createInfra(2),
+            vms: createVMs(3),
+          },
+        },
+        vcenter: { infra: createInfra(2), vms: createVMs(3) },
+      };
+      const subsets = [
+        { id: "group-1", name: "G1", inventory: subsetInventory },
+      ] as never[];
+
+      expect(resolveActiveInventory("group-1", subsets, fullInventory)).toBe(
+        subsetInventory,
+      );
+    });
+  });
+
+  describe("extractScopedInventoryData", () => {
+    it("prefers active inventory fields over snapshot fallbacks", () => {
+      const activeInventory = {
+        infra: createInfra(2),
+        vms: createVMs(3),
+        clusters: {
+          "Cluster-A": {
+            infra: createInfra(2),
+            vms: createVMs(3),
+          },
+        },
+      };
+      const latestSnapshot: SnapshotLike = {
+        infra: createInfra(99),
+        vms: createVMs(99),
+      };
+
+      const result = extractScopedInventoryData(
+        activeInventory,
+        latestSnapshot,
+      );
+      expect(result.infra?.totalHosts).toBe(2);
+      expect(result.vms?.total).toBe(3);
+      expect(result.clusters).toEqual(activeInventory.clusters);
+    });
+
+    it("falls back to snapshot inventory when active inventory is empty", () => {
+      const latestSnapshot: SnapshotLike = {
+        inventory: {
+          vcenter: {
+            infra: createInfra(4),
+            vms: createVMs(8),
+          },
+        },
+      };
+
+      const result = extractScopedInventoryData(undefined, latestSnapshot);
+      expect(result.infra?.totalHosts).toBe(4);
+      expect(result.vms?.total).toBe(8);
+    });
+  });
+
+  describe("assessmentHasSubsetDataFetched", () => {
+    it("returns false when snapshots are missing", () => {
+      expect(assessmentHasSubsetDataFetched(undefined)).toBe(false);
+      expect(assessmentHasSubsetDataFetched([])).toBe(false);
+    });
+
+    it("returns false when latest snapshot omits subsetInventories (list response)", () => {
+      expect(assessmentHasSubsetDataFetched([{ createdAt: new Date() }])).toBe(
+        false,
+      );
+    });
+
+    it("returns true when latest snapshot includes subsetInventories (GET response)", () => {
+      expect(
+        assessmentHasSubsetDataFetched([
+          { createdAt: new Date() },
+          { createdAt: new Date(), subsetInventories: null },
+        ]),
+      ).toBe(true);
+    });
+  });
+});

--- a/src/ui/report/helpers/__tests__/groupViewModel.test.ts
+++ b/src/ui/report/helpers/__tests__/groupViewModel.test.ts
@@ -1,0 +1,55 @@
+import type { AssessmentSubsetInventory } from "@openshift-migration-advisor/planner-sdk";
+import { describe, expect, it } from "vitest";
+
+import { buildGroupViewModel } from "../groupViewModel";
+
+const createSubset = (
+  overrides: Partial<AssessmentSubsetInventory> = {},
+): AssessmentSubsetInventory => ({
+  id: "group-1",
+  name: "Group 1",
+  vcenterId: "vcenter-1",
+  vmsCount: 350,
+  createdAt: new Date(),
+  inventory: {
+    vcenterId: "vcenter-1",
+    clusters: {},
+  },
+  ...overrides,
+});
+
+describe("buildGroupViewModel", () => {
+  it("hides the group filter when no subset inventories exist", () => {
+    const model = buildGroupViewModel({ subsetInventories: [] });
+
+    expect(model.showGroupFilter).toBe(false);
+    expect(model.groupSelectDisabled).toBe(true);
+    expect(model.selectionLabel).toBe("All VMs");
+  });
+
+  it("returns All VMs plus subset options sorted by API order", () => {
+    const model = buildGroupViewModel({
+      subsetInventories: [
+        createSubset({ id: "group-1", name: "Group 1", vmsCount: 350 }),
+        createSubset({ id: "group-2", name: "Group 2", vmsCount: 180 }),
+      ],
+    });
+
+    expect(model.showGroupFilter).toBe(true);
+    expect(model.groupOptions).toEqual([
+      { id: "all", label: "All VMs" },
+      { id: "group-1", label: "Group 1 (350 VMs)" },
+      { id: "group-2", label: "Group 2 (180 VMs)" },
+    ]);
+  });
+
+  it("falls back to All VMs when the selected group is invalid", () => {
+    const model = buildGroupViewModel({
+      subsetInventories: [createSubset()],
+      selectedGroupId: "missing-group",
+    });
+
+    expect(model.selectionId).toBe("all");
+    expect(model.selectionLabel).toBe("All VMs");
+  });
+});

--- a/src/ui/report/helpers/groupInventoryFilter.ts
+++ b/src/ui/report/helpers/groupInventoryFilter.ts
@@ -1,0 +1,86 @@
+import type {
+  AssessmentSubsetInventory,
+  Infra,
+  Inventory,
+  InventoryData,
+  VMs,
+} from "@openshift-migration-advisor/planner-sdk";
+
+import type { SnapshotLike } from "../../../services/html-export/types";
+import { ALL_VMS_GROUP_ID } from "./groupViewModel";
+
+export type ReportInventorySource = {
+  infra?: Infra;
+  vms?: VMs;
+  vcenter?: { infra?: Infra; vms?: VMs };
+  clusters?: { [key: string]: InventoryData };
+};
+
+export const resolveEffectiveGroupId = (
+  userSelectedGroupId: string | null,
+  subsetInventories: AssessmentSubsetInventory[],
+): string => {
+  if (userSelectedGroupId !== null) {
+    const isValidSelection =
+      userSelectedGroupId === ALL_VMS_GROUP_ID ||
+      subsetInventories.some((subset) => subset.id === userSelectedGroupId);
+    if (isValidSelection) {
+      return userSelectedGroupId;
+    }
+  }
+  return ALL_VMS_GROUP_ID;
+};
+
+export const resolveActiveInventory = (
+  selectedGroupId: string,
+  subsetInventories: AssessmentSubsetInventory[],
+  fullInventory: Inventory | ReportInventorySource | undefined,
+): ReportInventorySource | undefined => {
+  if (selectedGroupId !== ALL_VMS_GROUP_ID) {
+    const subset = subsetInventories.find(
+      (entry) => entry.id === selectedGroupId,
+    );
+    if (subset?.inventory) {
+      return subset.inventory;
+    }
+  }
+  return fullInventory;
+};
+
+export const extractScopedInventoryData = (
+  activeInventory: ReportInventorySource | undefined,
+  latestSnapshot: SnapshotLike,
+): {
+  infra: Infra | undefined;
+  vms: VMs | undefined;
+  clusters: { [key: string]: InventoryData } | undefined;
+} => ({
+  infra: (activeInventory?.infra ||
+    activeInventory?.vcenter?.infra ||
+    latestSnapshot.infra ||
+    latestSnapshot.inventory?.infra ||
+    latestSnapshot.inventory?.vcenter?.infra) as Infra | undefined,
+  vms: (activeInventory?.vms ||
+    activeInventory?.vcenter?.vms ||
+    latestSnapshot.vms ||
+    latestSnapshot.inventory?.vms ||
+    latestSnapshot.inventory?.vcenter?.vms) as VMs | undefined,
+  clusters: activeInventory?.clusters,
+});
+
+/**
+ * GET assessment responses include `subsetInventories` (nullable).
+ * LIST responses omit the field entirely — use that to skip redundant fetches.
+ */
+export const assessmentHasSubsetDataFetched = (
+  snapshots: SnapshotLike[] | undefined,
+): boolean => {
+  if (!snapshots?.length) {
+    return false;
+  }
+  const latestSnapshot = snapshots[snapshots.length - 1];
+  return Object.prototype.hasOwnProperty.call(
+    latestSnapshot,
+    "subsetInventories",
+  );
+};

--- a/src/ui/report/helpers/groupViewModel.ts
+++ b/src/ui/report/helpers/groupViewModel.ts
@@ -1,0 +1,51 @@
+import type { AssessmentSubsetInventory } from "@openshift-migration-advisor/planner-sdk";
+
+export const ALL_VMS_GROUP_ID = "all";
+
+export type GroupOption = { id: string; label: string };
+
+export type GroupViewModel = {
+  groupOptions: GroupOption[];
+  selectionId: string;
+  selectionLabel: string;
+  showGroupFilter: boolean;
+  groupSelectDisabled: boolean;
+};
+
+export const buildGroupViewModel = ({
+  subsetInventories,
+  selectedGroupId = ALL_VMS_GROUP_ID,
+}: {
+  subsetInventories?: AssessmentSubsetInventory[];
+  selectedGroupId?: string;
+}): GroupViewModel => {
+  const subsets = subsetInventories ?? [];
+  const showGroupFilter = subsets.length > 0;
+
+  const groupOptions: GroupOption[] = [
+    { id: ALL_VMS_GROUP_ID, label: "All VMs" },
+    ...subsets.map((subset) => ({
+      id: subset.id,
+      label: `${subset.name} (${subset.vmsCount} VMs)`,
+    })),
+  ];
+
+  const isValidSelection =
+    selectedGroupId === ALL_VMS_GROUP_ID ||
+    subsets.some((subset) => subset.id === selectedGroupId);
+  const effectiveSelection = isValidSelection
+    ? selectedGroupId
+    : ALL_VMS_GROUP_ID;
+
+  const selectedOption =
+    groupOptions.find((option) => option.id === effectiveSelection) ??
+    groupOptions[0];
+
+  return {
+    groupOptions,
+    selectionId: effectiveSelection,
+    selectionLabel: selectedOption.label,
+    showGroupFilter,
+    groupSelectDisabled: !showGroupFilter,
+  };
+};

--- a/src/ui/report/view-models/__tests__/useExampleReportViewModel.test.ts
+++ b/src/ui/report/view-models/__tests__/useExampleReportViewModel.test.ts
@@ -1,0 +1,55 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ALL_VMS_GROUP_ID } from "../../helpers/groupViewModel";
+import { getExampleInventory } from "../../views/example-data/inventoryFixture";
+import { getExampleSubsetInventories } from "../../views/example-data/subsetInventoryFixture";
+import { useExampleReportViewModel } from "../useExampleReportViewModel";
+
+describe("useExampleReportViewModel", () => {
+  it("shows group filter options from example subset inventories", () => {
+    const { result } = renderHook(() => useExampleReportViewModel());
+
+    expect(result.current.groupView.showGroupFilter).toBe(true);
+    expect(result.current.groupView.groupOptions.length).toBeGreaterThan(1);
+    expect(result.current.selectedGroupId).toBe(ALL_VMS_GROUP_ID);
+  });
+
+  it("scopes dashboard data when a group is selected", () => {
+    const fullInventory = getExampleInventory();
+    const subsets = getExampleSubsetInventories(fullInventory);
+    const targetGroup = subsets[0];
+
+    const { result } = renderHook(() => useExampleReportViewModel());
+    const fullVmTotal = result.current.clusterView.viewVms?.total;
+
+    act(() => {
+      result.current.handleGroupSelect(undefined, targetGroup.id);
+    });
+
+    expect(result.current.selectedGroupId).toBe(targetGroup.id);
+    expect(result.current.clusterView.viewVms?.total).toBe(
+      targetGroup.inventory?.vcenter?.vms?.total,
+    );
+    expect(result.current.clusterView.viewVms?.total).not.toBe(fullVmTotal);
+    expect(result.current.detectedSummaryText).toContain(
+      String(fullInventory.vcenter?.vms?.total),
+    );
+  });
+
+  it("resets cluster selection when group changes", () => {
+    const { result } = renderHook(() => useExampleReportViewModel());
+
+    act(() => {
+      result.current.handleClusterSelect(undefined, "all");
+    });
+    expect(result.current.selectedClusterId).toBe("all");
+
+    const subsets = getExampleSubsetInventories(getExampleInventory());
+    act(() => {
+      result.current.handleGroupSelect(undefined, subsets[0].id);
+    });
+
+    expect(result.current.selectedClusterId).toBe("all");
+  });
+});

--- a/src/ui/report/view-models/__tests__/useReportPageViewModel.test.ts
+++ b/src/ui/report/view-models/__tests__/useReportPageViewModel.test.ts
@@ -12,6 +12,9 @@ import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createSourceModel } from "../../../../models/SourceModel";
+import { mockClusterRequirementsResponse } from "../../views/cluster-sizer/__tests__/mocks/ClusterRequirementsResponse.mock";
+import { EXAMPLE_FORM_VALUES } from "../../views/example-data/clusterSizingFixture";
+import type { SizingPdfData } from "../useReportPageViewModel";
 import { useReportPageViewModel } from "../useReportPageViewModel";
 
 // ---------------------------------------------------------------------------
@@ -54,6 +57,7 @@ const mockAssessmentsStore = {
   subscribe: vi.fn(() => () => {}),
   getSnapshot: vi.fn((): Assessment[] => []),
   list: vi.fn().mockResolvedValue([]),
+  get: vi.fn().mockResolvedValue(undefined),
   getById: vi.fn(),
   startPolling: vi.fn(),
   stopPolling: vi.fn(),
@@ -211,6 +215,16 @@ const mockSource = createSourceModel({
   },
 });
 
+const createSizingPdfData = (
+  clusterId: string,
+  clusterName: string,
+): SizingPdfData => ({
+  clusterId,
+  clusterName,
+  formValues: EXAMPLE_FORM_VALUES,
+  result: mockClusterRequirementsResponse,
+});
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -245,12 +259,48 @@ describe("useReportPageViewModel", () => {
     expect(result.current.assessment?.name).toBe("Assessment assessment-1");
   });
 
-  it("fetches data on mount when assessments are empty", () => {
+  it("fetches assessment by ID and sources on mount", () => {
     mockAssessmentsStore.getSnapshot.mockReturnValue([]);
+    mockAssessmentsStore.getById.mockReturnValue(undefined);
     renderHook(() => useReportPageViewModel());
 
-    // useMount triggers and calls the fetch fn
-    expect(mockAssessmentsStore.list).toHaveBeenCalled();
+    expect(mockAssessmentsStore.get).toHaveBeenCalledWith("assessment-1");
+    expect(mockSourcesStore.list).toHaveBeenCalled();
+  });
+
+  it("skips GET assessment when cached snapshot already has subsetInventories", () => {
+    const assessment = createAssessment("assessment-1", {
+      "Cluster-A": { infra: createInfra(2, 2), vms: createVMs(5) },
+    });
+    assessment.snapshots = [
+      {
+        createdAt: new Date(),
+        inventory: assessment.snapshots?.[0]?.inventory ?? {
+          vcenterId: "vcenter-1",
+          clusters: {},
+        },
+        subsetInventories: null,
+      },
+    ];
+    mockAssessmentsStore.getSnapshot.mockReturnValue([assessment]);
+    mockAssessmentsStore.getById.mockReturnValue(assessment);
+
+    renderHook(() => useReportPageViewModel());
+
+    expect(mockAssessmentsStore.get).not.toHaveBeenCalled();
+    expect(mockSourcesStore.list).toHaveBeenCalled();
+  });
+
+  it("fetches GET assessment when cached snapshot lacks subsetInventories key", () => {
+    const assessment = createAssessment("assessment-1", {
+      "Cluster-A": { infra: createInfra(2, 2), vms: createVMs(5) },
+    });
+    mockAssessmentsStore.getSnapshot.mockReturnValue([assessment]);
+    mockAssessmentsStore.getById.mockReturnValue(assessment);
+
+    renderHook(() => useReportPageViewModel());
+
+    expect(mockAssessmentsStore.get).toHaveBeenCalledWith("assessment-1");
     expect(mockSourcesStore.list).toHaveBeenCalled();
   });
 
@@ -431,6 +481,87 @@ describe("useReportPageViewModel", () => {
       );
     });
 
+    it("exportPdf includes only sized clusters from the active group in aggregate view", () => {
+      const assessment = createAssessment("assessment-1", {
+        "Cluster-A": { infra: createInfra(2, 2), vms: createVMs(5) },
+        "Cluster-B": { infra: createInfra(2, 2), vms: createVMs(6) },
+        "Cluster-C": { infra: createInfra(2, 2), vms: createVMs(4) },
+      });
+      assessment.snapshots = [
+        {
+          createdAt: new Date(),
+          inventory: assessment.snapshots?.[0]?.inventory ?? {
+            vcenterId: "vcenter-1",
+            clusters: {},
+          },
+          subsetInventories: [
+            {
+              id: "group-1",
+              name: "Group 1",
+              vcenterId: "vcenter-1",
+              vmsCount: 9,
+              createdAt: new Date(),
+              inventory: {
+                vcenterId: "vcenter-1",
+                clusters: {
+                  "Cluster-A": {
+                    infra: createInfra(2, 2),
+                    vms: createVMs(5),
+                  },
+                  "Cluster-C": {
+                    infra: createInfra(2, 2),
+                    vms: createVMs(4),
+                  },
+                },
+                vcenter: {
+                  infra: createInfra(4, 4),
+                  vms: createVMs(9),
+                },
+              },
+            },
+          ],
+        },
+      ];
+      mockAssessmentsStore.getSnapshot.mockReturnValue([assessment]);
+
+      const { result } = renderHook(() => useReportPageViewModel());
+      const mockContainer = document.createElement("div");
+
+      act(() => {
+        result.current.onSizingCalculated(
+          createSizingPdfData("Cluster-A", "Cluster A"),
+        );
+        result.current.onSizingCalculated(
+          createSizingPdfData("Cluster-B", "Cluster B"),
+        );
+        result.current.onSizingCalculated(
+          createSizingPdfData("Cluster-C", "Cluster C"),
+        );
+        result.current.selectGroup("group-1");
+        result.current.selectCluster("all");
+      });
+
+      act(() => {
+        result.current.exportPdf(mockContainer);
+      });
+
+      const calls = mockReportStore.exportPdf.mock.calls as Array<
+        [
+          HTMLElement,
+          { additionalTocItems?: string[]; extraPages?: unknown[] } | undefined,
+        ]
+      >;
+      const exportOptions = calls[0]?.[1];
+      expect(exportOptions?.additionalTocItems).toHaveLength(2);
+      expect(exportOptions?.additionalTocItems).toEqual(
+        expect.arrayContaining([
+          "- Cluster sizing recommendations: Cluster A",
+          "- Cluster sizing recommendations: Cluster C",
+        ]),
+      );
+      expect(exportOptions?.extraPages).toHaveLength(2);
+    });
+
     it("exportHtml delegates to store.exportHtml()", () => {
       const { result } = renderHook(() => useReportPageViewModel());
 
@@ -439,6 +570,62 @@ describe("useReportPageViewModel", () => {
       });
 
       expect(mockReportStore.exportHtml).toHaveBeenCalledTimes(1);
+    });
+
+    it("exportHtml uses scoped inventory when a group is selected", () => {
+      const assessment = createAssessment("assessment-1", {
+        "Cluster-A": { infra: createInfra(2, 2), vms: createVMs(10) },
+      });
+      const subsetInventory = {
+        vcenterId: "vcenter-1",
+        clusters: {
+          "Cluster-A": {
+            infra: createInfra(1, 1),
+            vms: createVMs(3),
+          },
+        },
+        vcenter: {
+          infra: createInfra(1, 1),
+          vms: createVMs(3),
+        },
+      };
+      assessment.snapshots = [
+        {
+          createdAt: new Date(),
+          inventory: assessment.snapshots?.[0]?.inventory ?? {
+            vcenterId: "vcenter-1",
+            clusters: {},
+          },
+          subsetInventories: [
+            {
+              id: "group-1",
+              name: "Group 1",
+              vcenterId: "vcenter-1",
+              vmsCount: 3,
+              createdAt: new Date(),
+              inventory: subsetInventory,
+            },
+          ],
+        },
+      ];
+      mockAssessmentsStore.getSnapshot.mockReturnValue([assessment]);
+
+      const { result } = renderHook(() => useReportPageViewModel());
+
+      act(() => {
+        result.current.selectGroup("group-1");
+      });
+
+      act(() => {
+        result.current.exportHtml();
+      });
+
+      expect(mockReportStore.exportHtml).toHaveBeenCalledTimes(1);
+      const calls = mockReportStore.exportHtml.mock.calls as Array<
+        [unknown, { documentTitle?: string } | undefined]
+      >;
+      expect(calls[0]?.[0]).toBe(subsetInventory);
+      expect(calls[0]?.[1]?.documentTitle).toContain("Group 1");
     });
   });
 
@@ -498,6 +685,72 @@ describe("useReportPageViewModel", () => {
 
       const { result } = renderHook(() => useReportPageViewModel());
       expect(result.current.clusterSelectDisabled).toBe(false);
+    });
+  });
+
+  describe("group selection", () => {
+    it("hides group filter when no subset inventories are present", () => {
+      const assessment = createAssessment("assessment-1", {
+        "Cluster-A": { infra: createInfra(2, 2), vms: createVMs(5) },
+      });
+      mockAssessmentsStore.getSnapshot.mockReturnValue([assessment]);
+
+      const { result } = renderHook(() => useReportPageViewModel());
+      expect(result.current.groupView.showGroupFilter).toBe(false);
+      expect(result.current.selectedGroupId).toBe("all");
+    });
+
+    it("shows group options from subset inventories and scopes dashboard data", () => {
+      const assessment = createAssessment("assessment-1", {
+        "Cluster-A": { infra: createInfra(2, 2), vms: createVMs(10) },
+      });
+      assessment.snapshots = [
+        {
+          createdAt: new Date(),
+          inventory: assessment.snapshots?.[0]?.inventory ?? {
+            vcenterId: "vcenter-1",
+            clusters: {},
+          },
+          subsetInventories: [
+            {
+              id: "group-1",
+              name: "Group 1",
+              vcenterId: "vcenter-1",
+              vmsCount: 3,
+              createdAt: new Date(),
+              inventory: {
+                vcenterId: "vcenter-1",
+                clusters: {
+                  "Cluster-A": {
+                    infra: createInfra(1, 1),
+                    vms: createVMs(3),
+                  },
+                },
+                vcenter: {
+                  infra: createInfra(1, 1),
+                  vms: createVMs(3),
+                },
+              },
+            },
+          ],
+        },
+      ];
+      mockAssessmentsStore.getSnapshot.mockReturnValue([assessment]);
+
+      const { result } = renderHook(() => useReportPageViewModel());
+      expect(result.current.groupView.showGroupFilter).toBe(true);
+      expect(result.current.groupView.groupOptions).toHaveLength(2);
+      expect(result.current.groupView.groupOptions[1].label).toBe(
+        "Group 1 (3 VMs)",
+      );
+
+      act(() => {
+        result.current.selectGroup("group-1");
+      });
+
+      expect(result.current.selectedGroupId).toBe("group-1");
+      expect(result.current.clusterView.viewVms?.total).toBe(3);
+      expect(result.current.reportSummaryVms?.total).toBe(10);
     });
   });
 

--- a/src/ui/report/view-models/useExampleReportViewModel.ts
+++ b/src/ui/report/view-models/useExampleReportViewModel.ts
@@ -4,8 +4,9 @@ import type {
   InventoryData,
   VMs,
 } from "@openshift-migration-advisor/planner-sdk";
-import React, { useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 
+import { extractScopedInventoryData } from "../helpers/groupInventoryFilter";
 import {
   buildClusterViewModel,
   type ClusterViewModel,
@@ -13,6 +14,8 @@ import {
 import type { ExampleClusterData } from "../views/example-data/clusterSizingFixture";
 import { EXAMPLE_SIZING_MAP } from "../views/example-data/clusterSizingFixture";
 import { getExampleInventory } from "../views/example-data/inventoryFixture";
+import { getExampleSubsetInventories } from "../views/example-data/subsetInventoryFixture";
+import { useGroupInventoryFilter } from "./useGroupInventoryFilter";
 
 export interface ExampleReportVM {
   infra: Infra | undefined;
@@ -33,22 +36,54 @@ export interface ExampleReportVM {
     value: string | number | undefined,
   ) => void;
 
+  groupView: ReturnType<typeof useGroupInventoryFilter>["groupView"];
+  selectedGroupId: string;
+  isGroupSelectOpen: boolean;
+  setIsGroupSelectOpen: (open: boolean) => void;
+  handleGroupSelect: (
+    event: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined,
+  ) => void;
+
   isSizingWizardOpen: boolean;
   setIsSizingWizardOpen: (open: boolean) => void;
   exampleSizing: ExampleClusterData | null;
 }
 
 export function useExampleReportViewModel(): ExampleReportVM {
-  const inventory: Inventory = getExampleInventory();
-  const infra = inventory.vcenter?.infra;
-  const vms = inventory.vcenter?.vms;
-  const clusters = inventory.clusters;
+  const fullInventory: Inventory = useMemo(() => getExampleInventory(), []);
+  const subsetInventories = useMemo(
+    () => getExampleSubsetInventories(fullInventory),
+    [fullInventory],
+  );
 
   const [userSelectedClusterId, setUserSelectedClusterId] = useState<
     string | null
   >(null);
   const [isClusterSelectOpen, setIsClusterSelectOpen] = useState(false);
   const [isSizingWizardOpen, setIsSizingWizardOpen] = useState(false);
+
+  const resetClusterSelection = useCallback(() => {
+    setUserSelectedClusterId(null);
+  }, []);
+
+  const {
+    selectedGroupId,
+    groupView,
+    activeInventory,
+    isGroupSelectOpen,
+    setIsGroupSelectOpen,
+    handleGroupSelect,
+  } = useGroupInventoryFilter({
+    subsetInventories,
+    fullInventory,
+    onGroupChange: resetClusterSelection,
+  });
+
+  const { infra, vms, clusters } = useMemo(
+    () => extractScopedInventoryData(activeInventory, {}),
+    [activeInventory],
+  );
 
   const selectedClusterId = useMemo(
     () => userSelectedClusterId ?? "all",
@@ -60,8 +95,10 @@ export function useExampleReportViewModel(): ExampleReportVM {
     [infra, vms, clusters, selectedClusterId],
   );
 
-  const clusterCount = clusters ? Object.keys(clusters).length : 0;
-  const clusterSelectDisabled = clusterCount <= 0;
+  const clusterCount = fullInventory.clusters
+    ? Object.keys(fullInventory.clusters).length
+    : 0;
+  const clusterSelectDisabled = clusterView.clusterOptions.length <= 1;
 
   const exampleSizing =
     selectedClusterId !== "all"
@@ -72,12 +109,12 @@ export function useExampleReportViewModel(): ExampleReportVM {
     if (clusterCount <= 0) return "No clusters detected";
     const clusterLabel =
       clusterCount === 1 ? "vSphere cluster" : "vSphere clusters";
-    const totalVMs = vms?.total;
+    const totalVMs = fullInventory.vcenter?.vms?.total;
     if (typeof totalVMs === "number") {
       return `Detected ${totalVMs} VMs in ${clusterCount} ${clusterLabel}`;
     }
     return `Detected ${clusterCount} ${clusterLabel}`;
-  }, [vms?.total, clusterCount]);
+  }, [fullInventory.vcenter?.vms?.total, clusterCount]);
 
   const handleClusterSelect = (
     _event: React.MouseEvent<Element, MouseEvent> | undefined,
@@ -100,6 +137,11 @@ export function useExampleReportViewModel(): ExampleReportVM {
     isClusterSelectOpen,
     setIsClusterSelectOpen,
     handleClusterSelect,
+    groupView,
+    selectedGroupId,
+    isGroupSelectOpen,
+    setIsGroupSelectOpen,
+    handleGroupSelect,
     isSizingWizardOpen,
     setIsSizingWizardOpen,
     exampleSizing,

--- a/src/ui/report/view-models/useGroupInventoryFilter.ts
+++ b/src/ui/report/view-models/useGroupInventoryFilter.ts
@@ -1,0 +1,95 @@
+import type {
+  AssessmentSubsetInventory,
+  Inventory,
+} from "@openshift-migration-advisor/planner-sdk";
+import { useCallback, useMemo, useState } from "react";
+
+import {
+  type ReportInventorySource,
+  resolveActiveInventory,
+  resolveEffectiveGroupId,
+} from "../helpers/groupInventoryFilter";
+import {
+  buildGroupViewModel,
+  type GroupViewModel,
+} from "../helpers/groupViewModel";
+
+export interface GroupInventoryFilterState {
+  selectedGroupId: string;
+  groupView: GroupViewModel;
+  activeInventory: ReportInventorySource | undefined;
+  isGroupSelectOpen: boolean;
+  setIsGroupSelectOpen: (open: boolean) => void;
+  selectGroup: (groupId: string) => void;
+  handleGroupSelect: (
+    event: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined,
+  ) => void;
+}
+
+export const useGroupInventoryFilter = ({
+  subsetInventories,
+  fullInventory,
+  onGroupChange,
+}: {
+  subsetInventories: AssessmentSubsetInventory[];
+  fullInventory: Inventory | ReportInventorySource | undefined;
+  onGroupChange?: () => void;
+}): GroupInventoryFilterState => {
+  const [userSelectedGroupId, setUserSelectedGroupId] = useState<string | null>(
+    null,
+  );
+  const [isGroupSelectOpen, setIsGroupSelectOpen] = useState(false);
+
+  const selectedGroupId = useMemo(
+    () => resolveEffectiveGroupId(userSelectedGroupId, subsetInventories),
+    [userSelectedGroupId, subsetInventories],
+  );
+
+  const groupView = useMemo(
+    () =>
+      buildGroupViewModel({
+        subsetInventories,
+        selectedGroupId,
+      }),
+    [subsetInventories, selectedGroupId],
+  );
+
+  const activeInventory = useMemo(
+    () =>
+      resolveActiveInventory(selectedGroupId, subsetInventories, fullInventory),
+    [selectedGroupId, subsetInventories, fullInventory],
+  );
+
+  const selectGroup = useCallback(
+    (groupId: string) => {
+      setUserSelectedGroupId(groupId);
+      onGroupChange?.();
+      setIsGroupSelectOpen(false);
+    },
+    [onGroupChange],
+  );
+
+  const handleGroupSelect = useCallback(
+    (
+      _event: React.MouseEvent<Element, MouseEvent> | undefined,
+      value: string | number | undefined,
+    ) => {
+      if (value == null) {
+        return;
+      }
+      selectGroup(String(value));
+    },
+    [selectGroup],
+  );
+
+  return {
+    selectedGroupId,
+    groupView,
+    activeInventory,
+    isGroupSelectOpen,
+    setIsGroupSelectOpen,
+    selectGroup,
+    handleGroupSelect,
+  };
+};

--- a/src/ui/report/view-models/useReportPageViewModel.ts
+++ b/src/ui/report/view-models/useReportPageViewModel.ts
@@ -467,16 +467,14 @@ export const useReportPageViewModel = (): ReportPageViewModel => {
   }, [latestSnapshot.inventory?.clusters]);
 
   // ---- Cluster selection ---------------------------------------------------
-  const assessmentClusters = clusters;
-
   const selectedClusterId = useMemo(() => {
     if (userSelectedClusterId !== null) {
       const isValidSelection =
         userSelectedClusterId === "all" ||
         Boolean(
-          assessmentClusters &&
+          clusters &&
           Object.prototype.hasOwnProperty.call(
-            assessmentClusters,
+            clusters,
             userSelectedClusterId,
           ),
         );
@@ -485,20 +483,18 @@ export const useReportPageViewModel = (): ReportPageViewModel => {
       }
     }
 
-    const clusterKeys = assessmentClusters
-      ? Object.keys(assessmentClusters)
-      : [];
+    const clusterKeys = clusters ? Object.keys(clusters) : [];
 
     if (clusterKeys.length === 0) {
       return "all";
     }
 
     const sortedKeys = [...clusterKeys].sort((a, b) =>
-      compareClustersByVmCount(a, b, assessmentClusters),
+      compareClustersByVmCount(a, b, clusters),
     );
 
     return sortedKeys[0];
-  }, [userSelectedClusterId, assessmentClusters]);
+  }, [userSelectedClusterId, clusters]);
 
   const selectCluster = useCallback((clusterId: string) => {
     setUserSelectedClusterId(clusterId);
@@ -556,8 +552,6 @@ export const useReportPageViewModel = (): ReportPageViewModel => {
     const model = assessment;
     return model?.latestSnapshot?.lastUpdated || "-";
   }, [assessment]);
-
-  const clusterCount = reportSummaryClusterCount;
 
   // ---- Missing metrics detection -------------------------------------------
   // Uses the scoped (cluster-level) data that the Dashboard actually renders,
@@ -813,7 +807,7 @@ export const useReportPageViewModel = (): ReportPageViewModel => {
     clusters,
     latestSnapshot,
     lastUpdatedText,
-    clusterCount,
+    clusterCount: reportSummaryClusterCount,
     reportSummaryVms,
 
     scopedClusterView,

--- a/src/ui/report/view-models/useReportPageViewModel.ts
+++ b/src/ui/report/view-models/useReportPageViewModel.ts
@@ -473,10 +473,7 @@ export const useReportPageViewModel = (): ReportPageViewModel => {
         userSelectedClusterId === "all" ||
         Boolean(
           clusters &&
-          Object.prototype.hasOwnProperty.call(
-            clusters,
-            userSelectedClusterId,
-          ),
+          Object.prototype.hasOwnProperty.call(clusters, userSelectedClusterId),
         );
       if (isValidSelection) {
         return userSelectedClusterId;

--- a/src/ui/report/view-models/useReportPageViewModel.ts
+++ b/src/ui/report/view-models/useReportPageViewModel.ts
@@ -1,4 +1,5 @@
 import type {
+  AssessmentSubsetInventory,
   ClusterRequirementsResponse,
   Infra,
   InventoryData,
@@ -42,6 +43,12 @@ import {
   compareClustersByVmCount,
 } from "../helpers/clusterViewModel";
 import {
+  assessmentHasSubsetDataFetched,
+  extractScopedInventoryData,
+  type ReportInventorySource,
+} from "../helpers/groupInventoryFilter";
+import { ALL_VMS_GROUP_ID } from "../helpers/groupViewModel";
+import {
   isControlPlaneOnlyClusterMode,
   type SizingFormValues,
 } from "../views/cluster-sizer/types";
@@ -51,6 +58,7 @@ import {
   getCpuOvercommitLabel,
   getMemoryOvercommitLabel,
 } from "./ClusterSizingHelpers";
+import { useGroupInventoryFilter } from "./useGroupInventoryFilter";
 
 // ---------------------------------------------------------------------------
 // Sizing → PDF page builder
@@ -191,6 +199,13 @@ export interface ReportPageViewModel {
   setClusterSelectOpen: (open: boolean) => void;
   clusterSelectDisabled: boolean;
 
+  // Group view (subset inventories from GET assessment)
+  groupView: ReturnType<typeof useGroupInventoryFilter>["groupView"];
+  selectedGroupId: string;
+  selectGroup: (groupId: string) => void;
+  isGroupSelectOpen: boolean;
+  setGroupSelectOpen: (open: boolean) => void;
+
   // Computed data from latest snapshot
   infra: Infra | undefined;
   vms: VMs | undefined;
@@ -198,6 +213,7 @@ export interface ReportPageViewModel {
   latestSnapshot: SnapshotLike;
   lastUpdatedText: string;
   clusterCount: number;
+  reportSummaryVms: VMs | undefined;
 
   // Scoped cluster view (typed with required fields for Dashboard rendering)
   scopedClusterView: ClusterScopedView | undefined;
@@ -341,16 +357,30 @@ export const useReportPageViewModel = (): ReportPageViewModel => {
     jobsStore.getSnapshot.bind(jobsStore),
   );
 
-  // ---- Initial data fetch (no polling — detail page) -----------------------
+  // ---- Initial data fetch (GET assessment when subset data not yet loaded) --
   const [fetchState, doFetchData] = useAsyncFn(async () => {
-    await Promise.all([assessmentsStore.list(), sourcesStore.list()]);
-  }, [assessmentsStore, sourcesStore]);
+    const cachedAssessment = id ? assessmentsStore.getById(id) : undefined;
+    const sourcesPromise = sourcesStore.list();
+
+    if (id) {
+      const shouldFetchAssessment =
+        !cachedAssessment ||
+        !assessmentHasSubsetDataFetched(cachedAssessment.snapshots);
+
+      if (shouldFetchAssessment) {
+        await Promise.all([assessmentsStore.get(id), sourcesPromise]);
+        return;
+      }
+
+      await sourcesPromise;
+      return;
+    }
+
+    await Promise.all([assessmentsStore.list(), sourcesPromise]);
+  }, [assessmentsStore, sourcesStore, id]);
 
   useMount(() => {
-    // Only fetch if data is not already loaded
-    if (!assessments || assessments.length === 0) {
-      void doFetchData();
-    }
+    void doFetchData();
   });
 
   // ---- Assessment lookup ---------------------------------------------------
@@ -389,15 +419,39 @@ export const useReportPageViewModel = (): ReportPageViewModel => {
     return snapshots.length > 0 ? snapshots[snapshots.length - 1] : {};
   }, [assessment?.snapshots]);
 
-  const infra = useMemo(
-    () =>
-      (latestSnapshot.infra ||
-        latestSnapshot.inventory?.infra ||
-        latestSnapshot.inventory?.vcenter?.infra) as Infra | undefined,
-    [latestSnapshot],
+  const subsetInventories = useMemo(
+    (): AssessmentSubsetInventory[] => latestSnapshot.subsetInventories ?? [],
+    [latestSnapshot.subsetInventories],
   );
 
-  const vms = useMemo(
+  const fullInventory = useMemo(
+    () => latestSnapshot.inventory as ReportInventorySource | undefined,
+    [latestSnapshot.inventory],
+  );
+
+  const resetClusterSelection = useCallback(() => {
+    setUserSelectedClusterId(null);
+  }, []);
+
+  const {
+    selectedGroupId,
+    groupView,
+    activeInventory,
+    isGroupSelectOpen,
+    setIsGroupSelectOpen,
+    selectGroup,
+  } = useGroupInventoryFilter({
+    subsetInventories,
+    fullInventory,
+    onGroupChange: resetClusterSelection,
+  });
+
+  const { infra, vms, clusters } = useMemo(
+    () => extractScopedInventoryData(activeInventory, latestSnapshot),
+    [activeInventory, latestSnapshot],
+  );
+
+  const reportSummaryVms = useMemo(
     () =>
       (latestSnapshot.vms ||
         latestSnapshot.inventory?.vms ||
@@ -405,22 +459,15 @@ export const useReportPageViewModel = (): ReportPageViewModel => {
     [latestSnapshot],
   );
 
-  const clusters = useMemo(
-    () =>
-      latestSnapshot.inventory?.clusters as
-        | { [key: string]: InventoryData }
-        | undefined,
-    [latestSnapshot],
-  );
+  const reportSummaryClusterCount = useMemo(() => {
+    const summaryClusters = latestSnapshot.inventory?.clusters as
+      | { [key: string]: InventoryData }
+      | undefined;
+    return summaryClusters ? Object.keys(summaryClusters).length : 0;
+  }, [latestSnapshot.inventory?.clusters]);
 
   // ---- Cluster selection ---------------------------------------------------
-  const assessmentClusters = assessment?.snapshots?.length
-    ? (
-        assessment.snapshots[assessment.snapshots.length - 1] as {
-          inventory?: { clusters?: { [key: string]: InventoryData } };
-        }
-      ).inventory?.clusters
-    : undefined;
+  const assessmentClusters = clusters;
 
   const selectedClusterId = useMemo(() => {
     if (userSelectedClusterId !== null) {
@@ -510,7 +557,7 @@ export const useReportPageViewModel = (): ReportPageViewModel => {
     return model?.latestSnapshot?.lastUpdated || "-";
   }, [assessment]);
 
-  const clusterCount = clusters ? Object.keys(clusters).length : 0;
+  const clusterCount = reportSummaryClusterCount;
 
   // ---- Missing metrics detection -------------------------------------------
   // Uses the scoped (cluster-level) data that the Dashboard actually renders,
@@ -573,14 +620,23 @@ export const useReportPageViewModel = (): ReportPageViewModel => {
 
   const exportPdf = useCallback(
     (container: HTMLElement): void => {
-      const title = `${assessment?.name || `Assessment ${id}`} - vCenter report`;
+      // PDF captures the already-rendered dashboard DOM, which reflects the
+      // active group + cluster filters shown on screen.
+      const groupSuffix =
+        selectedGroupId !== ALL_VMS_GROUP_ID
+          ? ` - ${groupView.selectionLabel}`
+          : "";
+      const title = `${assessment?.name || `Assessment ${id}`} - vCenter report${groupSuffix}`;
 
       // Determine which sizing entries to include:
       // - Single cluster view → only that cluster (if calculated)
-      // - All-clusters view → every cluster that has been sized
+      // - All-clusters view → sized clusters within the active group inventory
+      const scopedClusterIds = new Set(clusters ? Object.keys(clusters) : []);
       const sizingEntries: SizingPdfData[] =
         selectedClusterId === "all"
-          ? Object.values(savedSizingDataMap)
+          ? Object.values(savedSizingDataMap).filter((entry) =>
+              scopedClusterIds.has(entry.clusterId),
+            )
           : savedSizingDataMap[selectedClusterId]
             ? [savedSizingDataMap[selectedClusterId]]
             : [];
@@ -597,18 +653,43 @@ export const useReportPageViewModel = (): ReportPageViewModel => {
         extraPages,
       });
     },
-    [reportStore, assessment?.name, id, savedSizingDataMap, selectedClusterId],
+    [
+      reportStore,
+      assessment?.name,
+      id,
+      savedSizingDataMap,
+      selectedClusterId,
+      clusters,
+      selectedGroupId,
+      groupView.selectionLabel,
+    ],
   );
 
   const exportHtml = useCallback((): void => {
     const inventory =
-      source?.inventory ?? latestSnapshot?.inventory ?? latestSnapshot;
+      activeInventory ??
+      source?.inventory ??
+      latestSnapshot?.inventory ??
+      latestSnapshot;
     if (!inventory) {
       return;
     }
-    const title = `${assessment?.name || `Assessment ${id}`} - vCenter report`;
+    const groupSuffix =
+      selectedGroupId !== ALL_VMS_GROUP_ID
+        ? ` - ${groupView.selectionLabel}`
+        : "";
+    const title = `${assessment?.name || `Assessment ${id}`} - vCenter report${groupSuffix}`;
     void reportStore.exportHtml(inventory, { documentTitle: title });
-  }, [reportStore, source, latestSnapshot, assessment?.name, id]);
+  }, [
+    reportStore,
+    activeInventory,
+    source,
+    latestSnapshot,
+    assessment?.name,
+    id,
+    selectedGroupId,
+    groupView.selectionLabel,
+  ]);
 
   const clearExportError = useCallback((): void => {
     reportStore.clearError();
@@ -721,12 +802,19 @@ export const useReportPageViewModel = (): ReportPageViewModel => {
     setClusterSelectOpen: setIsClusterSelectOpen,
     clusterSelectDisabled,
 
+    groupView,
+    selectedGroupId,
+    selectGroup,
+    isGroupSelectOpen,
+    setGroupSelectOpen: setIsGroupSelectOpen,
+
     infra,
     vms,
     clusters,
     latestSnapshot,
     lastUpdatedText,
     clusterCount,
+    reportSummaryVms,
 
     scopedClusterView,
     canExportReport,

--- a/src/ui/report/views/ExampleReport.tsx
+++ b/src/ui/report/views/ExampleReport.tsx
@@ -1,3 +1,4 @@
+import { css } from "@emotion/css";
 import {
   Button,
   Content,
@@ -18,6 +19,11 @@ import { Dashboard } from "./assessment-report/Dashboard";
 import { ReportFilterBar } from "./assessment-report/ReportFilterBar";
 import { ClusterSizingWizard } from "./cluster-sizer/ClusterSizingWizard";
 import { EXAMPLE_FORM_VALUES } from "./example-data/clusterSizingFixture";
+
+const reservedHeaderActionStyle = css`
+  visibility: hidden;
+  pointer-events: none;
+`;
 
 const ExampleReport: React.FC = () => {
   const vm = useExampleReportViewModel();
@@ -42,18 +48,21 @@ const ExampleReport: React.FC = () => {
       ]}
       title="RVTools example report"
       headerActions={
-        vm.exampleSizing ? (
-          <Split hasGutter>
-            <SplitItem>
-              <Button
-                variant="primary"
-                onClick={() => vm.setIsSizingWizardOpen(true)}
-              >
-                View recommendation for {vm.exampleSizing.clusterName}
-              </Button>
-            </SplitItem>
-          </Split>
-        ) : undefined
+        <Split hasGutter>
+          <SplitItem
+            className={vm.exampleSizing ? undefined : reservedHeaderActionStyle}
+            aria-hidden={!vm.exampleSizing}
+          >
+            <Button
+              variant="primary"
+              tabIndex={vm.exampleSizing ? undefined : -1}
+              onClick={() => vm.setIsSizingWizardOpen(true)}
+            >
+              View recommendation for{" "}
+              {vm.exampleSizing?.clusterName ?? "Cluster domain-c146658"}
+            </Button>
+          </SplitItem>
+        </Split>
       }
       caption={
         <Stack hasGutter>

--- a/src/ui/report/views/ExampleReport.tsx
+++ b/src/ui/report/views/ExampleReport.tsx
@@ -1,13 +1,7 @@
-import { css } from "@emotion/css";
 import {
   Button,
   Content,
   Icon,
-  MenuToggle,
-  type MenuToggleElement,
-  Select,
-  SelectList,
-  SelectOption,
   Split,
   SplitItem,
   Stack,
@@ -20,14 +14,10 @@ import React from "react";
 import { routes } from "../../../routing/Routes";
 import { AppPage } from "../../core/components/AppPage";
 import { useExampleReportViewModel } from "../view-models/useExampleReportViewModel";
-import type { ClusterOption } from "./assessment-report/ClusterView";
 import { Dashboard } from "./assessment-report/Dashboard";
+import { ReportFilterBar } from "./assessment-report/ReportFilterBar";
 import { ClusterSizingWizard } from "./cluster-sizer/ClusterSizingWizard";
 import { EXAMPLE_FORM_VALUES } from "./example-data/clusterSizingFixture";
-
-const clusterToggleStyle = css`
-  min-width: 422px;
-`;
 
 const ExampleReport: React.FC = () => {
   const vm = useExampleReportViewModel();
@@ -79,39 +69,17 @@ const ExampleReport: React.FC = () => {
           </StackItem>
           <StackItem>{vm.detectedSummaryText}</StackItem>
           <StackItem>
-            <Select
-              isScrollable
-              isOpen={vm.isClusterSelectOpen}
-              selected={vm.clusterView.selectionId}
-              onSelect={vm.handleClusterSelect}
-              onOpenChange={(isOpen: boolean) => {
-                if (!vm.clusterSelectDisabled)
-                  vm.setIsClusterSelectOpen(isOpen);
-              }}
-              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                <MenuToggle
-                  ref={toggleRef}
-                  isExpanded={vm.isClusterSelectOpen}
-                  onClick={() => {
-                    if (!vm.clusterSelectDisabled) {
-                      vm.setIsClusterSelectOpen(!vm.isClusterSelectOpen);
-                    }
-                  }}
-                  isDisabled={vm.clusterSelectDisabled}
-                  className={clusterToggleStyle}
-                >
-                  {vm.clusterView.selectionLabel}
-                </MenuToggle>
-              )}
-            >
-              <SelectList>
-                {vm.clusterView.clusterOptions.map((option: ClusterOption) => (
-                  <SelectOption key={option.id} value={option.id}>
-                    {option.label}
-                  </SelectOption>
-                ))}
-              </SelectList>
-            </Select>
+            <ReportFilterBar
+              clusterView={vm.clusterView}
+              clusterSelectDisabled={vm.clusterSelectDisabled}
+              isClusterSelectOpen={vm.isClusterSelectOpen}
+              onClusterSelectOpenChange={vm.setIsClusterSelectOpen}
+              onClusterSelect={vm.handleClusterSelect}
+              groupView={vm.groupView}
+              isGroupSelectOpen={vm.isGroupSelectOpen}
+              onGroupSelectOpenChange={vm.setIsGroupSelectOpen}
+              onGroupSelect={vm.handleGroupSelect}
+            />
           </StackItem>
         </Stack>
       }

--- a/src/ui/report/views/Report.tsx
+++ b/src/ui/report/views/Report.tsx
@@ -35,6 +35,11 @@ const alertSpacing = css`
   margin-top: var(--pf-t--global--spacer--md);
 `;
 
+const reservedHeaderActionStyle = css`
+  visibility: hidden;
+  pointer-events: none;
+`;
+
 const ReportContent: React.FC = () => {
   const vm = useReportPageViewModel();
   const offScreenRef = useRef<HTMLDivElement>(null);
@@ -276,36 +281,43 @@ const ReportContent: React.FC = () => {
               )}
             </SplitItem>
 
-            {vm.selectedClusterId !== "all" ? (
-              <SplitItem>
-                {vm.canShowClusterRecommendations ? (
+            <SplitItem
+              className={
+                vm.selectedClusterId === "all"
+                  ? reservedHeaderActionStyle
+                  : undefined
+              }
+              aria-hidden={vm.selectedClusterId === "all"}
+            >
+              {vm.canShowClusterRecommendations ? (
+                <Button
+                  variant="primary"
+                  tabIndex={vm.selectedClusterId === "all" ? -1 : undefined}
+                  onClick={() => vm.setIsSizingWizardOpen(true)}
+                >
+                  View Recommendation based on vCenter cluster
+                </Button>
+              ) : (
+                <Tooltip
+                  {...themeTooltipFlyoutProps}
+                  content={
+                    <p>
+                      This cluster has no VMs. Cluster recommendations are not
+                      available for empty clusters.
+                    </p>
+                  }
+                >
                   <Button
                     variant="primary"
+                    tabIndex={vm.selectedClusterId === "all" ? -1 : undefined}
                     onClick={() => vm.setIsSizingWizardOpen(true)}
+                    isAriaDisabled
                   >
                     View Recommendation based on vCenter cluster
                   </Button>
-                ) : (
-                  <Tooltip
-                    {...themeTooltipFlyoutProps}
-                    content={
-                      <p>
-                        This cluster has no VMs. Cluster recommendations are not
-                        available for empty clusters.
-                      </p>
-                    }
-                  >
-                    <Button
-                      variant="primary"
-                      onClick={() => vm.setIsSizingWizardOpen(true)}
-                      isAriaDisabled
-                    >
-                      View Recommendation based on vCenter cluster
-                    </Button>
-                  </Tooltip>
-                )}
-              </SplitItem>
-            ) : null}
+                </Tooltip>
+              )}
+            </SplitItem>
           </Split>
         ) : undefined
       }

--- a/src/ui/report/views/Report.tsx
+++ b/src/ui/report/views/Report.tsx
@@ -7,11 +7,6 @@ import {
   Content,
   List,
   ListItem,
-  MenuToggle,
-  type MenuToggleElement,
-  Select,
-  SelectList,
-  SelectOption,
   Spinner,
   Split,
   SplitItem,
@@ -30,8 +25,8 @@ import CreateAssessmentDropdown from "../../core/components/CreateAssessmentDrop
 import { OffScreenRenderer } from "../../core/components/OffScreenRenderer";
 import { AgentStatusView } from "../../environment/views/AgentStatusView";
 import { useReportPageViewModel } from "../view-models/useReportPageViewModel";
-import type { ClusterOption } from "./assessment-report/ClusterView";
 import { Dashboard } from "./assessment-report/Dashboard";
+import { ReportFilterBar } from "./assessment-report/ReportFilterBar";
 import { ClusterSizingWizard } from "./cluster-sizer/ClusterSizingWizard";
 import { DeployOvaBanner } from "./DeployOvaBanner";
 import { ExportReportButton } from "./ExportReportButton";
@@ -162,9 +157,9 @@ const ReportContent: React.FC = () => {
           </StackItem>
           <StackItem>
             {vm.clusterCount > 0 ? (
-              typeof vm.vms?.total === "number" ? (
+              typeof vm.reportSummaryVms?.total === "number" ? (
                 <>
-                  Detected <strong>{vm.vms?.total} VMS</strong> in{" "}
+                  Detected <strong>{vm.reportSummaryVms.total} VMs</strong> in{" "}
                   <strong>
                     {vm.clusterCount}{" "}
                     {vm.clusterCount === 1
@@ -188,38 +183,21 @@ const ReportContent: React.FC = () => {
             )}
           </StackItem>
           <StackItem>
-            <Select
-              isScrollable
-              isOpen={vm.isClusterSelectOpen}
-              selected={vm.clusterView.selectionId}
-              onSelect={handleClusterSelect}
-              onOpenChange={(isOpen: boolean) => {
-                if (!vm.clusterSelectDisabled) vm.setClusterSelectOpen(isOpen);
+            <ReportFilterBar
+              clusterView={vm.clusterView}
+              clusterSelectDisabled={vm.clusterSelectDisabled}
+              isClusterSelectOpen={vm.isClusterSelectOpen}
+              onClusterSelectOpenChange={vm.setClusterSelectOpen}
+              onClusterSelect={handleClusterSelect}
+              groupView={vm.groupView}
+              isGroupSelectOpen={vm.isGroupSelectOpen}
+              onGroupSelectOpenChange={vm.setGroupSelectOpen}
+              onGroupSelect={(_event, value) => {
+                if (typeof value === "string") {
+                  vm.selectGroup(value);
+                }
               }}
-              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                <MenuToggle
-                  ref={toggleRef}
-                  isExpanded={vm.isClusterSelectOpen}
-                  onClick={() => {
-                    if (!vm.clusterSelectDisabled) {
-                      vm.setClusterSelectOpen(!vm.isClusterSelectOpen);
-                    }
-                  }}
-                  isDisabled={vm.clusterSelectDisabled}
-                  style={{ minWidth: "422px" }}
-                >
-                  {vm.clusterView.selectionLabel}
-                </MenuToggle>
-              )}
-            >
-              <SelectList>
-                {vm.clusterView.clusterOptions.map((option: ClusterOption) => (
-                  <SelectOption key={option.id} value={option.id}>
-                    {option.label}
-                  </SelectOption>
-                ))}
-              </SelectList>
-            </Select>
+            />
           </StackItem>
         </Stack>
       }

--- a/src/ui/report/views/__tests__/Report.test.tsx
+++ b/src/ui/report/views/__tests__/Report.test.tsx
@@ -154,6 +154,7 @@ const mockSource = createSourceModel({
   },
 });
 
+import { buildGroupViewModel } from "../../helpers/groupViewModel";
 import { buildClusterViewModel } from "../assessment-report/ClusterView";
 
 function makeBaseVm(
@@ -168,6 +169,7 @@ function makeBaseVm(
     clusters,
     selectedClusterId: "all",
   });
+  const groupView = buildGroupViewModel({ subsetInventories: [] });
 
   return {
     assessmentId: "assessment-1",
@@ -180,12 +182,18 @@ function makeBaseVm(
     isClusterSelectOpen: false,
     setClusterSelectOpen: vi.fn(),
     clusterSelectDisabled: true,
+    groupView,
+    selectedGroupId: "all",
+    selectGroup: vi.fn(),
+    isGroupSelectOpen: false,
+    setGroupSelectOpen: vi.fn(),
     infra,
     vms,
     clusters,
     latestSnapshot: {},
     lastUpdatedText: "-",
     clusterCount: 0,
+    reportSummaryVms: vms,
     scopedClusterView: undefined,
     canExportReport: false,
     canShowClusterRecommendations: false,

--- a/src/ui/report/views/assessment-report/ReportFilterBar.tsx
+++ b/src/ui/report/views/assessment-report/ReportFilterBar.tsx
@@ -1,0 +1,128 @@
+import { css } from "@emotion/css";
+import {
+  MenuToggle,
+  type MenuToggleElement,
+  Select,
+  SelectList,
+  SelectOption,
+  Split,
+  SplitItem,
+} from "@patternfly/react-core";
+import React from "react";
+
+import type { ClusterViewModel } from "../../helpers/clusterViewModel";
+import type { GroupViewModel } from "../../helpers/groupViewModel";
+import type { ClusterOption } from "./ClusterView";
+
+const filterToggleStyle = css`
+  min-width: 422px;
+`;
+
+export interface ReportFilterBarProps {
+  clusterView: ClusterViewModel;
+  clusterSelectDisabled: boolean;
+  isClusterSelectOpen: boolean;
+  onClusterSelectOpenChange: (open: boolean) => void;
+  onClusterSelect: (
+    event: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined,
+  ) => void;
+  groupView: GroupViewModel;
+  isGroupSelectOpen: boolean;
+  onGroupSelectOpenChange: (open: boolean) => void;
+  onGroupSelect: (
+    event: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined,
+  ) => void;
+}
+
+export const ReportFilterBar: React.FC<ReportFilterBarProps> = ({
+  clusterView,
+  clusterSelectDisabled,
+  isClusterSelectOpen,
+  onClusterSelectOpenChange,
+  onClusterSelect,
+  groupView,
+  isGroupSelectOpen,
+  onGroupSelectOpenChange,
+  onGroupSelect,
+}) => (
+  <Split hasGutter>
+    <SplitItem>
+      <Select
+        isScrollable
+        isOpen={isClusterSelectOpen}
+        selected={clusterView.selectionId}
+        onSelect={onClusterSelect}
+        onOpenChange={(isOpen: boolean) => {
+          if (!clusterSelectDisabled) {
+            onClusterSelectOpenChange(isOpen);
+          }
+        }}
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle
+            ref={toggleRef}
+            isExpanded={isClusterSelectOpen}
+            onClick={() => {
+              if (!clusterSelectDisabled) {
+                onClusterSelectOpenChange(!isClusterSelectOpen);
+              }
+            }}
+            isDisabled={clusterSelectDisabled}
+            className={filterToggleStyle}
+          >
+            Filter by cluster: {clusterView.selectionLabel}
+          </MenuToggle>
+        )}
+      >
+        <SelectList>
+          {clusterView.clusterOptions.map((option: ClusterOption) => (
+            <SelectOption key={option.id} value={option.id}>
+              {option.label}
+            </SelectOption>
+          ))}
+        </SelectList>
+      </Select>
+    </SplitItem>
+    {groupView.showGroupFilter ? (
+      <SplitItem>
+        <Select
+          isScrollable
+          isOpen={isGroupSelectOpen}
+          selected={groupView.selectionId}
+          onSelect={onGroupSelect}
+          onOpenChange={(isOpen: boolean) => {
+            if (!groupView.groupSelectDisabled) {
+              onGroupSelectOpenChange(isOpen);
+            }
+          }}
+          toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+            <MenuToggle
+              ref={toggleRef}
+              isExpanded={isGroupSelectOpen}
+              onClick={() => {
+                if (!groupView.groupSelectDisabled) {
+                  onGroupSelectOpenChange(!isGroupSelectOpen);
+                }
+              }}
+              isDisabled={groupView.groupSelectDisabled}
+              className={filterToggleStyle}
+            >
+              Filter by group: {groupView.selectionLabel}
+            </MenuToggle>
+          )}
+        >
+          <SelectList>
+            {groupView.groupOptions.map((option) => (
+              <SelectOption key={option.id} value={option.id}>
+                {option.label}
+              </SelectOption>
+            ))}
+          </SelectList>
+        </Select>
+      </SplitItem>
+    ) : null}
+  </Split>
+);
+
+ReportFilterBar.displayName = "ReportFilterBar";

--- a/src/ui/report/views/example-data/__tests__/subsetInventoryFixture.test.ts
+++ b/src/ui/report/views/example-data/__tests__/subsetInventoryFixture.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { getExampleInventory } from "../inventoryFixture";
+import { getExampleSubsetInventories } from "../subsetInventoryFixture";
+
+describe("getExampleSubsetInventories", () => {
+  it("returns three demo groups with VM counts matching the design mockup", () => {
+    const subsets = getExampleSubsetInventories(getExampleInventory());
+
+    expect(subsets).toHaveLength(3);
+    expect(subsets.map((subset) => subset.name)).toEqual([
+      "Group 1",
+      "Group 2",
+      "Group 3",
+    ]);
+    expect(subsets.map((subset) => subset.vmsCount)).toEqual([350, 180, 100]);
+  });
+
+  it("scopes each subset inventory to a single cluster view", () => {
+    const subsets = getExampleSubsetInventories(getExampleInventory());
+
+    expect(subsets[0].inventory.clusters).toHaveProperty("domain-c34");
+    expect(subsets[0].inventory.vcenter?.vms?.total).toBe(350);
+    expect(subsets[1].inventory.vcenter?.vms?.total).toBe(180);
+    expect(subsets[2].inventory.vcenter?.vms?.total).toBe(100);
+  });
+});

--- a/src/ui/report/views/example-data/subsetInventoryFixture.ts
+++ b/src/ui/report/views/example-data/subsetInventoryFixture.ts
@@ -1,0 +1,130 @@
+import type {
+  AssessmentSubsetInventory,
+  Inventory,
+  InventoryData,
+  VMs,
+} from "@openshift-migration-advisor/planner-sdk";
+
+const EXAMPLE_SUBSET_CREATED_AT = new Date("2026-06-29T12:00:00.000Z");
+
+const scaleVms = (vms: VMs, targetTotal: number): VMs => {
+  if (targetTotal >= vms.total) {
+    return vms;
+  }
+
+  const ratio = targetTotal / vms.total;
+
+  return {
+    ...vms,
+    total: targetTotal,
+    totalMigratable: Math.round(vms.totalMigratable * ratio),
+    totalMigratableWithWarnings: Math.round(
+      (vms.totalMigratableWithWarnings ?? vms.totalMigratable) * ratio,
+    ),
+    cpuCores: vms.cpuCores
+      ? {
+          ...vms.cpuCores,
+          total: Math.round(vms.cpuCores.total * ratio),
+          totalForMigratableWithWarnings: Math.round(
+            vms.cpuCores.totalForMigratableWithWarnings * ratio,
+          ),
+          totalForNotMigratable: Math.round(
+            vms.cpuCores.totalForNotMigratable * ratio,
+          ),
+        }
+      : vms.cpuCores,
+    ramGB: vms.ramGB
+      ? {
+          ...vms.ramGB,
+          total: Math.round(vms.ramGB.total * ratio),
+          totalForMigratableWithWarnings: Math.round(
+            vms.ramGB.totalForMigratableWithWarnings * ratio,
+          ),
+          totalForNotMigratable: Math.round(
+            vms.ramGB.totalForNotMigratable * ratio,
+          ),
+        }
+      : vms.ramGB,
+  };
+};
+
+const buildSubsetInventory = ({
+  id,
+  name,
+  vcenterId,
+  clusterKey,
+  clusterData,
+  vmsCount,
+}: {
+  id: string;
+  name: string;
+  vcenterId: string;
+  clusterKey: string;
+  clusterData: InventoryData;
+  vmsCount: number;
+}): AssessmentSubsetInventory => {
+  const clusterVms = clusterData.vms;
+  const scaledCluster: InventoryData = clusterVms
+    ? {
+        ...clusterData,
+        vms: scaleVms(clusterVms, vmsCount),
+      }
+    : clusterData;
+
+  return {
+    id,
+    name,
+    vcenterId,
+    vmsCount,
+    createdAt: EXAMPLE_SUBSET_CREATED_AT,
+    inventory: {
+      vcenterId,
+      clusters: { [clusterKey]: scaledCluster },
+      vcenter: scaledCluster,
+    },
+  };
+};
+
+/**
+ * Example subset inventories for the RVTools example report.
+ * Mirrors the VM-groups demo: three groups plus the full snapshot total (630 VMs).
+ */
+export const getExampleSubsetInventories = (
+  inventory: Inventory,
+): AssessmentSubsetInventory[] => {
+  const vcenterId = inventory.vcenterId;
+  const clusters = inventory.clusters;
+  const domainC34 = clusters["domain-c34"];
+  const domainC146658 = clusters["domain-c146658"];
+
+  if (!domainC34 || !domainC146658) {
+    return [];
+  }
+
+  return [
+    buildSubsetInventory({
+      id: "11111111-1111-4111-8111-111111111101",
+      name: "Group 1",
+      vcenterId,
+      clusterKey: "domain-c34",
+      clusterData: domainC34,
+      vmsCount: 350,
+    }),
+    buildSubsetInventory({
+      id: "11111111-1111-4111-8111-111111111102",
+      name: "Group 2",
+      vcenterId,
+      clusterKey: "domain-c146658",
+      clusterData: domainC146658,
+      vmsCount: 180,
+    }),
+    buildSubsetInventory({
+      id: "11111111-1111-4111-8111-111111111103",
+      name: "Group 3",
+      vcenterId,
+      clusterKey: "domain-c146658",
+      clusterData: domainC146658,
+      vmsCount: 100,
+    }),
+  ];
+};


### PR DESCRIPTION
Add a 'Filter by group' dropdown on the assessment report page, backed by subsetInventories from GET assessment. Selecting a group scopes the dashboard, cluster filter, and HTML/PDF export to that subset while the header summary stays aggregate across all VMs.

- Fetch assessment by ID on report mount, skipping GET when subset data is already cached from a prior GET response
- Extract shared group-filter logic (groupInventoryFilter, useGroupInventoryFilter, ReportFilterBar) and use it in Report and ExampleReport
- Scope HTML export to activeInventory; include group name in export titles
- Add example subset fixture and tests for helpers, view models, and store

[Screen Recording 2026-06-30 09.10.webm](https://github.com/user-attachments/assets/f3aec9cd-5b31-4505-8ee9-a045e152d587)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added group-based filtering in reports, including a new filter bar and selectable group options with VM counts.
  * Reports and exports now reflect the currently selected group in titles and displayed VM totals.
* **Bug Fixes**
  * Improved loading behavior so assessment data is reused when already available, reducing unnecessary refetches.
  * Fixed report inventory scoping so the correct cluster and VM data are shown for each selected group.
* **Tests**
  * Expanded coverage for group selection, scoped inventory behavior, and export output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->