### PR TITLE
ECOPROJECT-4907 | fix: correct alignment of 'Export report' button and 'View recommendation' button

### DIFF
--- a/src/ui/core/components/AppPage.tsx
+++ b/src/ui/core/components/AppPage.tsx
@@ -45,16 +45,12 @@ export const AppPage: React.FC<React.PropsWithChildren<AppPage.Props>> = (
         </PageBreadcrumb>
         <PageHeader>
           <Flex>
-            <FlexItem>
+            <FlexItem flex={{ default: "flex_1" }}>
               <PageHeaderTitle title={title} />
             </FlexItem>
 
             {React.Children.map(headerActions, (action, index) => (
-              <FlexItem
-                {...(index === 0 ? { align: { default: "alignRight" } } : null)}
-              >
-                {action}
-              </FlexItem>
+              <FlexItem key={index}>{action}</FlexItem>
             ))}
           </Flex>
           {caption}

--- a/src/ui/report/views/Report.tsx
+++ b/src/ui/report/views/Report.tsx
@@ -35,11 +35,6 @@ const alertSpacing = css`
   margin-top: var(--pf-t--global--spacer--md);
 `;
 
-const reservedHeaderActionStyle = css`
-  visibility: hidden;
-  pointer-events: none;
-`;
-
 const ReportContent: React.FC = () => {
   const vm = useReportPageViewModel();
   const offScreenRef = useRef<HTMLDivElement>(null);
@@ -281,43 +276,36 @@ const ReportContent: React.FC = () => {
               )}
             </SplitItem>
 
-            <SplitItem
-              className={
-                vm.selectedClusterId === "all"
-                  ? reservedHeaderActionStyle
-                  : undefined
-              }
-              aria-hidden={vm.selectedClusterId === "all"}
-            >
-              {vm.canShowClusterRecommendations ? (
-                <Button
-                  variant="primary"
-                  tabIndex={vm.selectedClusterId === "all" ? -1 : undefined}
-                  onClick={() => vm.setIsSizingWizardOpen(true)}
-                >
-                  View Recommendation based on vCenter cluster
-                </Button>
-              ) : (
-                <Tooltip
-                  {...themeTooltipFlyoutProps}
-                  content={
-                    <p>
-                      This cluster has no VMs. Cluster recommendations are not
-                      available for empty clusters.
-                    </p>
-                  }
-                >
+            {vm.selectedClusterId !== "all" ? (
+              <SplitItem>
+                {vm.canShowClusterRecommendations ? (
                   <Button
                     variant="primary"
-                    tabIndex={vm.selectedClusterId === "all" ? -1 : undefined}
                     onClick={() => vm.setIsSizingWizardOpen(true)}
-                    isAriaDisabled
                   >
                     View Recommendation based on vCenter cluster
                   </Button>
-                </Tooltip>
-              )}
-            </SplitItem>
+                ) : (
+                  <Tooltip
+                    {...themeTooltipFlyoutProps}
+                    content={
+                      <p>
+                        This cluster has no VMs. Cluster recommendations are not
+                        available for empty clusters.
+                      </p>
+                    }
+                  >
+                    <Button
+                      variant="primary"
+                      onClick={() => vm.setIsSizingWizardOpen(true)}
+                      isAriaDisabled
+                    >
+                      View Recommendation based on vCenter cluster
+                    </Button>
+                  </Tooltip>
+                )}
+              </SplitItem>
+            ) : null}
           </Split>
         ) : undefined
       }

--- a/src/ui/report/views/__tests__/Report.test.tsx
+++ b/src/ui/report/views/__tests__/Report.test.tsx
@@ -254,6 +254,48 @@ describe("Report", () => {
   });
 
   describe("Cluster recommendations button", () => {
+    it("hides recommendations button in aggregate view so export stays right-aligned", async () => {
+      const clusterData = {
+        "Cluster A": { infra: createInfra(2, 2), vms: createVMs(5) },
+      };
+      const clusterView = buildClusterViewModel({
+        infra: clusterData["Cluster A"].infra,
+        vms: clusterData["Cluster A"].vms,
+        clusters: clusterData,
+        selectedClusterId: "all",
+      });
+
+      mockVm = makeBaseVm({
+        assessment: {
+          id: "assessment-1",
+          name: "Assessment 1",
+          sourceId: "source-1",
+          sourceType: "vcenter",
+        },
+        clusterView,
+        selectedClusterId: "all",
+        clusters: clusterData,
+        scopedClusterView: {
+          ...clusterView,
+          viewInfra: clusterData["Cluster A"].infra,
+          viewVms: clusterData["Cluster A"].vms,
+          cpuCores: clusterData["Cluster A"].vms.cpuCores,
+          ramGB: clusterData["Cluster A"].vms.ramGB,
+        },
+        canExportReport: true,
+      });
+
+      render(<Report />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("download-button")).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByText("View Recommendation based on vCenter cluster"),
+      ).not.toBeInTheDocument();
+    });
+
     it("auto-selects first cluster to show recommendations button", async () => {
       const clusterData = {
         "Cluster A": { infra: createInfra(2, 2), vms: createVMs(5) },


### PR DESCRIPTION
When both buttons are visible (a specific cluster selected), they still appear together on the right: Export Report, then View Recommendation. If only one button is visible is aligned to the right.

<img width="1576" height="344" alt="Captura desde 2026-07-03 09-26-19" src="https://github.com/user-attachments/assets/429bab7d-dd04-4f49-8270-e19fc768537a" />
<img width="1576" height="344" alt="Captura desde 2026-07-03 09-26-14" src="https://github.com/user-attachments/assets/d746a81d-3a58-4cf7-a3c7-60822dd26f6f" />


