### PR TITLE
ECOPROJECT-4821 | feat: Increase worker node CPU overcommitment to 1:8

### DIFF
--- a/src/ui/report/views/cluster-sizer/__tests__/mocks/ClusterRequirementsRequest.mock.ts
+++ b/src/ui/report/views/cluster-sizer/__tests__/mocks/ClusterRequirementsRequest.mock.ts
@@ -61,7 +61,7 @@ export const mockCustomNodeWithControlPlaneRequest: ClusterRequirementsRequest =
  */
 export const mockMaxValuesRequest: ClusterRequirementsRequest = {
   clusterId: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-  cpuOverCommitRatio: "1:6",
+  cpuOverCommitRatio: "1:8",
   memoryOverCommitRatio: "1:4",
   workerNodeCPU: 200,
   workerNodeMemory: 512,

--- a/src/ui/report/views/cluster-sizer/constants.ts
+++ b/src/ui/report/views/cluster-sizer/constants.ts
@@ -125,8 +125,15 @@ export const CPU_OVERCOMMIT_OPTIONS: {
   {
     value: 6,
     label: "High Density (1:6)",
-    description: "Heavy sharing. Maximum savings for test environments.",
+    description: "Heavy sharing. Good savings for test environments.",
     helpText: "Only recommended for non-production workloads.",
+  },
+  {
+    value: 8,
+    label: "Maximum Density (1:8)",
+    description: "Extreme sharing. Lowest infrastructure cost.",
+    helpText:
+      'Example: At 1:8, you can run 800 "virtual" CPUs on 100 "physical" cores. Only for non-production workloads.',
   },
 ];
 

--- a/src/ui/report/views/cluster-sizer/types.ts
+++ b/src/ui/report/views/cluster-sizer/types.ts
@@ -51,7 +51,7 @@ export type WorkerNodePreset = "small" | "medium" | "large" | "custom";
 /**
  * Over-commit ratio options for CPU (numeric value)
  */
-export type OvercommitRatio = 1 | 2 | 4 | 6;
+export type OvercommitRatio = 1 | 2 | 4 | 6 | 8;
 
 /**
  * Over-commit ratio options for memory (1:6 not supported by API)
@@ -157,6 +157,7 @@ const CPU_OVERCOMMIT_RATIO_MAP: Record<
   2: CpuOverCommitRatio.CpuOneToTwo,
   4: CpuOverCommitRatio.CpuOneToFour,
   6: CpuOverCommitRatio.CpuOneToSix,
+  8: CpuOverCommitRatio.CpuOneToEight,
 };
 
 /**


### PR DESCRIPTION
Added 1:8 CPU overcommitment to the cluster sizer UI.

Form:
<img width="1108" height="902" alt="Captura desde 2026-07-03 08-45-11" src="https://github.com/user-attachments/assets/89689673-bf35-4c37-bb03-9112242d8223" />

Results:
<img width="1108" height="902" alt="Captura desde 2026-07-03 08-45-48" src="https://github.com/user-attachments/assets/c0cf11d6-7f6e-4c39-af84-18f026066122" />
