### PR TITLE
ECOPROJECT-4870 | fix: not export shared disks card if we don't have shared disks

### DIFF
--- a/src/ui/report/views/assessment-report/StorageOverview.tsx
+++ b/src/ui/report/views/assessment-report/StorageOverview.tsx
@@ -234,6 +234,8 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
     [totalVMs, totalWithSharedDisks],
   );
 
+  const isSharedDisksViewAvailable = totalWithSharedDisks !== 0;
+
   const sharedDisksChartData = useMemo(() => {
     const withoutShared = totalVMs - normalizedWithShared;
 
@@ -397,10 +399,7 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
                   <DropdownItem
                     key="sharedDisks"
                     value="sharedDisks"
-                    isDisabled={
-                      totalWithSharedDisks !== undefined &&
-                      totalWithSharedDisks === 0
-                    }
+                    isDisabled={!isSharedDisksViewAvailable}
                   >
                     Shared disks VS. No shared disks
                   </DropdownItem>
@@ -663,28 +662,30 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
                 }
               />
             </div>
-            <div className={storageExportSectionMargin}>
-              <div className={storageExportSectionTitle}>
-                {VIEW_MODE_LABELS["sharedDisks"]}
+            {isSharedDisksViewAvailable && (
+              <div className={storageExportSectionMargin}>
+                <div className={storageExportSectionTitle}>
+                  {VIEW_MODE_LABELS["sharedDisks"]}
+                </div>
+                <MigrationDonutChart
+                  data={sharedDisksChartData}
+                  height={300}
+                  width={420}
+                  donutThickness={18}
+                  titleFontSize={34}
+                  title={`${totalVMs} VMs`}
+                  subTitle={`${normalizedWithShared} with shared disks`}
+                  subTitleColor="var(--pf-t--global--text--color--subtle)"
+                  itemsPerRow={Math.ceil(sharedDisksChartData.length / 2)}
+                  labelFontSize={18}
+                  marginLeft="52%"
+                  emptyStateTitle={REPORT_CARD_EMPTY_STATE_TITLES.storage}
+                  tooltipLabelFormatter={({ datum, percent }) =>
+                    `${datum.countDisplay}\n${percent.toFixed(1)}%`
+                  }
+                />
               </div>
-              <MigrationDonutChart
-                data={sharedDisksChartData}
-                height={300}
-                width={420}
-                donutThickness={18}
-                titleFontSize={34}
-                title={`${totalVMs} VMs`}
-                subTitle={`${normalizedWithShared} with shared disks`}
-                subTitleColor="var(--pf-t--global--text--color--subtle)"
-                itemsPerRow={Math.ceil(sharedDisksChartData.length / 2)}
-                labelFontSize={18}
-                marginLeft="52%"
-                emptyStateTitle={REPORT_CARD_EMPTY_STATE_TITLES.storage}
-                tooltipLabelFormatter={({ datum, percent }) =>
-                  `${datum.countDisplay}\n${percent.toFixed(1)}%`
-                }
-              />
-            </div>
+            )}
           </>
         )}
       </CardBody>

--- a/src/ui/report/views/assessment-report/__tests__/StorageOverview.test.tsx
+++ b/src/ui/report/views/assessment-report/__tests__/StorageOverview.test.tsx
@@ -254,7 +254,7 @@ describe("StorageOverview", () => {
       });
     });
 
-    it("handles zero VMs with shared disks", () => {
+    it("excludes shared disks chart from export when there are no shared disks", () => {
       render(
         <StorageOverview
           DiskSizeTierSummary={mockDiskSizeTierSummary}
@@ -266,26 +266,17 @@ describe("StorageOverview", () => {
         />,
       );
 
+      expect(
+        screen.queryByText(/Shared disks VS\. No shared disks/i),
+      ).not.toBeInTheDocument();
+
       const donutCharts = screen.getAllByTestId("donut-chart");
       const sharedDisksChart = donutCharts.find((chart) => {
         const subtitle = chart.querySelector('[data-testid="chart-subtitle"]');
-        return subtitle?.textContent === "0 with shared disks";
+        return subtitle?.textContent?.includes("with shared disks");
       });
 
-      expect(sharedDisksChart).toBeDefined();
-
-      const chartData = sharedDisksChart!.querySelector(
-        '[data-testid="chart-data"]',
-      );
-      const data = JSON.parse(
-        chartData!.textContent || "[]",
-      ) as ChartDataItem[];
-
-      expect(data.length).toBeGreaterThan(0);
-      const withoutShared = data.find((d) => d.name === "No shared disks");
-      expect(withoutShared).toMatchObject({
-        count: 100,
-      });
+      expect(sharedDisksChart).toBeUndefined();
     });
 
     it("handles all VMs with shared disks", () => {
@@ -322,7 +313,7 @@ describe("StorageOverview", () => {
       });
     });
 
-    it("handles undefined totalWithSharedDisks", () => {
+    it("excludes shared disks chart from export when totalWithSharedDisks is undefined", () => {
       render(
         <StorageOverview
           DiskSizeTierSummary={mockDiskSizeTierSummary}
@@ -334,13 +325,9 @@ describe("StorageOverview", () => {
         />,
       );
 
-      const donutCharts = screen.getAllByTestId("donut-chart");
-      const sharedDisksChart = donutCharts.find((chart) => {
-        const subtitle = chart.querySelector('[data-testid="chart-subtitle"]');
-        return subtitle?.textContent?.includes("with shared disks");
-      });
-
-      expect(sharedDisksChart).toBeDefined();
+      expect(
+        screen.queryByText(/Shared disks VS\. No shared disks/i),
+      ).not.toBeInTheDocument();
     });
 
     it("clamps totalWithSharedDisks to valid range", () => {


### PR DESCRIPTION
When an assessment has no shared disks, the PDF now omits that section, consistent with the interactive UI.


- Report:

<img width="779" height="536" alt="image" src="https://github.com/user-attachments/assets/c2261010-3205-40c0-b185-59be4a265143" />


- Export PDF:
<img width="344" height="678" alt="image" src="https://github.com/user-attachments/assets/1f3ff86d-b848-4e44-afd4-97287c0799ff" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The shared-disks export section now appears only when shared disks are available, avoiding an empty or misleading view.
  * The shared-disks export option is now disabled when there are no shared disks to show.
  * Updated export-mode behavior to keep the shared-disks chart hidden when the total is zero or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->