### PR TITLE
ECOPROJECT-4831 | feat: Improve partner management UI for partner creation

### DIFF
--- a/src/ui/partner/admin/components/CreateGroupModal.tsx
+++ b/src/ui/partner/admin/components/CreateGroupModal.tsx
@@ -28,7 +28,7 @@ export const CreateGroupModal: React.FC<CreateGroupModalProps> = ({
 
   return (
     <Modal
-      variant={ModalVariant.medium}
+      variant={ModalVariant.large}
       isOpen={isOpen}
       onClose={onClose}
       aria-label="Create group"

--- a/src/ui/partner/admin/components/EditGroupModal.tsx
+++ b/src/ui/partner/admin/components/EditGroupModal.tsx
@@ -31,7 +31,7 @@ export const EditGroupModal: React.FC<EditGroupModalProps> = ({
 
   return (
     <Modal
-      variant={ModalVariant.medium}
+      variant={ModalVariant.large}
       isOpen={isOpen}
       onClose={onClose}
       aria-label="Edit group"

--- a/src/ui/partner/admin/components/GroupForm.tsx
+++ b/src/ui/partner/admin/components/GroupForm.tsx
@@ -1,19 +1,41 @@
+import { css } from "@emotion/css";
 import { yupResolver } from "@hookform/resolvers/yup";
 import type {
   Group,
   GroupCreate,
   GroupCreateKindEnum,
 } from "@openshift-migration-advisor/planner-sdk";
-import { Form } from "@patternfly/react-core";
-import React, { useEffect } from "react";
-import { FormProvider, useForm } from "react-hook-form";
+import {
+  Alert,
+  Button,
+  Card,
+  CardBody,
+  Content,
+  Flex,
+  FlexItem,
+  Form,
+  FormGroup,
+  FormHelperText,
+  Grid,
+  GridItem,
+  HelperText,
+  HelperTextItem,
+  Stack,
+  StackItem,
+  Title,
+} from "@patternfly/react-core";
+import { RhUiUploadIcon } from "@patternfly/react-icons";
+import React, { useEffect, useRef, useState } from "react";
+import { FormProvider, useForm, useWatch } from "react-hook-form";
 import * as yup from "yup";
 
+import type { Partner } from "../../../../models/PartnerModel";
 import {
   SelectFormGroup,
   TextAreaFormGroup,
   TextInputFormGroup,
 } from "../../../core/components/form";
+import { PartnersGallery } from "../../regularUser/components/PartnersGallery";
 
 export type CreateGroupFormValues = GroupCreate;
 
@@ -52,6 +74,10 @@ interface CreateGroupFormProps extends BaseGroupFormProps {
 
 export type GroupFormProps = EditGroupFormProps | CreateGroupFormProps;
 
+const previewContainerStyle = css`
+  max-width: 340px;
+`;
+
 export const GroupForm: React.FC<GroupFormProps> = ({
   id,
   group,
@@ -78,9 +104,98 @@ export const GroupForm: React.FC<GroupFormProps> = ({
         },
   });
 
+  const [imageError, setImageError] = useState<string>("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const name = useWatch({ control: methods.control, name: "name" });
+  const description = useWatch({
+    control: methods.control,
+    name: "description",
+  });
+  const icon = useWatch({ control: methods.control, name: "icon" });
+  const company = useWatch({ control: methods.control, name: "company" });
+  const kind = useWatch({ control: methods.control, name: "kind" });
+
+  const previewPartner: Partner = {
+    id: group?.id || "preview",
+    name: name || "",
+    description: description || "",
+    icon: icon || "",
+    company: company || "",
+    kind: "partner",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
   useEffect(() => {
     setIsValid?.(methods.formState.isValid);
   }, [methods.formState.isValid, setIsValid]);
+
+  const convertFileToBase64 = (file: File): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        if (typeof reader.result === "string") {
+          resolve(reader.result);
+        } else {
+          reject(new Error("Failed to read file"));
+        }
+      };
+      reader.onerror = () =>
+        reject(
+          reader.error instanceof Error
+            ? reader.error
+            : new Error("Failed to read file"),
+        );
+      reader.readAsDataURL(file);
+    });
+  };
+
+  const handleLoadImageClick = () => {
+    setImageError("");
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setImageError("");
+    event.target.value = "";
+
+    const allowedTypes = [
+      "image/png",
+      "image/jpeg",
+      "image/gif",
+      "image/svg+xml",
+    ];
+    if (!allowedTypes.includes(file.type)) {
+      setImageError(
+        "Unsupported file format. Please select PNG, JPEG, GIF, or SVG.",
+      );
+      return;
+    }
+
+    const maxSizeBytes = 2 * 1024 * 1024;
+    if (file.size > maxSizeBytes) {
+      setImageError(
+        "File size exceeds 2MB limit. Please select a smaller image.",
+      );
+      return;
+    }
+
+    try {
+      const base64 = await convertFileToBase64(file);
+      methods.setValue("icon", base64, {
+        shouldValidate: true,
+        shouldDirty: true,
+      });
+    } catch {
+      setImageError("Failed to read file. Please try another image.");
+    }
+  };
 
   const handleFormSubmit = (data: CreateGroupFormValues) => {
     if (group) {
@@ -98,56 +213,130 @@ export const GroupForm: React.FC<GroupFormProps> = ({
 
   return (
     <FormProvider {...methods}>
-      <Form
-        noValidate
-        id={id}
-        onSubmit={(e) => {
-          void methods.handleSubmit(handleFormSubmit)(e);
-        }}
-      >
-        <TextInputFormGroup
-          label="Group Name"
-          id="group-name"
-          name="name"
-          isRequired
-          placeholder="Example: Tech Solutions Inc"
-        />
+      <Grid hasGutter>
+        <GridItem span={6}>
+          <Card>
+            <CardBody>
+              <Form
+                noValidate
+                id={id}
+                onSubmit={(e) => {
+                  void methods.handleSubmit(handleFormSubmit)(e);
+                }}
+              >
+                <TextInputFormGroup
+                  label="Group Name"
+                  id="group-name"
+                  name="name"
+                  isRequired
+                  placeholder="Example: Tech Solutions Inc"
+                />
 
-        <TextInputFormGroup
-          label="Company"
-          id="group-company"
-          name="company"
-          isRequired
-          placeholder="Example: Acme Corporation"
-        />
+                <TextInputFormGroup
+                  label="Company"
+                  id="group-company"
+                  name="company"
+                  isRequired
+                  placeholder="Example: Acme Corporation"
+                />
 
-        <SelectFormGroup
-          label="Kind"
-          id="group-kind"
-          name="kind"
-          isRequired
-          isDisabled={!!group}
-          options={[
-            { label: "Partner", value: "partner" },
-            { label: "Admin", value: "admin" },
-          ]}
-        />
+                <SelectFormGroup
+                  label="Kind"
+                  id="group-kind"
+                  name="kind"
+                  isRequired
+                  isDisabled={!!group}
+                  options={[
+                    { label: "Partner", value: "partner" },
+                    { label: "Admin", value: "admin" },
+                  ]}
+                />
 
-        <TextAreaFormGroup
-          label="Description"
-          id="group-description"
-          name="description"
-          placeholder="Example: Leading technology solutions provider"
-        />
+                <TextAreaFormGroup
+                  label="Description"
+                  id="group-description"
+                  name="description"
+                  placeholder="Example: Leading technology solutions provider"
+                />
 
-        <TextInputFormGroup
-          label="Icon"
-          id="group-icon"
-          name="icon"
-          placeholder="data:image/svg+xml;base64,..."
-          helpText="Base64 encoded image or URL to group icon"
-        />
-      </Form>
+                <FormGroup label="Icon" fieldId="group-icon">
+                  <Flex gap={{ default: "gapSm" }}>
+                    <FlexItem flex={{ default: "flex_1" }}>
+                      <TextInputFormGroup
+                        label=""
+                        id="group-icon"
+                        name="icon"
+                        placeholder="data:image/svg+xml;base64,..."
+                        helpText="Base64 encoded image or URL to group icon"
+                      />
+                    </FlexItem>
+                    <FlexItem>
+                      <Button
+                        variant="control"
+                        onClick={handleLoadImageClick}
+                        icon={<RhUiUploadIcon />}
+                      >
+                        Load Image
+                      </Button>
+                      <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept="image/png,image/jpeg,image/gif,image/svg+xml"
+                        style={{ display: "none" }}
+                        onChange={(e) => {
+                          void handleFileChange(e);
+                        }}
+                      />
+                    </FlexItem>
+                  </Flex>
+                  {imageError && (
+                    <FormHelperText>
+                      <HelperText>
+                        <HelperTextItem variant="error">
+                          {imageError}
+                        </HelperTextItem>
+                      </HelperText>
+                    </FormHelperText>
+                  )}
+                </FormGroup>
+              </Form>
+            </CardBody>
+          </Card>
+        </GridItem>
+
+        <GridItem span={6}>
+          <Stack hasGutter>
+            <StackItem>
+              <Title headingLevel="h2">Preview partner card</Title>
+            </StackItem>
+            <StackItem>
+              <Content component="p">
+                This preview shows how your partner group will be displayed to
+                users when they browse available partners
+              </Content>
+            </StackItem>
+            <StackItem>
+              {kind === "admin" ? (
+                <Alert
+                  variant="info"
+                  title="Admin groups are not displayed in the partner gallery"
+                  isInline
+                >
+                  Only partner groups are shown to users when browsing for
+                  partners.
+                </Alert>
+              ) : (
+                <div className={previewContainerStyle}>
+                  <PartnersGallery
+                    partners={[previewPartner]}
+                    onRequestAssignment={() => {}}
+                  />
+                </div>
+              )}
+            </StackItem>
+          </Stack>
+        </GridItem>
+      </Grid>
     </FormProvider>
   );
 };

--- a/src/ui/partner/regularUser/components/PartnersGallery.tsx
+++ b/src/ui/partner/regularUser/components/PartnersGallery.tsx
@@ -1,0 +1,53 @@
+import {
+  Button,
+  Card,
+  CardBody,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Gallery,
+} from "@patternfly/react-core";
+import React from "react";
+
+import type { Partner } from "../../../../models/PartnerModel";
+
+interface PartnersGalleryProps {
+  partners: Partner[];
+  onRequestAssignment: (partner: Partner | null) => void;
+}
+
+export const PartnersGallery: React.FC<PartnersGalleryProps> = ({
+  partners,
+  onRequestAssignment,
+}) => {
+  return (
+    <Gallery hasGutter minWidths={{ default: "300px" }}>
+      {partners.map((partner) => (
+        <Card key={partner.id}>
+          <CardHeader>
+            <img
+              src={partner.icon}
+              alt={`${partner.name} icon`}
+              style={{
+                height: "60px",
+              }}
+            />
+          </CardHeader>
+          <CardTitle>{partner.name}</CardTitle>
+          <CardBody>{partner.description}</CardBody>
+          <CardFooter>
+            <Button
+              variant="primary"
+              isBlock
+              onClick={() => onRequestAssignment(partner)}
+            >
+              Request assignment
+            </Button>
+          </CardFooter>
+        </Card>
+      ))}
+    </Gallery>
+  );
+};
+
+PartnersGallery.displayName = "PartnersGallery";

--- a/src/ui/partner/regularUser/views/PartnersListSection.tsx
+++ b/src/ui/partner/regularUser/views/PartnersListSection.tsx
@@ -2,15 +2,8 @@ import { css } from "@emotion/css";
 import type { PartnerRequestCreate } from "@openshift-migration-advisor/planner-sdk";
 import {
   Alert,
-  Button,
-  Card,
-  CardBody,
-  CardFooter,
-  CardHeader,
-  CardTitle,
   Content,
   EmptyState,
-  Gallery,
   PageSection,
   Title,
 } from "@patternfly/react-core";
@@ -19,6 +12,7 @@ import React from "react";
 
 import { LoadingSpinner } from "../../../core/components/LoadingSpinner";
 import { ContactFormModal } from "../components/ContactFormModal";
+import { PartnersGallery } from "../components/PartnersGallery";
 import { usePartnersViewModel } from "../view-models/usePartnersViewModel";
 
 const introStyle = css`
@@ -58,32 +52,10 @@ export const PartnersListSection: React.FC = () => {
         />
       )}
       {!vm.isLoading && !vm.error && vm.partners.length > 0 && (
-        <Gallery hasGutter minWidths={{ default: "300px" }}>
-          {vm.partners.map((partner) => (
-            <Card key={partner.id}>
-              <CardHeader>
-                <img
-                  src={partner.icon}
-                  alt={`${partner.name} icon`}
-                  style={{
-                    height: "60px",
-                  }}
-                />
-              </CardHeader>
-              <CardTitle>{partner.name}</CardTitle>
-              <CardBody>{partner.description}</CardBody>
-              <CardFooter>
-                <Button
-                  variant="primary"
-                  isBlock
-                  onClick={() => vm.openContactFormModal(partner)}
-                >
-                  Request assignment
-                </Button>
-              </CardFooter>
-            </Card>
-          ))}
-        </Gallery>
+        <PartnersGallery
+          partners={vm.partners}
+          onRequestAssignment={vm.openContactFormModal}
+        />
       )}
 
       {vm.isContactFormModalOpen && (


### PR DESCRIPTION
Add direct image upload with automatic Base64 conversion for partner icons. Administrators can now upload PNG, JPEG, GIF, or SVG images via a "Load Image" button, eliminating the need for manual Base64 encoding.

Enhance the create/edit partner modal with a two-column layout featuring:
- Left: Form fields in a Card component for better visual organization
- Right: Live preview showing how the partner will appear to users browsing the partner gallery, with real-time updates as form fields are filled

Extract PartnersGallery component for reusability across partner listing and form preview contexts.

Increase modal size from medium to large to accommodate the new layout and provide better workspace for administrators.

<img width="1120" height="668" alt="localhost_3000_partners_groups_d60318c5-5e77-4571-8ba0-51a307450e5d" src="https://github.com/user-attachments/assets/0dfd4242-fd11-43b4-9519-0e7bc9f5bd68" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a partner card gallery for browsing partners, with a clear “Request assignment” action.
  * Added icon image upload to group forms, including PNG/JPEG/GIF/SVG validation, a 2MB limit, and immediate preview.
  * Added a live partner card preview panel while creating or editing a group (with contextual messaging for admin groups).
* **UI Improvements**
  * Updated group creation and editing modals to a larger size for improved readability.
* **Refactor**
  * Centralized the partner gallery UI into a reusable component and used it in the partners list section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->