### PR TITLE
ECOPROJECT-4822 | feat: add compact mode to cluster recommendations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2159,21 +2159,6 @@
         "eslint-scope": "5.1.1"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@nuxtjs/opencollective": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@nuxtjs/opencollective/-/opencollective-0.3.2.tgz",
@@ -19932,24 +19917,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.3",

--- a/src/ui/report/view-models/ClusterSizingHelpers.ts
+++ b/src/ui/report/view-models/ClusterSizingHelpers.ts
@@ -2,9 +2,10 @@ import {
   CPU_OVERCOMMIT_OPTIONS,
   MEMORY_OVERCOMMIT_OPTIONS,
 } from "../views/cluster-sizer/constants";
-import type {
-  ClusterRequirementsResponse,
-  SizingFormValues,
+import {
+  type ClusterRequirementsResponse,
+  isControlPlaneOnlyClusterMode,
+  type SizingFormValues,
 } from "../views/cluster-sizer/types";
 import {
   computeEffectiveCpu,
@@ -71,7 +72,7 @@ ${DISCLAIMER_TEXT}
 `.trim();
   }
 
-  const isSNO = formValues.clusterMode === "single-node";
+  const isSNO = isControlPlaneOnlyClusterMode(formValues.clusterMode);
 
   if (isSNO) {
     return `

--- a/src/ui/report/view-models/useClusterSizingWizardViewModel.ts
+++ b/src/ui/report/view-models/useClusterSizingWizardViewModel.ts
@@ -427,7 +427,8 @@ export const useClusterSizingWizardViewModel = (
     formValues.clusterMode === "hosted-control-plane";
   const showControlPlane =
     formValues.clusterMode === "full-ha" ||
-    formValues.clusterMode === "single-node";
+    formValues.clusterMode === "single-node" ||
+    formValues.clusterMode === "compact";
   const showControlPlaneScheduling = formValues.clusterMode === "full-ha";
   const showSmt = smtVisible;
 

--- a/src/ui/report/view-models/useReportPageViewModel.ts
+++ b/src/ui/report/view-models/useReportPageViewModel.ts
@@ -41,7 +41,10 @@ import {
   type ClusterViewModel,
   compareClustersByVmCount,
 } from "../helpers/clusterViewModel";
-import type { SizingFormValues } from "../views/cluster-sizer/types";
+import {
+  isControlPlaneOnlyClusterMode,
+  type SizingFormValues,
+} from "../views/cluster-sizer/types";
 import {
   formatNumber,
   formatRatio,
@@ -55,7 +58,7 @@ import {
 
 const buildSizingPdfExtraPage = (data: SizingPdfData): PdfExtraPage => {
   const { result, formValues, clusterName } = data;
-  const isSNO = formValues.clusterMode === "single-node";
+  const isSNO = isControlPlaneOnlyClusterMode(formValues.clusterMode);
   const hasControlPlane = result.clusterSizing.controlPlaneNodes > 0;
 
   const cpuOverCommitRatio =

--- a/src/ui/report/view-models/useUtilizationComparisonData.ts
+++ b/src/ui/report/view-models/useUtilizationComparisonData.ts
@@ -1,10 +1,11 @@
 import { useMemo } from "react";
 
-import type {
-  ClusterSizing,
-  InventoryTotals,
-  Savings,
-  SizingFormValues,
+import {
+  type ClusterSizing,
+  type InventoryTotals,
+  isControlPlaneOnlyClusterMode,
+  type Savings,
+  type SizingFormValues,
 } from "../views/cluster-sizer/types";
 import {
   computeEffectiveCpu,
@@ -38,7 +39,7 @@ export const useUtilizationComparisonData = ({
     const memoryUtilization = optimizedSizing.memoryUtilizationMax;
 
     return {
-      isSNO: formValues.clusterMode === "single-node",
+      isSNO: isControlPlaneOnlyClusterMode(formValues.clusterMode),
       cpuUtilization,
       memoryUtilization,
       effectiveCpu: computeEffectiveCpu(

--- a/src/ui/report/views/cluster-sizer/SizingInputForm.tsx
+++ b/src/ui/report/views/cluster-sizer/SizingInputForm.tsx
@@ -100,7 +100,9 @@ export const SizingInputForm: React.FC<SizingInputFormProps> = ({
       ...values,
       clusterMode,
       scheduleOnControlPlane:
-        clusterMode === "single-node" ? true : values.scheduleOnControlPlane,
+        clusterMode === "single-node" || clusterMode === "compact"
+          ? true
+          : values.scheduleOnControlPlane,
     });
   };
 
@@ -552,7 +554,7 @@ export const SizingInputForm: React.FC<SizingInputFormProps> = ({
           </>
         )}
 
-        {/* Control plane section - show for Full HA and Single node */}
+        {/* Control plane section - show for Full HA, Compact, and Single node */}
         {showControlPlane && (
           <>
             <GridItem span={12}>

--- a/src/ui/report/views/cluster-sizer/SizingResult.tsx
+++ b/src/ui/report/views/cluster-sizer/SizingResult.tsx
@@ -22,6 +22,7 @@ import {
   getMemoryOvercommitLabel,
 } from "../../view-models/ClusterSizingHelpers";
 import type { ClusterRequirementsResponse, SizingFormValues } from "./types";
+import { isControlPlaneOnlyClusterMode } from "./types";
 import { UtilizationComparisonCards } from "./UtilizationComparisonCards";
 import {
   getOptimizationStatusMessage,
@@ -103,7 +104,7 @@ export const SizingResult: React.FC<SizingResultProps> = ({
     );
   }
 
-  const isSNO = formValues.clusterMode === "single-node";
+  const isSNO = isControlPlaneOnlyClusterMode(formValues.clusterMode);
   const showUtilizationComparison = hasUtilizationComparison(sizerOutput);
   const displaySizing =
     showUtilizationComparison && sizerOutput.optimizedSizing

--- a/src/ui/report/views/cluster-sizer/constants.ts
+++ b/src/ui/report/views/cluster-sizer/constants.ts
@@ -196,6 +196,7 @@ export const CLUSTER_MODE_OPTIONS: {
   label: string;
 }[] = [
   { value: "full-ha", label: "Full HA (3CP)" },
+  { value: "compact", label: "Compact (3CP)" },
   { value: "single-node", label: "Single node (SNO)" },
   { value: "hosted-control-plane", label: "Hosted control plane (HCP)" },
 ];

--- a/src/ui/report/views/cluster-sizer/types.ts
+++ b/src/ui/report/views/cluster-sizer/types.ts
@@ -66,7 +66,15 @@ export type HAReplicaCount = 1 | 2 | 3;
 /**
  * Cluster mode types
  */
-export type ClusterMode = "full-ha" | "single-node" | "hosted-control-plane";
+export type ClusterMode =
+  | "full-ha"
+  | "compact"
+  | "single-node"
+  | "hosted-control-plane";
+
+/** Cluster modes that only expose control plane sizing inputs (no worker node section). */
+export const isControlPlaneOnlyClusterMode = (mode: ClusterMode): boolean =>
+  mode === "single-node" || mode === "compact";
 
 /**
  * User input for standalone cluster sizing workload totals (form state)
@@ -190,6 +198,7 @@ const CLUSTER_MODE_TO_NODE_COUNT: Record<
   ClusterRequirementsRequest["controlPlaneNodeCount"] | undefined
 > = {
   "full-ha": ClusterRequirementsRequestControlPlaneNodeCountEnum.NUMBER_3,
+  compact: ClusterRequirementsRequestControlPlaneNodeCountEnum.NUMBER_3,
   "single-node": ClusterRequirementsRequestControlPlaneNodeCountEnum.NUMBER_1,
   "hosted-control-plane": undefined,
 };
@@ -199,6 +208,8 @@ const STANDALONE_CLUSTER_MODE_TO_NODE_COUNT: Record<
   StandaloneClusterRequirementsRequest["controlPlaneNodeCount"] | undefined
 > = {
   "full-ha":
+    StandaloneClusterRequirementsRequestControlPlaneNodeCountEnum.NUMBER_3,
+  compact:
     StandaloneClusterRequirementsRequestControlPlaneNodeCountEnum.NUMBER_3,
   "single-node":
     StandaloneClusterRequirementsRequestControlPlaneNodeCountEnum.NUMBER_1,
@@ -213,6 +224,7 @@ const SNO_DEFAULT_WORKER_MEMORY = 128;
  *
  * Mode-specific mapping:
  * - Full HA:  all fields sent (worker node, control plane, overcommit, SMT, scheduling)
+ * - Compact:  same minimal payload as SNO plus compactMode=true and controlPlaneNodeCount=3
  * - SNO:      minimal payload — controlPlaneSchedulable=true, control plane CPU/memory
  *             from form, workerNodeCPU/Memory use fixed defaults (required by SDK)
  * - HCP:      control-plane fields omitted (hosted externally)
@@ -225,16 +237,19 @@ export const formValuesToRequest = (
 ): ClusterRequirementsRequest => {
   const isHCP = values.clusterMode === "hosted-control-plane";
   const isSNO = values.clusterMode === "single-node";
+  const isCompact = values.clusterMode === "compact";
   const isFullHA = values.clusterMode === "full-ha";
 
-  if (isSNO) {
+  if (isSNO || isCompact) {
     return {
       clusterId,
       workerNodeCPU: SNO_DEFAULT_WORKER_CPU,
       workerNodeMemory: SNO_DEFAULT_WORKER_MEMORY,
       controlPlaneSchedulable: true,
-      controlPlaneNodeCount:
-        ClusterRequirementsRequestControlPlaneNodeCountEnum.NUMBER_1,
+      controlPlaneNodeCount: isCompact
+        ? ClusterRequirementsRequestControlPlaneNodeCountEnum.NUMBER_3
+        : ClusterRequirementsRequestControlPlaneNodeCountEnum.NUMBER_1,
+      compactMode: isCompact ? true : undefined,
       controlPlaneCPU: values.controlPlaneCpu,
       controlPlaneMemory: values.controlPlaneMemoryGb,
     } as ClusterRequirementsRequest;
@@ -275,6 +290,7 @@ export const workloadAndFormValuesToStandaloneRequest = (
 ): StandaloneClusterRequirementsRequest => {
   const isHCP = values.clusterMode === "hosted-control-plane";
   const isSNO = values.clusterMode === "single-node";
+  const isCompact = values.clusterMode === "compact";
   const isFullHA = values.clusterMode === "full-ha";
 
   const workloadFields = {
@@ -283,7 +299,7 @@ export const workloadAndFormValuesToStandaloneRequest = (
     totalMemory: workload.totalMemory,
   };
 
-  if (isSNO) {
+  if (isSNO || isCompact) {
     return {
       ...workloadFields,
       cpuOverCommitRatio: cpuOvercommitRatioToApiEnum(
@@ -295,8 +311,10 @@ export const workloadAndFormValuesToStandaloneRequest = (
       workerNodeCPU: SNO_DEFAULT_WORKER_CPU,
       workerNodeMemory: SNO_DEFAULT_WORKER_MEMORY,
       controlPlaneSchedulable: true,
-      controlPlaneNodeCount:
-        StandaloneClusterRequirementsRequestControlPlaneNodeCountEnum.NUMBER_1,
+      controlPlaneNodeCount: isCompact
+        ? StandaloneClusterRequirementsRequestControlPlaneNodeCountEnum.NUMBER_3
+        : StandaloneClusterRequirementsRequestControlPlaneNodeCountEnum.NUMBER_1,
+      compactMode: isCompact ? true : undefined,
       controlPlaneCPU: values.controlPlaneCpu,
       controlPlaneMemory: values.controlPlaneMemoryGb,
     };

--- a/src/ui/tools/view-models/useClusterSizingToolViewModel.ts
+++ b/src/ui/tools/view-models/useClusterSizingToolViewModel.ts
@@ -85,7 +85,8 @@ export const useClusterSizingToolViewModel = (): ClusterSizingToolViewModel => {
     formValues.clusterMode === "hosted-control-plane";
   const showControlPlane =
     formValues.clusterMode === "full-ha" ||
-    formValues.clusterMode === "single-node";
+    formValues.clusterMode === "single-node" ||
+    formValues.clusterMode === "compact";
   const showControlPlaneScheduling = formValues.clusterMode === "full-ha";
   const showSmt = smtVisible;
   const isFormValid = !hasSmtError && !hasInvalidWorkload;


### PR DESCRIPTION
With Compact (3CP) selected and Generate recommendation clicked, the request will include compactMode: true and controlPlaneNodeCount: 3 along with the control plane CPU/memory from the form.

[Screen Recording 2026-07-01 14.59.webm](https://github.com/user-attachments/assets/0113458c-1701-42b2-bf71-687bf313c4e4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Compact (3CP)** cluster sizing mode.
  * Updated the sizing UI to display control-plane inputs for Compact mode.

* **Bug Fixes**
  * Improved SNO-style handling so control-plane-only modes are treated consistently across the sizing results, recommendations, and PDF output.
  * Ensured Compact mode follows the correct control-plane-only logic for node-count and conditional sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->